### PR TITLE
[HAL] Split task and Vulkan profile recorders

### DIFF
--- a/build_tools/devtools/ci_config.py
+++ b/build_tools/devtools/ci_config.py
@@ -125,7 +125,6 @@ CPU_SANITIZERS_XFAILS = (
     bazel_xfail("//runtime/src/iree/async/platform/io_uring/cts/..."),
     bazel_xfail("//runtime/src/iree/hal:string_util_test"),
     bazel_xfail("//runtime/src/iree/hal/local/elf/..."),
-    bazel_xfail("//runtime/src/iree/hal/local:profile_test"),
     bazel_xfail("//runtime/src/iree/hal/replay:execute_test"),
     bazel_xfail("//runtime/src/iree/tokenizer/..."),
     bazel_xfail("//runtime/src/iree/tooling/profile:cli_test"),

--- a/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
@@ -30,6 +30,32 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "profile",
+    srcs = ["profile.c"],
+    hdrs = ["profile.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/local:executable_loader",
+        "//runtime/src/iree/hal/utils:profile_event_ring",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "profile_test",
+    srcs = ["profile_test.cc"],
+    deps = [
+        ":profile",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/local:executable_loader",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "block_builder",
     srcs = [
         "block_builder.c",
@@ -137,6 +163,7 @@ iree_runtime_cc_library(
     ],
     deps = [
         ":block_isa",
+        ":profile",
         "//runtime/src/iree/async",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:cpu",
@@ -144,7 +171,6 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base/threading:thread",
         "//runtime/src/iree/hal/local:atomic",
         "//runtime/src/iree/hal/local:executable_loader",
-        "//runtime/src/iree/hal/local:profile",
         "//runtime/src/iree/task",
     ],
 )
@@ -186,6 +212,7 @@ iree_runtime_cc_library(
         ":block_command_buffer",
         ":block_command_ops",
         ":block_processor",
+        ":profile",
         ":transient_buffer",
         "//runtime/src/iree/async",
         "//runtime/src/iree/async/util:proactor_pool",
@@ -202,7 +229,6 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/local:executable_environment",
         "//runtime/src/iree/hal/local:executable_library",
         "//runtime/src/iree/hal/local:executable_loader",
-        "//runtime/src/iree/hal/local:profile",
         "//runtime/src/iree/hal/memory:cpu_slab_provider",
         "//runtime/src/iree/hal/memory:passthrough_pool",
         "//runtime/src/iree/hal/memory:tlsf_pool",

--- a/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
@@ -26,6 +26,35 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    profile
+  HDRS
+    "profile.h"
+  SRCS
+    "profile.c"
+  DEPS
+    iree::base
+    iree::base::threading
+    iree::hal
+    iree::hal::local::executable_loader
+    iree::hal::utils::profile_event_ring
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    profile_test
+  SRCS
+    "profile_test.cc"
+  DEPS
+    ::profile
+    iree::hal
+    iree::hal::local::executable_loader
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_library(
+  NAME
     block_builder
   HDRS
     "block_builder.h"
@@ -126,6 +155,7 @@ iree_cc_library(
     "block_processor.c"
   DEPS
     ::block_isa
+    ::profile
     iree::async
     iree::base
     iree::base::internal::cpu
@@ -133,7 +163,6 @@ iree_cc_library(
     iree::base::threading::thread
     iree::hal::local::atomic
     iree::hal::local::executable_loader
-    iree::hal::local::profile
     iree::task
   PUBLIC
 )
@@ -173,6 +202,7 @@ iree_cc_library(
     ::block_command_buffer
     ::block_command_ops
     ::block_processor
+    ::profile
     ::transient_buffer
     iree::async
     iree::async::util::proactor_pool
@@ -189,7 +219,6 @@ iree_cc_library(
     iree::hal::local::executable_environment
     iree::hal::local::executable_library
     iree::hal::local::executable_loader
-    iree::hal::local::profile
     iree::hal::memory::cpu_slab_provider
     iree::hal::memory::passthrough_pool
     iree::hal::memory::tlsf_pool

--- a/runtime/src/iree/hal/drivers/local_task/block_processor.c
+++ b/runtime/src/iree/hal/drivers/local_task/block_processor.c
@@ -905,13 +905,13 @@ static void iree_hal_cmd_block_processor_profile_make_dispatch_event(
     uint64_t tile_count, int64_t tile_duration_sum_ns,
     iree_status_code_t status_code, iree_time_t start_host_time_ns,
     iree_time_t end_host_time_ns,
-    iree_hal_local_profile_host_execution_event_info_t* out_event_info) {
+    iree_hal_task_profile_host_execution_event_info_t* out_event_info) {
   uint32_t workgroup_count[3];
   iree_hal_cmd_dispatch_read_workgroup_count(dispatch, binding_ptrs,
                                              workgroup_count);
 
-  iree_hal_local_profile_host_execution_event_info_t event_info =
-      iree_hal_local_profile_host_execution_event_info_default();
+  iree_hal_task_profile_host_execution_event_info_t event_info =
+      iree_hal_task_profile_host_execution_event_info_default();
   event_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_DISPATCH;
   event_info.flags = IREE_HAL_PROFILE_HOST_EXECUTION_EVENT_FLAG_COMMAND_BUFFER |
                      IREE_HAL_PROFILE_HOST_EXECUTION_EVENT_FLAG_DEFERRED;
@@ -949,11 +949,11 @@ static void iree_hal_cmd_block_processor_profile_append_dispatch_event(
     uint64_t tile_count, int64_t tile_duration_sum_ns,
     iree_status_code_t status_code, iree_time_t start_host_time_ns,
     iree_time_t end_host_time_ns) {
-  iree_hal_local_profile_host_execution_event_info_t event_info;
+  iree_hal_task_profile_host_execution_event_info_t event_info;
   iree_hal_cmd_block_processor_profile_make_dispatch_event(
       context, dispatch, binding_ptrs, tile_count, tile_duration_sum_ns,
       status_code, start_host_time_ns, end_host_time_ns, &event_info);
-  iree_hal_local_profile_recorder_append_host_execution_event(
+  iree_hal_task_profile_recorder_append_host_execution_event(
       context->profile.recorder, &event_info, /*out_event_id=*/NULL);
 }
 
@@ -966,10 +966,9 @@ static iree_status_t iree_hal_cmd_execute_dispatch_tiles_profiled(
     uint32_t worker_count, uint32_t* out_tiles_completed) {
   *out_tiles_completed = 0;
 
-  iree_hal_local_profile_recorder_t* recorder = context->profile.recorder;
-  const bool profile_host_execution =
-      iree_hal_local_profile_recorder_is_enabled(
-          recorder, IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS);
+  iree_hal_task_profile_recorder_t* recorder = context->profile.recorder;
+  const bool profile_host_execution = iree_hal_task_profile_recorder_is_enabled(
+      recorder, IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS);
   const bool aggregate_host_execution = profile_host_execution &&
                                         context->worker_count > 1 &&
                                         context->profile.dispatches != NULL;
@@ -1011,10 +1010,10 @@ static iree_status_t iree_hal_cmd_execute_dispatch_tiles_profiled(
 static iree_host_size_t iree_hal_cmd_block_processor_profile_snapshot_region(
     iree_hal_cmd_block_processor_context_t* context,
     const iree_hal_cmd_barrier_t* barrier, void** binding_ptrs,
-    iree_hal_local_profile_host_execution_event_info_t* out_events,
+    iree_hal_task_profile_host_execution_event_info_t* out_events,
     iree_host_size_t event_capacity) {
   if (!context->profile.dispatches ||
-      !iree_hal_local_profile_recorder_is_enabled(
+      !iree_hal_task_profile_recorder_is_enabled(
           context->profile.recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS)) {
     return 0;
@@ -1062,10 +1061,10 @@ static iree_host_size_t iree_hal_cmd_block_processor_profile_snapshot_region(
 
 static void iree_hal_cmd_block_processor_profile_append_host_execution_events(
     iree_hal_cmd_block_processor_context_t* context,
-    const iree_hal_local_profile_host_execution_event_info_t* events,
+    const iree_hal_task_profile_host_execution_event_info_t* events,
     iree_host_size_t event_count) {
   for (iree_host_size_t i = 0; i < event_count; ++i) {
-    iree_hal_local_profile_recorder_append_host_execution_event(
+    iree_hal_task_profile_recorder_append_host_execution_event(
         context->profile.recorder, &events[i], /*out_event_id=*/NULL);
   }
 }
@@ -1845,8 +1844,8 @@ static void iree_hal_cmd_block_processor_profile_append_command_region_event(
         IREE_HAL_PROFILE_COMMAND_REGION_EVENT_FLAG_HAS_NEXT_REGION;
   }
 
-  iree_hal_local_profile_command_region_event_info_t event_info =
-      iree_hal_local_profile_command_region_event_info_default();
+  iree_hal_task_profile_command_region_event_info_t event_info =
+      iree_hal_task_profile_command_region_event_info_default();
   event_info.flags = IREE_HAL_PROFILE_COMMAND_REGION_EVENT_FLAG_COMMAND_BUFFER |
                      transition_flags;
   event_info.scope = context->profile.scope;
@@ -1911,7 +1910,7 @@ static void iree_hal_cmd_block_processor_profile_append_command_region_event(
       region_snapshot.command_region.retention.publish_keep_active_count;
   event_info.retention.keep_warm_count =
       region_snapshot.command_region.retention.keep_warm_count;
-  iree_hal_local_profile_recorder_append_command_region_event(
+  iree_hal_task_profile_recorder_append_command_region_event(
       context->profile.recorder, &event_info, /*out_event_id=*/NULL);
 }
 
@@ -1942,13 +1941,13 @@ static void iree_hal_cmd_block_processor_handle_region_completion(
   const iree_hal_cmd_block_processor_profile_region_snapshot_t
       completed_region_profile =
           iree_hal_cmd_block_processor_profile_snapshot_active_region(context);
-  iree_hal_local_profile_host_execution_event_info_t* profile_events = NULL;
+  iree_hal_task_profile_host_execution_event_info_t* profile_events = NULL;
   iree_host_size_t profile_event_capacity = completed_barrier->dispatch_count;
   iree_host_size_t profile_event_count = 0;
   if (IREE_UNLIKELY(profile_event_capacity != 0 &&
                     context->profile.dispatches != NULL)) {
     profile_events =
-        (iree_hal_local_profile_host_execution_event_info_t*)iree_alloca(
+        (iree_hal_task_profile_host_execution_event_info_t*)iree_alloca(
             profile_event_capacity * sizeof(*profile_events));
     profile_event_count = iree_hal_cmd_block_processor_profile_snapshot_region(
         context, completed_barrier, binding_ptrs, profile_events,
@@ -2423,8 +2422,8 @@ void iree_hal_cmd_block_processor_context_initialize(
 
 void iree_hal_cmd_block_processor_context_set_profile_recorder(
     iree_hal_cmd_block_processor_context_t* context,
-    iree_hal_local_profile_recorder_t* recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t submission_id,
+    iree_hal_task_profile_recorder_t* recorder,
+    iree_hal_task_profile_queue_scope_t scope, uint64_t submission_id,
     uint64_t command_buffer_id,
     iree_hal_cmd_block_processor_profile_dispatch_t* dispatches,
     iree_host_size_t dispatch_capacity) {
@@ -2436,7 +2435,7 @@ void iree_hal_cmd_block_processor_context_set_profile_recorder(
   context->profile.dispatches = dispatches;
   context->profile.dispatch_capacity = dispatch_capacity;
   context->profile.command_region.events_enabled =
-      iree_hal_local_profile_recorder_is_enabled(
+      iree_hal_task_profile_recorder_is_enabled(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_COMMAND_REGION_EVENTS);
   iree_hal_cmd_block_processor_profile_reset_dispatches(context);
   if (context->worker_count > 1 &&

--- a/runtime/src/iree/hal/drivers/local_task/block_processor.h
+++ b/runtime/src/iree/hal/drivers/local_task/block_processor.h
@@ -40,7 +40,7 @@
 #include "iree/base/api.h"
 #include "iree/base/internal/cpu.h"
 #include "iree/hal/drivers/local_task/block_isa.h"
-#include "iree/hal/local/profile.h"
+#include "iree/hal/drivers/local_task/profile.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -171,10 +171,10 @@ typedef struct iree_hal_cmd_block_processor_context_t {
 
   struct {
     // Optional recorder receiving command-buffer dispatch execution records.
-    iree_hal_local_profile_recorder_t* recorder;
+    iree_hal_task_profile_recorder_t* recorder;
 
     // Queue identity attached to emitted dispatch records.
-    iree_hal_local_profile_queue_scope_t scope;
+    iree_hal_task_profile_queue_scope_t scope;
 
     // Queue submission id shared by command-buffer dispatch records.
     uint64_t submission_id;
@@ -383,8 +383,8 @@ void iree_hal_cmd_block_processor_context_initialize(
 // queue-operation-level profiling record.
 void iree_hal_cmd_block_processor_context_set_profile_recorder(
     iree_hal_cmd_block_processor_context_t* context,
-    iree_hal_local_profile_recorder_t* recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t submission_id,
+    iree_hal_task_profile_recorder_t* recorder,
+    iree_hal_task_profile_queue_scope_t scope, uint64_t submission_id,
     uint64_t command_buffer_id,
     iree_hal_cmd_block_processor_profile_dispatch_t* dispatches,
     iree_host_size_t dispatch_capacity);

--- a/runtime/src/iree/hal/drivers/local_task/profile.c
+++ b/runtime/src/iree/hal/drivers/local_task/profile.c
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/hal/local/profile.h"
+#include "iree/hal/drivers/local_task/profile.h"
 
 #include <inttypes.h>
 #include <string.h>
@@ -14,13 +14,13 @@
 #include "iree/hal/utils/profile_event_ring.h"
 
 //===----------------------------------------------------------------------===//
-// iree_hal_local_profile_recorder_t
+// iree_hal_task_profile_recorder_t
 //===----------------------------------------------------------------------===//
 
 // Default number of records retained per enabled event stream between flushes.
-#define IREE_HAL_LOCAL_PROFILE_DEFAULT_EVENT_CAPACITY 4096
+#define IREE_HAL_TASK_PROFILE_DEFAULT_EVENT_CAPACITY 4096
 
-typedef struct iree_hal_local_profile_id_set_t {
+typedef struct iree_hal_task_profile_id_set_t {
   // Open-addressed nonzero ids whose metadata was emitted.
   uint64_t* ids;
 
@@ -29,17 +29,9 @@ typedef struct iree_hal_local_profile_id_set_t {
 
   // Number of occupied id slots.
   iree_host_size_t count;
-} iree_hal_local_profile_id_set_t;
+} iree_hal_task_profile_id_set_t;
 
-typedef struct iree_hal_local_profile_dispatch_event_record_t {
-  // Queue scope used for chunk metadata when flushing the event.
-  iree_hal_local_profile_queue_scope_t scope;
-
-  // Serialized dispatch event record.
-  iree_hal_profile_dispatch_event_t event;
-} iree_hal_local_profile_dispatch_event_record_t;
-
-struct iree_hal_local_profile_recorder_t {
+struct iree_hal_task_profile_recorder_t {
   // Host allocator used for recorder-owned storage.
   iree_allocator_t host_allocator;
 
@@ -70,14 +62,8 @@ struct iree_hal_local_profile_recorder_t {
   // Single allocation backing all enabled event rings.
   void* event_storage;
 
-  // Ring of producer-owned dispatch event records.
-  iree_hal_profile_event_ring_t dispatch_event_ring;
-
   // Ring of host queue event records.
   iree_hal_profile_event_ring_t queue_event_ring;
-
-  // Ring of producer-owned queue device event records.
-  iree_hal_profile_event_ring_t queue_device_event_ring;
 
   // Ring of host execution span records.
   iree_hal_profile_event_ring_t host_execution_event_ring;
@@ -91,51 +77,36 @@ struct iree_hal_local_profile_recorder_t {
   // Metadata ids already emitted to the session sink.
   struct {
     // Executable ids whose metadata was emitted.
-    iree_hal_local_profile_id_set_t executables;
+    iree_hal_task_profile_id_set_t executables;
 
     // Command-buffer ids whose metadata was emitted.
-    iree_hal_local_profile_id_set_t command_buffers;
+    iree_hal_task_profile_id_set_t command_buffers;
   } emitted;
 };
 
-static bool iree_hal_local_profile_recorder_requests_data(
-    const iree_hal_local_profile_recorder_t* recorder,
+static bool iree_hal_task_profile_recorder_requests_data(
+    const iree_hal_task_profile_recorder_t* recorder,
     iree_hal_device_profiling_data_families_t data_families) {
   return iree_hal_device_profiling_options_requests_data(&recorder->options,
                                                          data_families);
 }
 
 static iree_hal_device_profiling_data_families_t
-iree_hal_local_profile_recorder_lightweight_statistics_data_families(void) {
+iree_hal_task_profile_recorder_lightweight_statistics_data_families(void) {
   return IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
          IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS |
          IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA;
 }
 
-static iree_hal_device_profiling_data_families_t
-iree_hal_local_profile_recorder_all_data_families(void) {
-  return IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
-         IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS |
-         IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS |
-         IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS |
-         IREE_HAL_DEVICE_PROFILING_DATA_COUNTER_SAMPLES |
-         IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA |
-         IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_TRACES |
-         IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS |
-         IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_METRICS |
-         IREE_HAL_DEVICE_PROFILING_DATA_COMMAND_REGION_EVENTS |
-         IREE_HAL_DEVICE_PROFILING_DATA_COUNTER_RANGES;
-}
-
 static iree_hal_device_profiling_options_t
-iree_hal_local_profile_recorder_resolve_profiling_options(
+iree_hal_task_profile_recorder_resolve_profiling_options(
     const iree_hal_device_profiling_options_t* profiling_options) {
   iree_hal_device_profiling_options_t resolved_options = *profiling_options;
   if (resolved_options.data_families == IREE_HAL_DEVICE_PROFILING_DATA_NONE &&
       iree_hal_device_profiling_options_requests_lightweight_statistics(
           profiling_options)) {
     resolved_options.data_families =
-        iree_hal_local_profile_recorder_lightweight_statistics_data_families();
+        iree_hal_task_profile_recorder_lightweight_statistics_data_families();
   }
   if (iree_hal_device_profiling_options_requests_data(
           &resolved_options,
@@ -149,43 +120,38 @@ iree_hal_local_profile_recorder_resolve_profiling_options(
     resolved_options.data_families |=
         IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA;
   }
-  if (iree_hal_device_profiling_options_requests_data(
-          &resolved_options, IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS)) {
-    resolved_options.data_families |=
-        IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA;
-  }
   resolved_options.flags &=
       ~IREE_HAL_DEVICE_PROFILING_FLAG_LIGHTWEIGHT_STATISTICS;
   return resolved_options;
 }
 
-static iree_status_t iree_hal_local_profile_recorder_validate_records(
-    const iree_hal_local_profile_recorder_options_t* recorder_options) {
+static iree_status_t iree_hal_task_profile_recorder_validate_records(
+    const iree_hal_task_profile_recorder_options_t* recorder_options) {
   if (recorder_options->device_record_count == 0 ||
       !recorder_options->device_records) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling requires at least one device metadata record");
+        "task profiling requires at least one device metadata record");
   }
   if (recorder_options->queue_record_count == 0 ||
       !recorder_options->queue_records) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling requires at least one queue metadata record");
+        "task profiling requires at least one queue metadata record");
   }
   for (iree_host_size_t i = 0; i < recorder_options->device_record_count; ++i) {
     const iree_hal_profile_device_record_t* record =
         &recorder_options->device_records[i];
     if (record->record_length != sizeof(*record)) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "local profiling device metadata record %" PRIhsz
+                              "task profiling device metadata record %" PRIhsz
                               " has unsupported length %" PRIu32,
                               i, record->record_length);
     }
     if (record->physical_device_ordinal == UINT32_MAX ||
         record->queue_count == 0) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "local profiling device metadata record %" PRIhsz
+                              "task profiling device metadata record %" PRIhsz
                               " has invalid queue identity",
                               i);
     }
@@ -193,7 +159,7 @@ static iree_status_t iree_hal_local_profile_recorder_validate_records(
                           IREE_HAL_PROFILE_DEVICE_FLAG_TIMESTAMP_FREQUENCY) &&
         record->timestamp_frequency_hz == 0) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "local profiling device metadata record %" PRIhsz
+                              "task profiling device metadata record %" PRIhsz
                               " advertises a zero timestamp frequency",
                               i);
     }
@@ -203,14 +169,14 @@ static iree_status_t iree_hal_local_profile_recorder_validate_records(
         &recorder_options->queue_records[i];
     if (record->record_length != sizeof(*record)) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "local profiling queue metadata record %" PRIhsz
+                              "task profiling queue metadata record %" PRIhsz
                               " has unsupported length %" PRIu32,
                               i, record->record_length);
     }
     if (record->physical_device_ordinal == UINT32_MAX ||
         record->queue_ordinal == UINT32_MAX) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "local profiling queue metadata record %" PRIhsz
+                              "task profiling queue metadata record %" PRIhsz
                               " has invalid queue identity",
                               i);
     }
@@ -218,135 +184,92 @@ static iree_status_t iree_hal_local_profile_recorder_validate_records(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_local_profile_recorder_validate_profiling_options(
-    const iree_hal_local_profile_recorder_options_t* recorder_options,
+static iree_status_t iree_hal_task_profile_recorder_validate_profiling_options(
     const iree_hal_device_profiling_options_t* profiling_options) {
   if (profiling_options->flags != IREE_HAL_DEVICE_PROFILING_FLAG_NONE) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "unsupported local profiling flags 0x%x",
+                            "unsupported task profiling flags 0x%x",
                             profiling_options->flags);
   }
-  const iree_hal_device_profiling_data_families_t
-      unknown_producer_data_families =
-          recorder_options->producer_data_families &
-          ~iree_hal_local_profile_recorder_all_data_families();
-  if (unknown_producer_data_families != IREE_HAL_DEVICE_PROFILING_DATA_NONE) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "unrecognized local profiling producer data families 0x%" PRIx64,
-        unknown_producer_data_families);
-  }
-  const iree_hal_device_profiling_data_families_t supported_data_families =
-      iree_hal_local_profile_recorder_supported_data_families() |
-      recorder_options->producer_data_families;
   const iree_hal_device_profiling_data_families_t unsupported_data_families =
-      profiling_options->data_families & ~supported_data_families;
+      profiling_options->data_families &
+      ~iree_hal_task_profile_recorder_supported_data_families();
   if (unsupported_data_families != IREE_HAL_DEVICE_PROFILING_DATA_NONE) {
     return iree_make_status(
         IREE_STATUS_UNIMPLEMENTED,
-        "unsupported local profiling data families 0x%" PRIx64,
+        "unsupported task profiling data families 0x%" PRIx64,
         unsupported_data_families);
   }
   if (profiling_options->data_families != IREE_HAL_DEVICE_PROFILING_DATA_NONE &&
       !profiling_options->sink) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling with requested data families requires a profile sink");
+        "task profiling with requested data families requires a profile sink");
   }
   if (profiling_options->capture_filter.reserved0 != 0) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling capture filter reserved fields must be zero");
+        "task profiling capture filter reserved fields must be zero");
   }
   if (!iree_hal_profile_capture_filter_is_default(
           &profiling_options->capture_filter)) {
-    const bool dispatch_filter_owned_by_producer =
-        iree_hal_device_profiling_options_requests_data(
-            profiling_options,
-            IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS) &&
-        iree_all_bits_set(recorder_options->producer_data_families,
-                          IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS);
-    const iree_hal_device_profiling_data_families_t unfilterable_data_families =
-        profiling_options->data_families &
-        ~(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS |
-          IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA);
-    if (!dispatch_filter_owned_by_producer ||
-        unfilterable_data_families != IREE_HAL_DEVICE_PROFILING_DATA_NONE) {
-      return iree_make_status(
-          IREE_STATUS_UNIMPLEMENTED,
-          "local profiling capture filters require producer-owned dispatch "
-          "events and no unfilterable local data families");
-    }
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "task profiling does not support capture filters");
   }
   if (profiling_options->counter_set_count != 0 ||
       profiling_options->counter_sets) {
     return iree_make_status(
         IREE_STATUS_UNIMPLEMENTED,
-        "local profiling does not support counter set selections");
+        "task profiling does not support counter set selections");
   }
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_local_profile_recorder_normalize_capacity(
+static iree_status_t iree_hal_task_profile_recorder_normalize_capacity(
     iree_host_size_t requested_capacity, iree_host_size_t* out_capacity) {
   iree_host_size_t capacity =
       requested_capacity != 0 ? requested_capacity
-                              : IREE_HAL_LOCAL_PROFILE_DEFAULT_EVENT_CAPACITY;
+                              : IREE_HAL_TASK_PROFILE_DEFAULT_EVENT_CAPACITY;
   capacity = iree_host_size_next_power_of_two(capacity);
   if (IREE_UNLIKELY(!iree_host_size_is_power_of_two(capacity))) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "local profiling event capacity is too large");
+                            "task profiling event capacity is too large");
   }
   *out_capacity = capacity;
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_local_profile_recorder_allocate_events(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_recorder_options_t* recorder_options) {
-  iree_host_size_t dispatch_event_capacity = 0;
+static iree_status_t iree_hal_task_profile_recorder_allocate_events(
+    iree_hal_task_profile_recorder_t* recorder,
+    const iree_hal_task_profile_recorder_options_t* recorder_options) {
   iree_host_size_t queue_event_capacity = 0;
-  iree_host_size_t queue_device_event_capacity = 0;
   iree_host_size_t host_execution_event_capacity = 0;
   iree_host_size_t memory_event_capacity = 0;
   iree_host_size_t command_region_event_capacity = 0;
-  if (iree_hal_local_profile_recorder_requests_data(
-          recorder, IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS)) {
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_normalize_capacity(
-        recorder_options->dispatch_event_capacity, &dispatch_event_capacity));
-  }
-  if (iree_hal_local_profile_recorder_requests_data(
+  if (iree_hal_task_profile_recorder_requests_data(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS)) {
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_normalize_capacity(
+    IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_normalize_capacity(
         recorder_options->queue_event_capacity, &queue_event_capacity));
   }
-  if (iree_hal_local_profile_recorder_requests_data(
-          recorder, IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS)) {
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_normalize_capacity(
-        recorder_options->queue_device_event_capacity,
-        &queue_device_event_capacity));
-  }
-  if (iree_hal_local_profile_recorder_requests_data(
+  if (iree_hal_task_profile_recorder_requests_data(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS)) {
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_normalize_capacity(
+    IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_normalize_capacity(
         recorder_options->host_execution_event_capacity,
         &host_execution_event_capacity));
   }
-  if (iree_hal_local_profile_recorder_requests_data(
+  if (iree_hal_task_profile_recorder_requests_data(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS)) {
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_normalize_capacity(
+    IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_normalize_capacity(
         recorder_options->memory_event_capacity, &memory_event_capacity));
   }
-  if (iree_hal_local_profile_recorder_requests_data(
+  if (iree_hal_task_profile_recorder_requests_data(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_COMMAND_REGION_EVENTS)) {
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_normalize_capacity(
+    IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_normalize_capacity(
         recorder_options->command_region_event_capacity,
         &command_region_event_capacity));
   }
 
-  iree_host_size_t dispatch_events_offset = 0;
   iree_host_size_t queue_events_offset = 0;
-  iree_host_size_t queue_device_events_offset = 0;
   iree_host_size_t host_execution_events_offset = 0;
   iree_host_size_t memory_events_offset = 0;
   iree_host_size_t command_region_events_offset = 0;
@@ -354,17 +277,8 @@ static iree_status_t iree_hal_local_profile_recorder_allocate_events(
   IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
       0, &total_size,
       IREE_STRUCT_FIELD_ALIGNED(
-          dispatch_event_capacity,
-          iree_hal_local_profile_dispatch_event_record_t,
-          iree_alignof(iree_hal_local_profile_dispatch_event_record_t),
-          &dispatch_events_offset),
-      IREE_STRUCT_FIELD_ALIGNED(
           queue_event_capacity, iree_hal_profile_queue_event_t,
           iree_alignof(iree_hal_profile_queue_event_t), &queue_events_offset),
-      IREE_STRUCT_FIELD_ALIGNED(
-          queue_device_event_capacity, iree_hal_profile_queue_device_event_t,
-          iree_alignof(iree_hal_profile_queue_device_event_t),
-          &queue_device_events_offset),
       IREE_STRUCT_FIELD_ALIGNED(
           host_execution_event_capacity,
           iree_hal_profile_host_execution_event_t,
@@ -386,23 +300,11 @@ static iree_status_t iree_hal_local_profile_recorder_allocate_events(
   memset(event_storage, 0, total_size);
   recorder->event_storage = event_storage;
 
-  if (dispatch_event_capacity != 0) {
-    iree_hal_profile_event_ring_initialize(
-        (uint8_t*)event_storage + dispatch_events_offset,
-        sizeof(iree_hal_local_profile_dispatch_event_record_t),
-        dispatch_event_capacity, &recorder->dispatch_event_ring);
-  }
   if (queue_event_capacity != 0) {
     iree_hal_profile_event_ring_initialize(
         (uint8_t*)event_storage + queue_events_offset,
         sizeof(iree_hal_profile_queue_event_t), queue_event_capacity,
         &recorder->queue_event_ring);
-  }
-  if (queue_device_event_capacity != 0) {
-    iree_hal_profile_event_ring_initialize(
-        (uint8_t*)event_storage + queue_device_events_offset,
-        sizeof(iree_hal_profile_queue_device_event_t),
-        queue_device_event_capacity, &recorder->queue_device_event_ring);
   }
   if (host_execution_event_capacity != 0) {
     iree_hal_profile_event_ring_initialize(
@@ -425,10 +327,10 @@ static iree_status_t iree_hal_local_profile_recorder_allocate_events(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_local_profile_recorder_copy_name(
-    iree_hal_local_profile_recorder_t* recorder, iree_string_view_t name) {
+static iree_status_t iree_hal_task_profile_recorder_copy_name(
+    iree_hal_task_profile_recorder_t* recorder, iree_string_view_t name) {
   if (iree_string_view_is_empty(name)) {
-    recorder->name = IREE_SV("local");
+    recorder->name = IREE_SV("local-task");
     return iree_ok_status();
   }
   IREE_RETURN_IF_ERROR(iree_allocator_clone(
@@ -439,8 +341,8 @@ static iree_status_t iree_hal_local_profile_recorder_copy_name(
 }
 
 static iree_hal_profile_chunk_metadata_t
-iree_hal_local_profile_recorder_metadata(
-    const iree_hal_local_profile_recorder_t* recorder,
+iree_hal_task_profile_recorder_metadata(
+    const iree_hal_task_profile_recorder_t* recorder,
     iree_string_view_t content_type) {
   iree_hal_profile_chunk_metadata_t metadata =
       iree_hal_profile_chunk_metadata_default();
@@ -450,45 +352,45 @@ iree_hal_local_profile_recorder_metadata(
   return metadata;
 }
 
-static iree_status_t iree_hal_local_profile_recorder_write_records(
-    iree_hal_local_profile_recorder_t* recorder,
-    iree_string_view_t content_type, const void* records,
-    iree_host_size_t record_count, iree_host_size_t record_size) {
+static iree_status_t iree_hal_task_profile_recorder_write_records(
+    iree_hal_task_profile_recorder_t* recorder, iree_string_view_t content_type,
+    const void* records, iree_host_size_t record_count,
+    iree_host_size_t record_size) {
   if (record_count == 0) return iree_ok_status();
   iree_host_size_t byte_length = 0;
   if (IREE_UNLIKELY(!iree_host_size_checked_mul(record_count, record_size,
                                                 &byte_length))) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "local profiling chunk size overflow for %" PRIhsz
+                            "task profiling chunk size overflow for %" PRIhsz
                             " records",
                             record_count);
   }
   iree_hal_profile_chunk_metadata_t metadata =
-      iree_hal_local_profile_recorder_metadata(recorder, content_type);
+      iree_hal_task_profile_recorder_metadata(recorder, content_type);
   iree_const_byte_span_t iovec =
       iree_make_const_byte_span(records, byte_length);
   return iree_hal_profile_sink_write(recorder->options.sink, &metadata, 1,
                                      &iovec);
 }
 
-static iree_status_t iree_hal_local_profile_recorder_write_metadata(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_recorder_options_t* recorder_options) {
-  IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_write_records(
+static iree_status_t iree_hal_task_profile_recorder_write_metadata(
+    iree_hal_task_profile_recorder_t* recorder,
+    const iree_hal_task_profile_recorder_options_t* recorder_options) {
+  IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_write_records(
       recorder, IREE_HAL_PROFILE_CONTENT_TYPE_DEVICES,
       recorder_options->device_records, recorder_options->device_record_count,
       sizeof(*recorder_options->device_records)));
-  return iree_hal_local_profile_recorder_write_records(
+  return iree_hal_task_profile_recorder_write_records(
       recorder, IREE_HAL_PROFILE_CONTENT_TYPE_QUEUES,
       recorder_options->queue_records, recorder_options->queue_record_count,
       sizeof(*recorder_options->queue_records));
 }
 
-iree_status_t iree_hal_local_profile_recorder_create(
-    const iree_hal_local_profile_recorder_options_t* recorder_options,
+iree_status_t iree_hal_task_profile_recorder_create(
+    const iree_hal_task_profile_recorder_options_t* recorder_options,
     const iree_hal_device_profiling_options_t* profiling_options,
     iree_allocator_t host_allocator,
-    iree_hal_local_profile_recorder_t** out_recorder) {
+    iree_hal_task_profile_recorder_t** out_recorder) {
   IREE_ASSERT_ARGUMENT(recorder_options);
   IREE_ASSERT_ARGUMENT(profiling_options);
   IREE_ASSERT_ARGUMENT(out_recorder);
@@ -498,23 +400,23 @@ iree_status_t iree_hal_local_profile_recorder_create(
       IREE_HAL_DEVICE_PROFILING_FLAG_LIGHTWEIGHT_STATISTICS;
   if (iree_any_bit_set(profiling_options->flags, ~supported_flags)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "unsupported local profiling flags 0x%x",
+                            "unsupported task profiling flags 0x%x",
                             profiling_options->flags & ~supported_flags);
   }
   iree_hal_device_profiling_options_t resolved_options =
-      iree_hal_local_profile_recorder_resolve_profiling_options(
+      iree_hal_task_profile_recorder_resolve_profiling_options(
           profiling_options);
   if (resolved_options.data_families == IREE_HAL_DEVICE_PROFILING_DATA_NONE) {
     return iree_ok_status();
   }
 
   IREE_RETURN_IF_ERROR(
-      iree_hal_local_profile_recorder_validate_profiling_options(
-          recorder_options, &resolved_options));
+      iree_hal_task_profile_recorder_validate_profiling_options(
+          &resolved_options));
   IREE_RETURN_IF_ERROR(
-      iree_hal_local_profile_recorder_validate_records(recorder_options));
+      iree_hal_task_profile_recorder_validate_records(recorder_options));
 
-  iree_hal_local_profile_recorder_t* recorder = NULL;
+  iree_hal_task_profile_recorder_t* recorder = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(host_allocator, sizeof(*recorder),
                                              (void**)&recorder));
   memset(recorder, 0, sizeof(*recorder));
@@ -524,7 +426,7 @@ iree_status_t iree_hal_local_profile_recorder_create(
   iree_slim_mutex_initialize(&recorder->flush_mutex);
 
   bool sink_session_begun = false;
-  iree_status_t status = iree_hal_local_profile_recorder_copy_name(
+  iree_status_t status = iree_hal_task_profile_recorder_copy_name(
       recorder, recorder_options->name);
   if (iree_status_is_ok(status)) {
     status = iree_hal_device_profiling_options_clone(
@@ -532,20 +434,20 @@ iree_status_t iree_hal_local_profile_recorder_create(
         &recorder->options_storage);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_allocate_events(recorder,
-                                                             recorder_options);
+    status = iree_hal_task_profile_recorder_allocate_events(recorder,
+                                                            recorder_options);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_profile_chunk_metadata_t metadata =
-        iree_hal_local_profile_recorder_metadata(
+        iree_hal_task_profile_recorder_metadata(
             recorder, IREE_HAL_PROFILE_CONTENT_TYPE_SESSION);
     status =
         iree_hal_profile_sink_begin_session(recorder->options.sink, &metadata);
     sink_session_begun = iree_status_is_ok(status);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_write_metadata(recorder,
-                                                            recorder_options);
+    status = iree_hal_task_profile_recorder_write_metadata(recorder,
+                                                           recorder_options);
   }
 
   if (iree_status_is_ok(status)) {
@@ -554,23 +456,23 @@ iree_status_t iree_hal_local_profile_recorder_create(
   } else {
     if (sink_session_begun) {
       iree_hal_profile_chunk_metadata_t metadata =
-          iree_hal_local_profile_recorder_metadata(
+          iree_hal_task_profile_recorder_metadata(
               recorder, IREE_HAL_PROFILE_CONTENT_TYPE_SESSION);
       iree_status_code_t status_code = iree_status_code(status);
       status = iree_status_join(
           status, iree_hal_profile_sink_end_session(recorder->options.sink,
                                                     &metadata, status_code));
     }
-    iree_hal_local_profile_recorder_destroy(recorder);
+    iree_hal_task_profile_recorder_destroy(recorder);
   }
   return status;
 }
 
-void iree_hal_local_profile_recorder_destroy(
-    iree_hal_local_profile_recorder_t* recorder) {
+void iree_hal_task_profile_recorder_destroy(
+    iree_hal_task_profile_recorder_t* recorder) {
   if (!recorder) return;
   IREE_ASSERT(!recorder->active,
-              "active local profile recorders must be ended before destroy");
+              "active task profile recorders must be ended before destroy");
   iree_allocator_t host_allocator = recorder->host_allocator;
   iree_allocator_free(host_allocator, recorder->event_storage);
   iree_allocator_free(host_allocator, recorder->emitted.executables.ids);
@@ -583,21 +485,15 @@ void iree_hal_local_profile_recorder_destroy(
   iree_allocator_free(host_allocator, recorder);
 }
 
-bool iree_hal_local_profile_recorder_is_enabled(
-    const iree_hal_local_profile_recorder_t* recorder,
+bool iree_hal_task_profile_recorder_is_enabled(
+    const iree_hal_task_profile_recorder_t* recorder,
     iree_hal_device_profiling_data_families_t data_families) {
   return recorder && recorder->active &&
          iree_hal_device_profiling_options_requests_data(&recorder->options,
                                                          data_families);
 }
 
-const iree_hal_device_profiling_options_t*
-iree_hal_local_profile_recorder_options(
-    const iree_hal_local_profile_recorder_t* recorder) {
-  return recorder && recorder->active ? &recorder->options : NULL;
-}
-
-static iree_host_size_t iree_hal_local_profile_hash_id(
+static iree_host_size_t iree_hal_task_profile_hash_id(
     uint64_t id, iree_host_size_t capacity) {
   id ^= id >> 33;
   id *= 0xff51afd7ed558ccdull;
@@ -607,11 +503,11 @@ static iree_host_size_t iree_hal_local_profile_hash_id(
   return (iree_host_size_t)id & (capacity - 1);
 }
 
-static bool iree_hal_local_profile_id_set_find_slot(
-    const iree_hal_local_profile_id_set_t* set, uint64_t id,
+static bool iree_hal_task_profile_id_set_find_slot(
+    const iree_hal_task_profile_id_set_t* set, uint64_t id,
     iree_host_size_t* out_slot) {
   IREE_ASSERT(set->capacity != 0);
-  iree_host_size_t slot = iree_hal_local_profile_hash_id(id, set->capacity);
+  iree_host_size_t slot = iree_hal_task_profile_hash_id(id, set->capacity);
   while (set->ids[slot] != 0) {
     if (set->ids[slot] == id) {
       *out_slot = slot;
@@ -623,12 +519,12 @@ static bool iree_hal_local_profile_id_set_find_slot(
   return false;
 }
 
-static iree_status_t iree_hal_local_profile_id_set_reserve(
-    iree_allocator_t host_allocator, iree_hal_local_profile_id_set_t* set,
+static iree_status_t iree_hal_task_profile_id_set_reserve(
+    iree_allocator_t host_allocator, iree_hal_task_profile_id_set_t* set,
     iree_host_size_t minimum_capacity, const char* label) {
   if (IREE_UNLIKELY(minimum_capacity > IREE_HOST_SIZE_MAX / 2)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "local profiling %s metadata set is too large",
+                            "task profiling %s metadata set is too large",
                             label);
   }
   const iree_host_size_t required_capacity = minimum_capacity * 2;
@@ -638,7 +534,7 @@ static iree_status_t iree_hal_local_profile_id_set_reserve(
   while (required_capacity > capacity) {
     if (IREE_UNLIKELY(capacity > IREE_HOST_SIZE_MAX / 2)) {
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                              "local profiling %s metadata set is too large",
+                              "task profiling %s metadata set is too large",
                               label);
     }
     capacity *= 2;
@@ -648,14 +544,14 @@ static iree_status_t iree_hal_local_profile_id_set_reserve(
   if (IREE_UNLIKELY(!iree_host_size_checked_mul(capacity, sizeof(*set->ids),
                                                 &byte_length))) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "local profiling %s metadata set size overflow",
+                            "task profiling %s metadata set size overflow",
                             label);
   }
   uint64_t* ids = NULL;
   IREE_RETURN_IF_ERROR(
       iree_allocator_malloc(host_allocator, byte_length, (void**)&ids));
   memset(ids, 0, byte_length);
-  iree_hal_local_profile_id_set_t new_set = {
+  iree_hal_task_profile_id_set_t new_set = {
       .ids = ids,
       .capacity = capacity,
   };
@@ -663,7 +559,7 @@ static iree_status_t iree_hal_local_profile_id_set_reserve(
     const uint64_t id = set->ids[i];
     if (id == 0) continue;
     iree_host_size_t slot = 0;
-    iree_hal_local_profile_id_set_find_slot(&new_set, id, &slot);
+    iree_hal_task_profile_id_set_find_slot(&new_set, id, &slot);
     ids[slot] = id;
   }
   new_set.count = set->count;
@@ -673,19 +569,19 @@ static iree_status_t iree_hal_local_profile_id_set_reserve(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_local_profile_recorder_mark_id_emitted(
-    iree_hal_local_profile_recorder_t* recorder,
-    iree_hal_local_profile_id_set_t* set, uint64_t id, const char* label,
+static iree_status_t iree_hal_task_profile_recorder_mark_id_emitted(
+    iree_hal_task_profile_recorder_t* recorder,
+    iree_hal_task_profile_id_set_t* set, uint64_t id, const char* label,
     bool* out_should_emit) {
   *out_should_emit = false;
 
   iree_slim_mutex_lock(&recorder->mutex);
-  iree_status_t status = iree_hal_local_profile_id_set_reserve(
+  iree_status_t status = iree_hal_task_profile_id_set_reserve(
       recorder->host_allocator, set, set->count + 1, label);
   if (iree_status_is_ok(status)) {
     iree_host_size_t slot = 0;
     const bool already_emitted =
-        iree_hal_local_profile_id_set_find_slot(set, id, &slot);
+        iree_hal_task_profile_id_set_find_slot(set, id, &slot);
     if (!already_emitted) {
       set->ids[slot] = id;
       ++set->count;
@@ -696,20 +592,20 @@ static iree_status_t iree_hal_local_profile_recorder_mark_id_emitted(
   return status;
 }
 
-static bool iree_hal_local_profile_recorder_has_emitted_id(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_id_set_t* set, uint64_t id) {
+static bool iree_hal_task_profile_recorder_has_emitted_id(
+    iree_hal_task_profile_recorder_t* recorder,
+    const iree_hal_task_profile_id_set_t* set, uint64_t id) {
   iree_slim_mutex_lock(&recorder->mutex);
   bool has_emitted = false;
   if (set->capacity != 0) {
     iree_host_size_t slot = 0;
-    has_emitted = iree_hal_local_profile_id_set_find_slot(set, id, &slot);
+    has_emitted = iree_hal_task_profile_id_set_find_slot(set, id, &slot);
   }
   iree_slim_mutex_unlock(&recorder->mutex);
   return has_emitted;
 }
 
-static iree_status_t iree_hal_local_profile_executable_function_record_length(
+static iree_status_t iree_hal_task_profile_executable_function_record_length(
     iree_string_view_t name, iree_host_size_t* out_record_length) {
   *out_record_length = 0;
   if (IREE_UNLIKELY(name.size > UINT32_MAX)) {
@@ -729,7 +625,7 @@ static iree_status_t iree_hal_local_profile_executable_function_record_length(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_local_profile_executable_function_data_length(
+static iree_status_t iree_hal_task_profile_executable_function_data_length(
     iree_hal_executable_t* executable, iree_host_size_t function_count,
     iree_host_size_t* out_data_length) {
   *out_data_length = 0;
@@ -743,7 +639,7 @@ static iree_status_t iree_hal_local_profile_executable_function_data_length(
         &function_info);
     iree_host_size_t record_length = 0;
     if (iree_status_is_ok(status)) {
-      status = iree_hal_local_profile_executable_function_record_length(
+      status = iree_hal_task_profile_executable_function_record_length(
           function_info.name, &record_length);
     }
     if (iree_status_is_ok(status) &&
@@ -758,7 +654,7 @@ static iree_status_t iree_hal_local_profile_executable_function_data_length(
   return status;
 }
 
-static iree_status_t iree_hal_local_profile_append_executable_function_records(
+static iree_status_t iree_hal_task_profile_append_executable_function_records(
     uint64_t executable_id, iree_hal_executable_t* executable,
     iree_host_size_t function_count, uint8_t* target_data) {
   uint8_t* cursor = target_data;
@@ -770,7 +666,7 @@ static iree_status_t iree_hal_local_profile_append_executable_function_records(
 
     iree_host_size_t record_length = 0;
     IREE_RETURN_IF_ERROR(
-        iree_hal_local_profile_executable_function_record_length(
+        iree_hal_task_profile_executable_function_record_length(
             function_info.name, &record_length));
 
     iree_hal_profile_executable_function_record_t record =
@@ -795,30 +691,30 @@ static iree_status_t iree_hal_local_profile_append_executable_function_records(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_local_profile_recorder_write_span(
-    iree_hal_local_profile_recorder_t* recorder,
-    iree_string_view_t content_type, iree_const_byte_span_t span) {
+static iree_status_t iree_hal_task_profile_recorder_write_span(
+    iree_hal_task_profile_recorder_t* recorder, iree_string_view_t content_type,
+    iree_const_byte_span_t span) {
   if (span.data_length == 0) return iree_ok_status();
   iree_hal_profile_chunk_metadata_t metadata =
-      iree_hal_local_profile_recorder_metadata(recorder, content_type);
+      iree_hal_task_profile_recorder_metadata(recorder, content_type);
   return iree_hal_profile_sink_write(recorder->options.sink, &metadata, 1,
                                      &span);
 }
 
-iree_status_t iree_hal_local_profile_recorder_record_executable_with_id(
-    iree_hal_local_profile_recorder_t* recorder,
+static iree_status_t iree_hal_task_profile_recorder_record_executable_with_id(
+    iree_hal_task_profile_recorder_t* recorder,
     iree_hal_executable_t* executable, uint64_t executable_id) {
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA)) {
     return iree_ok_status();
   }
   if (IREE_UNLIKELY(executable_id == 0)) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling executable metadata requires a nonzero id");
+        "task profiling executable metadata requires a nonzero id");
   }
 
-  if (iree_hal_local_profile_recorder_has_emitted_id(
+  if (iree_hal_task_profile_recorder_has_emitted_id(
           recorder, &recorder->emitted.executables, executable_id)) {
     return iree_ok_status();
   }
@@ -837,7 +733,7 @@ iree_status_t iree_hal_local_profile_recorder_record_executable_with_id(
   executable_record.function_count = (uint32_t)function_count;
 
   iree_host_size_t function_data_length = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_local_profile_executable_function_data_length(
+  IREE_RETURN_IF_ERROR(iree_hal_task_profile_executable_function_data_length(
       executable, function_count, &function_data_length));
   uint8_t* function_data = NULL;
   iree_status_t status = iree_ok_status();
@@ -846,23 +742,23 @@ iree_status_t iree_hal_local_profile_recorder_record_executable_with_id(
         recorder->host_allocator, function_data_length, (void**)&function_data);
   }
   if (iree_status_is_ok(status) && function_data_length != 0) {
-    status = iree_hal_local_profile_append_executable_function_records(
+    status = iree_hal_task_profile_append_executable_function_records(
         executable_id, executable, function_count, function_data);
   }
 
   bool should_emit = false;
   if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_mark_id_emitted(
+    status = iree_hal_task_profile_recorder_mark_id_emitted(
         recorder, &recorder->emitted.executables, executable_id, "executable",
         &should_emit);
   }
   if (iree_status_is_ok(status) && should_emit) {
-    status = iree_hal_local_profile_recorder_write_records(
+    status = iree_hal_task_profile_recorder_write_records(
         recorder, IREE_HAL_PROFILE_CONTENT_TYPE_EXECUTABLES, &executable_record,
         /*record_count=*/1, sizeof(executable_record));
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_write_span(
+    status = iree_hal_task_profile_recorder_write_span(
         recorder, IREE_HAL_PROFILE_CONTENT_TYPE_EXECUTABLE_FUNCTIONS,
         should_emit
             ? iree_make_const_byte_span(function_data, function_data_length)
@@ -872,26 +768,26 @@ iree_status_t iree_hal_local_profile_recorder_record_executable_with_id(
   return status;
 }
 
-iree_status_t iree_hal_local_profile_recorder_record_executable(
-    iree_hal_local_profile_recorder_t* recorder,
+iree_status_t iree_hal_task_profile_recorder_record_executable(
+    iree_hal_task_profile_recorder_t* recorder,
     iree_hal_executable_t* executable) {
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA)) {
     return iree_ok_status();
   }
   iree_hal_local_executable_t* local_executable =
       iree_hal_local_executable_cast(executable);
-  return iree_hal_local_profile_recorder_record_executable_with_id(
+  return iree_hal_task_profile_recorder_record_executable_with_id(
       recorder, executable,
       iree_hal_local_executable_profile_id(local_executable));
 }
 
-iree_status_t iree_hal_local_profile_recorder_record_command_buffer(
-    iree_hal_local_profile_recorder_t* recorder,
+iree_status_t iree_hal_task_profile_recorder_record_command_buffer(
+    iree_hal_task_profile_recorder_t* recorder,
     const iree_hal_profile_command_buffer_record_t* command_buffer,
     iree_host_size_t operation_count,
     const iree_hal_profile_command_operation_record_t* operations) {
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA)) {
     return iree_ok_status();
   }
@@ -899,155 +795,72 @@ iree_status_t iree_hal_local_profile_recorder_record_command_buffer(
                     command_buffer->command_buffer_id == 0)) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling command-buffer metadata requires a nonzero id");
+        "task profiling command-buffer metadata requires a nonzero id");
   }
   if (IREE_UNLIKELY(operation_count != 0 && !operations)) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling command-buffer operation records are required");
+        "task profiling command-buffer operation records are required");
   }
 
   bool should_emit = false;
-  IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_mark_id_emitted(
+  IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_mark_id_emitted(
       recorder, &recorder->emitted.command_buffers,
       command_buffer->command_buffer_id, "command-buffer", &should_emit));
   if (!should_emit) return iree_ok_status();
 
-  IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_write_records(
+  IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_write_records(
       recorder, IREE_HAL_PROFILE_CONTENT_TYPE_COMMAND_BUFFERS, command_buffer,
       /*record_count=*/1, sizeof(*command_buffer)));
-  return iree_hal_local_profile_recorder_write_records(
+  return iree_hal_task_profile_recorder_write_records(
       recorder, IREE_HAL_PROFILE_CONTENT_TYPE_COMMAND_OPERATIONS, operations,
       operation_count, sizeof(*operations));
 }
 
-static bool iree_hal_local_profile_queue_scope_is_valid(
-    const iree_hal_local_profile_queue_scope_t* scope) {
+static bool iree_hal_task_profile_queue_scope_is_valid(
+    const iree_hal_task_profile_queue_scope_t* scope) {
   return scope->physical_device_ordinal != UINT32_MAX &&
          scope->queue_ordinal != UINT32_MAX;
 }
 
-static iree_hal_profile_queue_event_t* iree_hal_local_profile_queue_event_at(
+static iree_hal_profile_queue_event_t* iree_hal_task_profile_queue_event_at(
     const iree_hal_profile_event_ring_t* ring, uint64_t position) {
   return (iree_hal_profile_queue_event_t*)iree_hal_profile_event_ring_record_at(
       ring, position);
 }
 
-static iree_hal_local_profile_dispatch_event_record_t*
-iree_hal_local_profile_dispatch_event_at(
-    const iree_hal_profile_event_ring_t* ring, uint64_t position) {
-  return (iree_hal_local_profile_dispatch_event_record_t*)
-      iree_hal_profile_event_ring_record_at(ring, position);
-}
-
-static iree_hal_profile_queue_device_event_t*
-iree_hal_local_profile_queue_device_event_at(
-    const iree_hal_profile_event_ring_t* ring, uint64_t position) {
-  return (iree_hal_profile_queue_device_event_t*)
-      iree_hal_profile_event_ring_record_at(ring, position);
-}
-
 static iree_hal_profile_host_execution_event_t*
-iree_hal_local_profile_host_execution_event_at(
+iree_hal_task_profile_host_execution_event_at(
     const iree_hal_profile_event_ring_t* ring, uint64_t position) {
   return (iree_hal_profile_host_execution_event_t*)
       iree_hal_profile_event_ring_record_at(ring, position);
 }
 
-static iree_hal_profile_memory_event_t* iree_hal_local_profile_memory_event_at(
+static iree_hal_profile_memory_event_t* iree_hal_task_profile_memory_event_at(
     const iree_hal_profile_event_ring_t* ring, uint64_t position) {
   return (iree_hal_profile_memory_event_t*)
       iree_hal_profile_event_ring_record_at(ring, position);
 }
 
 static iree_hal_profile_command_region_event_t*
-iree_hal_local_profile_command_region_event_at(
+iree_hal_task_profile_command_region_event_at(
     const iree_hal_profile_event_ring_t* ring, uint64_t position) {
   return (iree_hal_profile_command_region_event_t*)
       iree_hal_profile_event_ring_record_at(ring, position);
 }
 
-iree_status_t iree_hal_local_profile_recorder_append_dispatch_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_dispatch_event_info_t* event_info,
+void iree_hal_task_profile_recorder_append_queue_event(
+    iree_hal_task_profile_recorder_t* recorder,
+    const iree_hal_task_profile_queue_event_info_t* event_info,
     uint64_t* out_event_id) {
   IREE_ASSERT_ARGUMENT(event_info);
   if (out_event_id) *out_event_id = 0;
-  if (!iree_hal_local_profile_recorder_is_enabled(
-          recorder, IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS)) {
-    return iree_ok_status();
-  }
-  const bool is_valid =
-      iree_hal_local_profile_queue_scope_is_valid(&event_info->scope) &&
-      event_info->executable_id != 0 &&
-      event_info->function_ordinal != UINT32_MAX &&
-      event_info->workgroup_size[0] != 0 &&
-      event_info->start_tick <= event_info->end_tick;
-  IREE_ASSERT(is_valid);
-  if (IREE_UNLIKELY(!is_valid)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling dispatch event has invalid identity, workgroup size, "
-        "or timestamp range");
-  }
-
-  iree_hal_profile_event_ring_t* ring = &recorder->dispatch_event_ring;
-  uint64_t event_position = 0;
-  uint64_t event_id = 0;
-  while (true) {
-    iree_slim_mutex_lock(&recorder->mutex);
-    const iree_host_size_t available_capacity =
-        iree_hal_profile_event_ring_available_capacity(ring);
-    if (available_capacity != 0) {
-      const bool appended = iree_hal_profile_event_ring_try_append(
-          ring, &event_position, &event_id);
-      IREE_ASSERT(appended);
-      if (IREE_LIKELY(appended)) break;
-    }
-    const bool ring_is_enabled = ring->records && ring->capacity != 0;
-    iree_slim_mutex_unlock(&recorder->mutex);
-    if (IREE_UNLIKELY(!ring_is_enabled)) {
-      return iree_make_status(
-          IREE_STATUS_FAILED_PRECONDITION,
-          "local profiling dispatch event ring is unavailable");
-    }
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_flush(recorder));
-  }
-
-  iree_hal_local_profile_dispatch_event_record_t* record =
-      iree_hal_local_profile_dispatch_event_at(ring, event_position);
-  record->scope = event_info->scope;
-  record->event = iree_hal_profile_dispatch_event_default();
-  record->event.flags = event_info->flags;
-  record->event.event_id = event_id;
-  record->event.submission_id = event_info->submission_id;
-  record->event.command_buffer_id = event_info->command_buffer_id;
-  record->event.executable_id = event_info->executable_id;
-  record->event.command_index = event_info->command_index;
-  record->event.function_ordinal = event_info->function_ordinal;
-  memcpy(record->event.workgroup_count, event_info->workgroup_count,
-         sizeof(record->event.workgroup_count));
-  memcpy(record->event.workgroup_size, event_info->workgroup_size,
-         sizeof(record->event.workgroup_size));
-  record->event.start_tick = event_info->start_tick;
-  record->event.end_tick = event_info->end_tick;
-  if (out_event_id) *out_event_id = event_id;
-  iree_slim_mutex_unlock(&recorder->mutex);
-  return iree_ok_status();
-}
-
-void iree_hal_local_profile_recorder_append_queue_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_queue_event_info_t* event_info,
-    uint64_t* out_event_id) {
-  IREE_ASSERT_ARGUMENT(event_info);
-  if (out_event_id) *out_event_id = 0;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS)) {
     return;
   }
   const bool is_valid =
-      iree_hal_local_profile_queue_scope_is_valid(&event_info->scope) &&
+      iree_hal_task_profile_queue_scope_is_valid(&event_info->scope) &&
       event_info->type != IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_NONE;
   IREE_ASSERT(is_valid);
   if (IREE_UNLIKELY(!is_valid)) return;
@@ -1063,7 +876,7 @@ void iree_hal_local_profile_recorder_append_queue_event(
   }
 
   iree_hal_profile_queue_event_t* event =
-      iree_hal_local_profile_queue_event_at(ring, event_position);
+      iree_hal_task_profile_queue_event_at(ring, event_position);
   *event = iree_hal_profile_queue_event_default();
   event->type = event_info->type;
   event->flags = event_info->flags;
@@ -1087,84 +900,18 @@ void iree_hal_local_profile_recorder_append_queue_event(
   iree_slim_mutex_unlock(&recorder->mutex);
 }
 
-iree_status_t iree_hal_local_profile_recorder_append_queue_device_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_queue_device_event_info_t* event_info,
+void iree_hal_task_profile_recorder_append_host_execution_event(
+    iree_hal_task_profile_recorder_t* recorder,
+    const iree_hal_task_profile_host_execution_event_info_t* event_info,
     uint64_t* out_event_id) {
   IREE_ASSERT_ARGUMENT(event_info);
   if (out_event_id) *out_event_id = 0;
-  if (!iree_hal_local_profile_recorder_is_enabled(
-          recorder, IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS)) {
-    return iree_ok_status();
-  }
-  const bool is_valid =
-      iree_hal_local_profile_queue_scope_is_valid(&event_info->scope) &&
-      event_info->type != IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_NONE &&
-      event_info->start_tick <= event_info->end_tick;
-  IREE_ASSERT(is_valid);
-  if (IREE_UNLIKELY(!is_valid)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling queue device event has invalid identity or timestamp "
-        "range");
-  }
-
-  iree_hal_profile_event_ring_t* ring = &recorder->queue_device_event_ring;
-  uint64_t event_position = 0;
-  uint64_t event_id = 0;
-  while (true) {
-    iree_slim_mutex_lock(&recorder->mutex);
-    const iree_host_size_t available_capacity =
-        iree_hal_profile_event_ring_available_capacity(ring);
-    if (available_capacity != 0) {
-      const bool appended = iree_hal_profile_event_ring_try_append(
-          ring, &event_position, &event_id);
-      IREE_ASSERT(appended);
-      if (IREE_LIKELY(appended)) break;
-    }
-    const bool ring_is_enabled = ring->records && ring->capacity != 0;
-    iree_slim_mutex_unlock(&recorder->mutex);
-    if (IREE_UNLIKELY(!ring_is_enabled)) {
-      return iree_make_status(
-          IREE_STATUS_FAILED_PRECONDITION,
-          "local profiling queue device event ring is unavailable");
-    }
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_flush(recorder));
-  }
-
-  iree_hal_profile_queue_device_event_t* event =
-      iree_hal_local_profile_queue_device_event_at(ring, event_position);
-  *event = iree_hal_profile_queue_device_event_default();
-  event->type = event_info->type;
-  event->flags = event_info->flags;
-  event->event_id = event_id;
-  event->submission_id = event_info->submission_id;
-  event->command_buffer_id = event_info->command_buffer_id;
-  event->allocation_id = event_info->allocation_id;
-  event->stream_id = event_info->scope.stream_id;
-  event->payload_length = event_info->payload_length;
-  event->physical_device_ordinal = event_info->scope.physical_device_ordinal;
-  event->queue_ordinal = event_info->scope.queue_ordinal;
-  event->operation_count = event_info->operation_count;
-  event->start_tick = event_info->start_tick;
-  event->end_tick = event_info->end_tick;
-  if (out_event_id) *out_event_id = event_id;
-  iree_slim_mutex_unlock(&recorder->mutex);
-  return iree_ok_status();
-}
-
-void iree_hal_local_profile_recorder_append_host_execution_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_host_execution_event_info_t* event_info,
-    uint64_t* out_event_id) {
-  IREE_ASSERT_ARGUMENT(event_info);
-  if (out_event_id) *out_event_id = 0;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS)) {
     return;
   }
   const bool is_valid =
-      iree_hal_local_profile_queue_scope_is_valid(&event_info->scope) &&
+      iree_hal_task_profile_queue_scope_is_valid(&event_info->scope) &&
       event_info->type != IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_NONE;
   IREE_ASSERT(is_valid);
   if (IREE_UNLIKELY(!is_valid)) return;
@@ -1188,7 +935,7 @@ void iree_hal_local_profile_recorder_append_host_execution_event(
   }
 
   iree_hal_profile_host_execution_event_t* event =
-      iree_hal_local_profile_host_execution_event_at(ring, event_position);
+      iree_hal_task_profile_host_execution_event_at(ring, event_position);
   *event = iree_hal_profile_host_execution_event_default();
   event->type = event_info->type;
   event->flags = event_info->flags;
@@ -1217,18 +964,18 @@ void iree_hal_local_profile_recorder_append_host_execution_event(
   iree_slim_mutex_unlock(&recorder->mutex);
 }
 
-void iree_hal_local_profile_recorder_append_command_region_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_command_region_event_info_t* event_info,
+void iree_hal_task_profile_recorder_append_command_region_event(
+    iree_hal_task_profile_recorder_t* recorder,
+    const iree_hal_task_profile_command_region_event_info_t* event_info,
     uint64_t* out_event_id) {
   IREE_ASSERT_ARGUMENT(event_info);
   if (out_event_id) *out_event_id = 0;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_COMMAND_REGION_EVENTS)) {
     return;
   }
   const bool is_valid =
-      iree_hal_local_profile_queue_scope_is_valid(&event_info->scope) &&
+      iree_hal_task_profile_queue_scope_is_valid(&event_info->scope) &&
       event_info->command_buffer_id != 0 &&
       event_info->command_region.index >= 0;
   IREE_ASSERT(is_valid);
@@ -1253,7 +1000,7 @@ void iree_hal_local_profile_recorder_append_command_region_event(
   }
 
   iree_hal_profile_command_region_event_t* event =
-      iree_hal_local_profile_command_region_event_at(ring, event_position);
+      iree_hal_task_profile_command_region_event_at(ring, event_position);
   *event = iree_hal_profile_command_region_event_default();
   event->flags = event_info->flags;
   event->event_id = event_id;
@@ -1320,7 +1067,7 @@ void iree_hal_local_profile_recorder_append_command_region_event(
   iree_slim_mutex_unlock(&recorder->mutex);
 }
 
-static bool iree_hal_local_profile_memory_event_is_valid(
+static bool iree_hal_task_profile_memory_event_is_valid(
     const iree_hal_profile_memory_event_t* event) {
   if (event->type == IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_NONE) return false;
   if (event->physical_device_ordinal == UINT32_MAX) return false;
@@ -1332,16 +1079,16 @@ static bool iree_hal_local_profile_memory_event_is_valid(
   return true;
 }
 
-void iree_hal_local_profile_recorder_append_memory_event(
-    iree_hal_local_profile_recorder_t* recorder,
+void iree_hal_task_profile_recorder_append_memory_event(
+    iree_hal_task_profile_recorder_t* recorder,
     const iree_hal_profile_memory_event_t* event, uint64_t* out_event_id) {
   IREE_ASSERT_ARGUMENT(event);
   if (out_event_id) *out_event_id = 0;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS)) {
     return;
   }
-  const bool is_valid = iree_hal_local_profile_memory_event_is_valid(event);
+  const bool is_valid = iree_hal_task_profile_memory_event_is_valid(event);
   IREE_ASSERT(is_valid);
   if (IREE_UNLIKELY(!is_valid)) return;
 
@@ -1356,7 +1103,7 @@ void iree_hal_local_profile_recorder_append_memory_event(
   }
 
   iree_hal_profile_memory_event_t* record =
-      iree_hal_local_profile_memory_event_at(ring, event_position);
+      iree_hal_task_profile_memory_event_at(ring, event_position);
   *record = *event;
   record->record_length = sizeof(*record);
   record->event_id = event_id;
@@ -1367,9 +1114,9 @@ void iree_hal_local_profile_recorder_append_memory_event(
   iree_slim_mutex_unlock(&recorder->mutex);
 }
 
-static iree_status_t iree_hal_local_profile_recorder_write_event_ring(
-    iree_hal_local_profile_recorder_t* recorder,
-    iree_string_view_t content_type, iree_hal_profile_event_ring_t* ring) {
+static iree_status_t iree_hal_task_profile_recorder_write_event_ring(
+    iree_hal_task_profile_recorder_t* recorder, iree_string_view_t content_type,
+    iree_hal_profile_event_ring_t* ring) {
   iree_hal_profile_event_ring_snapshot_t snapshot;
   iree_slim_mutex_lock(&recorder->mutex);
   iree_status_t status = iree_hal_profile_event_ring_snapshot(ring, &snapshot);
@@ -1381,7 +1128,7 @@ static iree_status_t iree_hal_local_profile_recorder_write_event_ring(
   }
 
   iree_hal_profile_chunk_metadata_t metadata =
-      iree_hal_local_profile_recorder_metadata(recorder, content_type);
+      iree_hal_task_profile_recorder_metadata(recorder, content_type);
   if (snapshot.dropped_record_count != 0) {
     metadata.flags |= IREE_HAL_PROFILE_CHUNK_FLAG_TRUNCATED;
     metadata.dropped_record_count = snapshot.dropped_record_count;
@@ -1396,261 +1143,24 @@ static iree_status_t iree_hal_local_profile_recorder_write_event_ring(
   return iree_ok_status();
 }
 
-static bool iree_hal_local_profile_dispatch_events_have_same_scope(
-    const iree_hal_local_profile_dispatch_event_record_t* lhs,
-    const iree_hal_local_profile_dispatch_event_record_t* rhs) {
-  return lhs->scope.stream_id == rhs->scope.stream_id &&
-         lhs->scope.physical_device_ordinal ==
-             rhs->scope.physical_device_ordinal &&
-         lhs->scope.queue_ordinal == rhs->scope.queue_ordinal;
-}
-
-static iree_hal_profile_chunk_metadata_t
-iree_hal_local_profile_recorder_dispatch_event_metadata(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_dispatch_event_record_t* record,
-    uint64_t dropped_record_count) {
-  iree_hal_profile_chunk_metadata_t metadata =
-      iree_hal_local_profile_recorder_metadata(
-          recorder, IREE_HAL_PROFILE_CONTENT_TYPE_DISPATCH_EVENTS);
-  if (record) {
-    metadata.stream_id = record->scope.stream_id;
-    metadata.physical_device_ordinal = record->scope.physical_device_ordinal;
-    metadata.queue_ordinal = record->scope.queue_ordinal;
-  }
-  if (dropped_record_count != 0) {
-    metadata.flags |= IREE_HAL_PROFILE_CHUNK_FLAG_TRUNCATED;
-    metadata.dropped_record_count = dropped_record_count;
-  }
-  return metadata;
-}
-
-static iree_status_t iree_hal_local_profile_recorder_write_dispatch_event_run(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_dispatch_event_record_t* records,
-    iree_host_size_t record_count, uint64_t dropped_record_count) {
-  if (record_count == 0 && dropped_record_count == 0) return iree_ok_status();
-  const iree_hal_local_profile_dispatch_event_record_t* first_record =
-      record_count != 0 ? records : NULL;
-  iree_hal_profile_chunk_metadata_t metadata =
-      iree_hal_local_profile_recorder_dispatch_event_metadata(
-          recorder, first_record, dropped_record_count);
-  if (record_count == 0) {
-    return iree_hal_profile_sink_write(recorder->options.sink, &metadata,
-                                       /*iovec_count=*/0, /*iovecs=*/NULL);
-  }
-
-  iree_hal_profile_dispatch_event_t* events = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_allocator_malloc_array(recorder->host_allocator, record_count,
-                                  sizeof(*events), (void**)&events));
-  for (iree_host_size_t i = 0; i < record_count; ++i) {
-    events[i] = records[i].event;
-  }
-  iree_const_byte_span_t iovec =
-      iree_make_const_byte_span(events, record_count * sizeof(*events));
-  iree_status_t status = iree_hal_profile_sink_write(
-      recorder->options.sink, &metadata, /*iovec_count=*/1, &iovec);
-  iree_allocator_free(recorder->host_allocator, events);
-  return status;
-}
-
-static iree_status_t iree_hal_local_profile_recorder_write_dispatch_event_span(
-    iree_hal_local_profile_recorder_t* recorder, iree_const_byte_span_t span,
-    uint64_t* remaining_dropped_record_count) {
-  IREE_ASSERT(span.data_length %
-                  sizeof(iree_hal_local_profile_dispatch_event_record_t) ==
-              0);
-  const iree_hal_local_profile_dispatch_event_record_t* records =
-      (const iree_hal_local_profile_dispatch_event_record_t*)span.data;
-  const iree_host_size_t record_count =
-      span.data_length / sizeof(iree_hal_local_profile_dispatch_event_record_t);
-  iree_host_size_t run_start = 0;
-  iree_status_t status = iree_ok_status();
-  while (iree_status_is_ok(status) && run_start < record_count) {
-    iree_host_size_t run_end = run_start + 1;
-    while (run_end < record_count &&
-           iree_hal_local_profile_dispatch_events_have_same_scope(
-               &records[run_start], &records[run_end])) {
-      ++run_end;
-    }
-    const uint64_t run_dropped_record_count = *remaining_dropped_record_count;
-    *remaining_dropped_record_count = 0;
-    status = iree_hal_local_profile_recorder_write_dispatch_event_run(
-        recorder, &records[run_start], run_end - run_start,
-        run_dropped_record_count);
-    run_start = run_end;
-  }
-  return status;
-}
-
-static iree_status_t iree_hal_local_profile_recorder_write_dispatch_event_ring(
-    iree_hal_local_profile_recorder_t* recorder,
-    iree_hal_profile_event_ring_t* ring) {
-  iree_hal_profile_event_ring_snapshot_t snapshot;
-  iree_slim_mutex_lock(&recorder->mutex);
-  iree_status_t status = iree_hal_profile_event_ring_snapshot(ring, &snapshot);
-  iree_slim_mutex_unlock(&recorder->mutex);
-  IREE_RETURN_IF_ERROR(status);
-
-  if (snapshot.record_count == 0 && snapshot.dropped_record_count == 0) {
-    return iree_ok_status();
-  }
-
-  uint64_t remaining_dropped_record_count = snapshot.dropped_record_count;
-  for (iree_host_size_t i = 0;
-       i < snapshot.record_span_count && iree_status_is_ok(status); ++i) {
-    status = iree_hal_local_profile_recorder_write_dispatch_event_span(
-        recorder, snapshot.record_spans[i], &remaining_dropped_record_count);
-  }
-  if (iree_status_is_ok(status) && remaining_dropped_record_count != 0) {
-    status = iree_hal_local_profile_recorder_write_dispatch_event_run(
-        recorder, /*records=*/NULL, /*record_count=*/0,
-        remaining_dropped_record_count);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_slim_mutex_lock(&recorder->mutex);
-    iree_hal_profile_event_ring_commit_snapshot(ring, &snapshot);
-    iree_slim_mutex_unlock(&recorder->mutex);
-  }
-  return status;
-}
-
-static bool iree_hal_local_profile_queue_device_events_have_same_scope(
-    const iree_hal_profile_queue_device_event_t* lhs,
-    const iree_hal_profile_queue_device_event_t* rhs) {
-  return lhs->stream_id == rhs->stream_id &&
-         lhs->physical_device_ordinal == rhs->physical_device_ordinal &&
-         lhs->queue_ordinal == rhs->queue_ordinal;
-}
-
-static iree_hal_profile_chunk_metadata_t
-iree_hal_local_profile_recorder_queue_device_event_metadata(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_profile_queue_device_event_t* event,
-    uint64_t dropped_record_count) {
-  iree_hal_profile_chunk_metadata_t metadata =
-      iree_hal_local_profile_recorder_metadata(
-          recorder, IREE_HAL_PROFILE_CONTENT_TYPE_QUEUE_DEVICE_EVENTS);
-  if (event) {
-    metadata.stream_id = event->stream_id;
-    metadata.physical_device_ordinal = event->physical_device_ordinal;
-    metadata.queue_ordinal = event->queue_ordinal;
-  }
-  if (dropped_record_count != 0) {
-    metadata.flags |= IREE_HAL_PROFILE_CHUNK_FLAG_TRUNCATED;
-    metadata.dropped_record_count = dropped_record_count;
-  }
-  return metadata;
-}
-
-static iree_status_t
-iree_hal_local_profile_recorder_write_queue_device_event_run(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_profile_queue_device_event_t* events,
-    iree_host_size_t event_count, uint64_t dropped_record_count) {
-  if (event_count == 0 && dropped_record_count == 0) return iree_ok_status();
-  const iree_hal_profile_queue_device_event_t* first_event =
-      event_count != 0 ? events : NULL;
-  iree_hal_profile_chunk_metadata_t metadata =
-      iree_hal_local_profile_recorder_queue_device_event_metadata(
-          recorder, first_event, dropped_record_count);
-  iree_const_byte_span_t iovec = iree_make_const_byte_span(
-      events, event_count * sizeof(iree_hal_profile_queue_device_event_t));
-  return iree_hal_profile_sink_write(recorder->options.sink, &metadata,
-                                     event_count != 0 ? 1 : 0,
-                                     event_count != 0 ? &iovec : NULL);
-}
-
-static iree_status_t
-iree_hal_local_profile_recorder_write_queue_device_event_span(
-    iree_hal_local_profile_recorder_t* recorder, iree_const_byte_span_t span,
-    uint64_t* remaining_dropped_record_count) {
-  IREE_ASSERT(
-      span.data_length % sizeof(iree_hal_profile_queue_device_event_t) == 0);
-  const iree_hal_profile_queue_device_event_t* events =
-      (const iree_hal_profile_queue_device_event_t*)span.data;
-  const iree_host_size_t event_count =
-      span.data_length / sizeof(iree_hal_profile_queue_device_event_t);
-  iree_host_size_t run_start = 0;
-  iree_status_t status = iree_ok_status();
-  while (iree_status_is_ok(status) && run_start < event_count) {
-    iree_host_size_t run_end = run_start + 1;
-    while (run_end < event_count &&
-           iree_hal_local_profile_queue_device_events_have_same_scope(
-               &events[run_start], &events[run_end])) {
-      ++run_end;
-    }
-    const uint64_t run_dropped_record_count = *remaining_dropped_record_count;
-    *remaining_dropped_record_count = 0;
-    status = iree_hal_local_profile_recorder_write_queue_device_event_run(
-        recorder, &events[run_start], run_end - run_start,
-        run_dropped_record_count);
-    run_start = run_end;
-  }
-  return status;
-}
-
-static iree_status_t
-iree_hal_local_profile_recorder_write_queue_device_event_ring(
-    iree_hal_local_profile_recorder_t* recorder,
-    iree_hal_profile_event_ring_t* ring) {
-  iree_hal_profile_event_ring_snapshot_t snapshot;
-  iree_slim_mutex_lock(&recorder->mutex);
-  iree_status_t status = iree_hal_profile_event_ring_snapshot(ring, &snapshot);
-  iree_slim_mutex_unlock(&recorder->mutex);
-  IREE_RETURN_IF_ERROR(status);
-
-  if (snapshot.record_count == 0 && snapshot.dropped_record_count == 0) {
-    return iree_ok_status();
-  }
-
-  uint64_t remaining_dropped_record_count = snapshot.dropped_record_count;
-  for (iree_host_size_t i = 0;
-       i < snapshot.record_span_count && iree_status_is_ok(status); ++i) {
-    status = iree_hal_local_profile_recorder_write_queue_device_event_span(
-        recorder, snapshot.record_spans[i], &remaining_dropped_record_count);
-  }
-  if (iree_status_is_ok(status) && remaining_dropped_record_count != 0) {
-    status = iree_hal_local_profile_recorder_write_queue_device_event_run(
-        recorder, /*events=*/NULL, /*event_count=*/0,
-        remaining_dropped_record_count);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_slim_mutex_lock(&recorder->mutex);
-    iree_hal_profile_event_ring_commit_snapshot(ring, &snapshot);
-    iree_slim_mutex_unlock(&recorder->mutex);
-  }
-  return status;
-}
-
-static iree_status_t iree_hal_local_profile_recorder_flush_records(
-    iree_hal_local_profile_recorder_t* recorder) {
+static iree_status_t iree_hal_task_profile_recorder_flush_records(
+    iree_hal_task_profile_recorder_t* recorder) {
   iree_slim_mutex_lock(&recorder->flush_mutex);
-  iree_status_t status =
-      iree_hal_local_profile_recorder_write_dispatch_event_ring(
-          recorder, &recorder->dispatch_event_ring);
+  iree_status_t status = iree_hal_task_profile_recorder_write_event_ring(
+      recorder, IREE_HAL_PROFILE_CONTENT_TYPE_QUEUE_EVENTS,
+      &recorder->queue_event_ring);
   if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_write_event_ring(
-        recorder, IREE_HAL_PROFILE_CONTENT_TYPE_QUEUE_EVENTS,
-        &recorder->queue_event_ring);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_write_queue_device_event_ring(
-        recorder, &recorder->queue_device_event_ring);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_write_event_ring(
+    status = iree_hal_task_profile_recorder_write_event_ring(
         recorder, IREE_HAL_PROFILE_CONTENT_TYPE_HOST_EXECUTION_EVENTS,
         &recorder->host_execution_event_ring);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_write_event_ring(
+    status = iree_hal_task_profile_recorder_write_event_ring(
         recorder, IREE_HAL_PROFILE_CONTENT_TYPE_COMMAND_REGION_EVENTS,
         &recorder->command_region_event_ring);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_write_event_ring(
+    status = iree_hal_task_profile_recorder_write_event_ring(
         recorder, IREE_HAL_PROFILE_CONTENT_TYPE_MEMORY_EVENTS,
         &recorder->memory_event_ring);
   }
@@ -1658,36 +1168,19 @@ static iree_status_t iree_hal_local_profile_recorder_flush_records(
   return status;
 }
 
-iree_status_t iree_hal_local_profile_recorder_write_clock_correlations(
-    iree_hal_local_profile_recorder_t* recorder, iree_host_size_t record_count,
-    const iree_hal_profile_clock_correlation_record_t* records) {
-  if (!recorder || !recorder->active || record_count == 0) {
-    return iree_ok_status();
-  }
-  if (IREE_UNLIKELY(!records)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "local profiling clock correlation records are required");
-  }
-  return iree_hal_local_profile_recorder_write_records(
-      recorder, IREE_HAL_PROFILE_CONTENT_TYPE_CLOCK_CORRELATIONS, records,
-      record_count, sizeof(*records));
+iree_status_t iree_hal_task_profile_recorder_flush(
+    iree_hal_task_profile_recorder_t* recorder) {
+  if (!recorder || !recorder->active) return iree_ok_status();
+  return iree_hal_task_profile_recorder_flush_records(recorder);
 }
 
-iree_status_t iree_hal_local_profile_recorder_flush(
-    iree_hal_local_profile_recorder_t* recorder) {
-  if (!recorder || !recorder->active) return iree_ok_status();
-  return iree_hal_local_profile_recorder_flush_records(recorder);
-}
-
-iree_status_t iree_hal_local_profile_recorder_end(
-    iree_hal_local_profile_recorder_t* recorder) {
+iree_status_t iree_hal_task_profile_recorder_end(
+    iree_hal_task_profile_recorder_t* recorder) {
   if (!recorder || !recorder->active) return iree_ok_status();
 
-  iree_status_t status =
-      iree_hal_local_profile_recorder_flush_records(recorder);
+  iree_status_t status = iree_hal_task_profile_recorder_flush_records(recorder);
   iree_hal_profile_chunk_metadata_t metadata =
-      iree_hal_local_profile_recorder_metadata(
+      iree_hal_task_profile_recorder_metadata(
           recorder, IREE_HAL_PROFILE_CONTENT_TYPE_SESSION);
   iree_status_code_t status_code = iree_status_code(status);
   status = iree_status_join(

--- a/runtime/src/iree/hal/drivers/local_task/profile.h
+++ b/runtime/src/iree/hal/drivers/local_task/profile.h
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef IREE_HAL_LOCAL_PROFILE_H_
-#define IREE_HAL_LOCAL_PROFILE_H_
+#ifndef IREE_HAL_TASK_PROFILE_H_
+#define IREE_HAL_TASK_PROFILE_H_
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -19,16 +19,15 @@ extern "C" {
 #endif  // __cplusplus
 
 //===----------------------------------------------------------------------===//
-// iree_hal_local_profile_recorder_t
+// iree_hal_task_profile_recorder_t
 //===----------------------------------------------------------------------===//
 
-typedef struct iree_hal_local_profile_recorder_t
-    iree_hal_local_profile_recorder_t;
+typedef struct iree_hal_task_profile_recorder_t
+    iree_hal_task_profile_recorder_t;
 
-// Returns the HAL-native profiling data families produced by local CPU
-// profiling recorders.
+// Returns the HAL-native profiling data families produced by task recorders.
 static inline iree_hal_device_profiling_data_families_t
-iree_hal_local_profile_recorder_supported_data_families(void) {
+iree_hal_task_profile_recorder_supported_data_families(void) {
   return IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
          IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS |
          IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA |
@@ -36,12 +35,12 @@ iree_hal_local_profile_recorder_supported_data_families(void) {
          IREE_HAL_DEVICE_PROFILING_DATA_COMMAND_REGION_EVENTS;
 }
 
-// Metadata needed to begin a local CPU profiling session.
+// Metadata needed to begin a task driver profiling session.
 //
 // The recorder writes the supplied device and queue records during creation and
 // does not retain the record arrays. |name| is copied into recorder-owned
 // storage because flush/end can happen after profiling_begin returns.
-typedef struct iree_hal_local_profile_recorder_options_t {
+typedef struct iree_hal_task_profile_recorder_options_t {
   // Human-readable producer name used on session and metadata chunks.
   iree_string_view_t name;
 
@@ -60,22 +59,8 @@ typedef struct iree_hal_local_profile_recorder_options_t {
   // Borrowed queue metadata records emitted at session begin.
   const iree_hal_profile_queue_record_t* queue_records;
 
-  // Additional data families that the embedding producer implements.
-  //
-  // The local recorder only produces host/local families itself. Non-local HALs
-  // may opt in to precise producer-owned families such as dispatch and device
-  // queue events and feed records through the explicit append APIs below.
-  iree_hal_device_profiling_data_families_t producer_data_families;
-
-  // Maximum dispatch events retained between flushes; 0 selects the default.
-  iree_host_size_t dispatch_event_capacity;
-
   // Maximum queue events retained between flushes; 0 selects the default.
   iree_host_size_t queue_event_capacity;
-
-  // Maximum queue device events retained between flushes; 0 selects the
-  // default.
-  iree_host_size_t queue_device_event_capacity;
 
   // Maximum host execution events retained between flushes; 0 selects the
   // default.
@@ -87,10 +72,10 @@ typedef struct iree_hal_local_profile_recorder_options_t {
   // Maximum command region events retained between flushes; 0 selects the
   // default.
   iree_host_size_t command_region_event_capacity;
-} iree_hal_local_profile_recorder_options_t;
+} iree_hal_task_profile_recorder_options_t;
 
-// Queue identity shared by local profiling records.
-typedef struct iree_hal_local_profile_queue_scope_t {
+// Queue identity shared by task profiling records.
+typedef struct iree_hal_task_profile_queue_scope_t {
   // Session-local physical device ordinal associated with the record.
   uint32_t physical_device_ordinal;
 
@@ -99,67 +84,20 @@ typedef struct iree_hal_local_profile_queue_scope_t {
 
   // Producer-defined stream identifier matching queue metadata.
   uint64_t stream_id;
-} iree_hal_local_profile_queue_scope_t;
+} iree_hal_task_profile_queue_scope_t;
 
 // Returns a queue scope with absent ordinals and no stream id.
-static inline iree_hal_local_profile_queue_scope_t
-iree_hal_local_profile_queue_scope_default(void) {
-  iree_hal_local_profile_queue_scope_t scope;
+static inline iree_hal_task_profile_queue_scope_t
+iree_hal_task_profile_queue_scope_default(void) {
+  iree_hal_task_profile_queue_scope_t scope;
   memset(&scope, 0, sizeof(scope));
   scope.physical_device_ordinal = UINT32_MAX;
   scope.queue_ordinal = UINT32_MAX;
   return scope;
 }
 
-// Device-timestamped dispatch data used to append one dispatch event.
-typedef struct iree_hal_local_profile_dispatch_event_info_t {
-  // Flags describing how the dispatch was produced.
-  iree_hal_profile_dispatch_event_flags_t flags;
-
-  // Queue metadata identity associated with the dispatch event chunk.
-  iree_hal_local_profile_queue_scope_t scope;
-
-  // Queue submission epoch containing this dispatch.
-  uint64_t submission_id;
-
-  // Session-local command-buffer identifier, or 0 for direct dispatch.
-  uint64_t command_buffer_id;
-
-  // Session-local executable identifier.
-  uint64_t executable_id;
-
-  // Command ordinal within a command buffer, or UINT32_MAX for direct dispatch.
-  uint32_t command_index;
-
-  // Executable function ordinal dispatched.
-  uint32_t function_ordinal;
-
-  // Workgroup counts submitted for each dimension.
-  uint32_t workgroup_count[3];
-
-  // Workgroup sizes submitted for each dimension.
-  uint32_t workgroup_size[3];
-
-  // Device timestamp captured when dispatch execution started.
-  uint64_t start_tick;
-
-  // Device timestamp captured when dispatch execution completed.
-  uint64_t end_tick;
-} iree_hal_local_profile_dispatch_event_info_t;
-
-// Returns default dispatch event append data.
-static inline iree_hal_local_profile_dispatch_event_info_t
-iree_hal_local_profile_dispatch_event_info_default(void) {
-  iree_hal_local_profile_dispatch_event_info_t info;
-  memset(&info, 0, sizeof(info));
-  info.scope = iree_hal_local_profile_queue_scope_default();
-  info.command_index = UINT32_MAX;
-  info.function_ordinal = UINT32_MAX;
-  return info;
-}
-
 // Queue operation data used to append one queue event record.
-typedef struct iree_hal_local_profile_queue_event_info_t {
+typedef struct iree_hal_task_profile_queue_event_info_t {
   // Kind of queue operation represented by the event.
   iree_hal_profile_queue_event_type_t type;
 
@@ -170,7 +108,7 @@ typedef struct iree_hal_local_profile_queue_event_info_t {
   iree_hal_profile_queue_dependency_strategy_t dependency_strategy;
 
   // Queue metadata identity shared by the appended record.
-  iree_hal_local_profile_queue_scope_t scope;
+  iree_hal_task_profile_queue_scope_t scope;
 
   // IREE monotonic host timestamp when submitted, or 0 to sample now.
   iree_time_t host_time_ns;
@@ -201,61 +139,19 @@ typedef struct iree_hal_local_profile_queue_event_info_t {
 
   // Type-specific payload byte length, or 0 when not applicable.
   uint64_t payload_length;
-} iree_hal_local_profile_queue_event_info_t;
+} iree_hal_task_profile_queue_event_info_t;
 
 // Returns default queue event append data.
-static inline iree_hal_local_profile_queue_event_info_t
-iree_hal_local_profile_queue_event_info_default(void) {
-  iree_hal_local_profile_queue_event_info_t info;
+static inline iree_hal_task_profile_queue_event_info_t
+iree_hal_task_profile_queue_event_info_default(void) {
+  iree_hal_task_profile_queue_event_info_t info;
   memset(&info, 0, sizeof(info));
-  info.scope = iree_hal_local_profile_queue_scope_default();
-  return info;
-}
-
-// Queue operation data used to append one device-timestamped queue event.
-typedef struct iree_hal_local_profile_queue_device_event_info_t {
-  // Kind of queue operation represented by the event.
-  iree_hal_profile_queue_event_type_t type;
-
-  // Flags describing queue operation properties.
-  iree_hal_profile_queue_event_flags_t flags;
-
-  // Queue metadata identity shared by the appended record.
-  iree_hal_local_profile_queue_scope_t scope;
-
-  // Queue submission epoch associated with this operation, or 0 when absent.
-  uint64_t submission_id;
-
-  // Session-local command-buffer identifier, or 0 when not applicable.
-  uint64_t command_buffer_id;
-
-  // Producer-defined allocation identifier, or 0 when not applicable.
-  uint64_t allocation_id;
-
-  // Number of encoded payload operations represented by this queue operation.
-  uint32_t operation_count;
-
-  // Type-specific payload byte length, or 0 when not applicable.
-  uint64_t payload_length;
-
-  // Device timestamp captured when queue-visible work started.
-  uint64_t start_tick;
-
-  // Device timestamp captured when queue-visible work completed.
-  uint64_t end_tick;
-} iree_hal_local_profile_queue_device_event_info_t;
-
-// Returns default queue device event append data.
-static inline iree_hal_local_profile_queue_device_event_info_t
-iree_hal_local_profile_queue_device_event_info_default(void) {
-  iree_hal_local_profile_queue_device_event_info_t info;
-  memset(&info, 0, sizeof(info));
-  info.scope = iree_hal_local_profile_queue_scope_default();
+  info.scope = iree_hal_task_profile_queue_scope_default();
   return info;
 }
 
 // Host execution span data used to append one host execution event record.
-typedef struct iree_hal_local_profile_host_execution_event_info_t {
+typedef struct iree_hal_task_profile_host_execution_event_info_t {
   // Kind of queue operation represented by this span.
   iree_hal_profile_queue_event_type_t type;
 
@@ -266,7 +162,7 @@ typedef struct iree_hal_local_profile_host_execution_event_info_t {
   uint32_t status_code;
 
   // Queue metadata identity shared by the appended record.
-  iree_hal_local_profile_queue_scope_t scope;
+  iree_hal_task_profile_queue_scope_t scope;
 
   // Queue submission epoch containing this span, or 0 when absent.
   uint64_t submission_id;
@@ -310,27 +206,27 @@ typedef struct iree_hal_local_profile_host_execution_event_info_t {
 
   // Number of encoded payload operations represented by this span.
   uint32_t operation_count;
-} iree_hal_local_profile_host_execution_event_info_t;
+} iree_hal_task_profile_host_execution_event_info_t;
 
 // Returns default host execution event append data.
-static inline iree_hal_local_profile_host_execution_event_info_t
-iree_hal_local_profile_host_execution_event_info_default(void) {
-  iree_hal_local_profile_host_execution_event_info_t info;
+static inline iree_hal_task_profile_host_execution_event_info_t
+iree_hal_task_profile_host_execution_event_info_default(void) {
+  iree_hal_task_profile_host_execution_event_info_t info;
   memset(&info, 0, sizeof(info));
   info.status_code = UINT32_MAX;
-  info.scope = iree_hal_local_profile_queue_scope_default();
+  info.scope = iree_hal_task_profile_queue_scope_default();
   info.command_index = UINT32_MAX;
   info.function_ordinal = UINT32_MAX;
   return info;
 }
 
 // Command-buffer region data used to append one command region event record.
-typedef struct iree_hal_local_profile_command_region_event_info_t {
+typedef struct iree_hal_task_profile_command_region_event_info_t {
   // Flags describing command region transition properties.
   iree_hal_profile_command_region_event_flags_t flags;
 
   // Queue metadata identity shared by the appended record.
-  iree_hal_local_profile_queue_scope_t scope;
+  iree_hal_task_profile_queue_scope_t scope;
 
   // Queue submission epoch containing this region, or 0 when absent.
   uint64_t submission_id;
@@ -428,57 +324,42 @@ typedef struct iree_hal_local_profile_command_region_event_info_t {
     // No-work drains that waited warm on the process retention epoch.
     uint32_t keep_warm_count;
   } retention;
-} iree_hal_local_profile_command_region_event_info_t;
+} iree_hal_task_profile_command_region_event_info_t;
 
 // Returns default command region event append data.
-static inline iree_hal_local_profile_command_region_event_info_t
-iree_hal_local_profile_command_region_event_info_default(void) {
-  iree_hal_local_profile_command_region_event_info_t info;
+static inline iree_hal_task_profile_command_region_event_info_t
+iree_hal_task_profile_command_region_event_info_default(void) {
+  iree_hal_task_profile_command_region_event_info_t info;
   memset(&info, 0, sizeof(info));
-  info.scope = iree_hal_local_profile_queue_scope_default();
+  info.scope = iree_hal_task_profile_queue_scope_default();
   info.command_region.index = -1;
   info.next_command_region.index = -1;
   return info;
 }
 
-// Begins a local CPU profiling session and returns its recorder.
+// Begins a task profiling session and returns its recorder.
 //
 // Returns OK with |out_recorder| set to NULL when
 // |profiling_options->data_families| is NONE. Otherwise the requested families
-// must be a subset of iree_hal_local_profile_recorder_supported_data_families()
+// must be a subset of iree_hal_task_profile_recorder_supported_data_families()
 // and |profiling_options->sink| must be non-NULL.
-iree_status_t iree_hal_local_profile_recorder_create(
-    const iree_hal_local_profile_recorder_options_t* recorder_options,
+iree_status_t iree_hal_task_profile_recorder_create(
+    const iree_hal_task_profile_recorder_options_t* recorder_options,
     const iree_hal_device_profiling_options_t* profiling_options,
     iree_allocator_t host_allocator,
-    iree_hal_local_profile_recorder_t** out_recorder);
+    iree_hal_task_profile_recorder_t** out_recorder);
 
 // Destroys |recorder| and releases retained session resources.
 //
-// Callers should end active sessions with iree_hal_local_profile_recorder_end
+// Callers should end active sessions with iree_hal_task_profile_recorder_end
 // before destroying the recorder so sink end-session failures can be observed.
-void iree_hal_local_profile_recorder_destroy(
-    iree_hal_local_profile_recorder_t* recorder);
+void iree_hal_task_profile_recorder_destroy(
+    iree_hal_task_profile_recorder_t* recorder);
 
 // Returns true when |recorder| is active and any of |data_families| is enabled.
-bool iree_hal_local_profile_recorder_is_enabled(
-    const iree_hal_local_profile_recorder_t* recorder,
+bool iree_hal_task_profile_recorder_is_enabled(
+    const iree_hal_task_profile_recorder_t* recorder,
     iree_hal_device_profiling_data_families_t data_families);
-
-// Returns the resolved profiling options held by |recorder|, or NULL.
-const iree_hal_device_profiling_options_t*
-iree_hal_local_profile_recorder_options(
-    const iree_hal_local_profile_recorder_t* recorder);
-
-// Emits executable function metadata for |executable_id| once per recorder
-// session.
-//
-// |executable_id| must be a producer-defined nonzero identifier that remains
-// stable for the lifetime of |executable|. This helper is for non-local HAL
-// executables that cannot use iree_hal_local_executable_t as their base type.
-iree_status_t iree_hal_local_profile_recorder_record_executable_with_id(
-    iree_hal_local_profile_recorder_t* recorder,
-    iree_hal_executable_t* executable, uint64_t executable_id);
 
 // Emits local executable function metadata once per recorder session.
 //
@@ -486,53 +367,28 @@ iree_status_t iree_hal_local_profile_recorder_record_executable_with_id(
 // cold-path helper for queue submission/replay sites that produce events with
 // executable ids and need offline tools to resolve those ids into function
 // names.
-iree_status_t iree_hal_local_profile_recorder_record_executable(
-    iree_hal_local_profile_recorder_t* recorder,
+iree_status_t iree_hal_task_profile_recorder_record_executable(
+    iree_hal_task_profile_recorder_t* recorder,
     iree_hal_executable_t* executable);
 
 // Emits command-buffer and operation metadata once per recorder session.
 //
 // Returns OK without work when metadata is not enabled. The caller owns
 // |command_buffer| and |operations|; the recorder does not retain them.
-iree_status_t iree_hal_local_profile_recorder_record_command_buffer(
-    iree_hal_local_profile_recorder_t* recorder,
+iree_status_t iree_hal_task_profile_recorder_record_command_buffer(
+    iree_hal_task_profile_recorder_t* recorder,
     const iree_hal_profile_command_buffer_record_t* command_buffer,
     iree_host_size_t operation_count,
     const iree_hal_profile_command_operation_record_t* operations);
-
-// Appends one producer-owned dispatch event to |recorder|.
-//
-// |out_event_id| may be NULL. When provided it receives the assigned event id,
-// or 0 if dispatch events were not requested. Dispatch events are lossless
-// profiling records. A full ring is flushed synchronously before appending; if
-// that flush fails, the pending records are preserved and the failure is
-// returned to the producer instead of silently truncating device timelines.
-iree_status_t iree_hal_local_profile_recorder_append_dispatch_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_dispatch_event_info_t* event_info,
-    uint64_t* out_event_id);
 
 // Appends one host-timestamped queue event to |recorder|.
 //
 // |out_event_id| may be NULL. When provided it receives the assigned event id,
 // or 0 if queue events were not requested or the event ring was full. Ring
 // capacity pressure is reported later as truncated chunks during flush.
-void iree_hal_local_profile_recorder_append_queue_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_queue_event_info_t* event_info,
-    uint64_t* out_event_id);
-
-// Appends one device-timestamped queue event to |recorder|.
-//
-// |out_event_id| may be NULL. When provided it receives the assigned event id,
-// or 0 if queue device events were not requested. Unlike host queue events,
-// queue device events are lossless profiling records. A full ring is flushed
-// synchronously before appending; if that flush fails, the pending records are
-// preserved and the failure is returned to the producer instead of silently
-// truncating device timelines.
-iree_status_t iree_hal_local_profile_recorder_append_queue_device_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_queue_device_event_info_t* event_info,
+void iree_hal_task_profile_recorder_append_queue_event(
+    iree_hal_task_profile_recorder_t* recorder,
+    const iree_hal_task_profile_queue_event_info_t* event_info,
     uint64_t* out_event_id);
 
 // Appends one host execution span to |recorder|.
@@ -540,9 +396,9 @@ iree_status_t iree_hal_local_profile_recorder_append_queue_device_event(
 // |out_event_id| may be NULL. When provided it receives the assigned event id,
 // or 0 if host execution events were not requested or the event ring was full.
 // Ring capacity pressure is reported later as truncated chunks during flush.
-void iree_hal_local_profile_recorder_append_host_execution_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_host_execution_event_info_t* event_info,
+void iree_hal_task_profile_recorder_append_host_execution_event(
+    iree_hal_task_profile_recorder_t* recorder,
+    const iree_hal_task_profile_host_execution_event_info_t* event_info,
     uint64_t* out_event_id);
 
 // Appends one host-timestamped command-buffer region event to |recorder|.
@@ -550,9 +406,9 @@ void iree_hal_local_profile_recorder_append_host_execution_event(
 // |out_event_id| may be NULL. When provided it receives the assigned event id,
 // or 0 if command region events were not requested or the event ring was full.
 // Ring capacity pressure is reported later as truncated chunks during flush.
-void iree_hal_local_profile_recorder_append_command_region_event(
-    iree_hal_local_profile_recorder_t* recorder,
-    const iree_hal_local_profile_command_region_event_info_t* event_info,
+void iree_hal_task_profile_recorder_append_command_region_event(
+    iree_hal_task_profile_recorder_t* recorder,
+    const iree_hal_task_profile_command_region_event_info_t* event_info,
     uint64_t* out_event_id);
 
 // Appends one host-timestamped memory lifecycle event to |recorder|.
@@ -563,33 +419,24 @@ void iree_hal_local_profile_recorder_append_command_region_event(
 // may be NULL. When provided it receives the assigned event id, or 0 if memory
 // events were not requested or the event ring was full. Ring capacity pressure
 // is reported later as truncated chunks during flush.
-void iree_hal_local_profile_recorder_append_memory_event(
-    iree_hal_local_profile_recorder_t* recorder,
+void iree_hal_task_profile_recorder_append_memory_event(
+    iree_hal_task_profile_recorder_t* recorder,
     const iree_hal_profile_memory_event_t* event, uint64_t* out_event_id);
 
-// Writes clock-correlation records to the active session sink.
-//
-// The caller must provide real producer-obtained clock samples. This helper is
-// intentionally not buffered: correlations are cold-path session calibration
-// records, and failures must be reported directly to the profiling operation.
-iree_status_t iree_hal_local_profile_recorder_write_clock_correlations(
-    iree_hal_local_profile_recorder_t* recorder, iree_host_size_t record_count,
-    const iree_hal_profile_clock_correlation_record_t* records);
-
 // Writes all buffered profile records to the session sink.
-iree_status_t iree_hal_local_profile_recorder_flush(
-    iree_hal_local_profile_recorder_t* recorder);
+iree_status_t iree_hal_task_profile_recorder_flush(
+    iree_hal_task_profile_recorder_t* recorder);
 
 // Flushes and ends the profiling session.
 //
 // The sink receives the terminal status code derived from the first failing
 // flush or end-session operation. A second call after a successful end is a
 // no-op.
-iree_status_t iree_hal_local_profile_recorder_end(
-    iree_hal_local_profile_recorder_t* recorder);
+iree_status_t iree_hal_task_profile_recorder_end(
+    iree_hal_task_profile_recorder_t* recorder);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // IREE_HAL_LOCAL_PROFILE_H_
+#endif  // IREE_HAL_TASK_PROFILE_H_

--- a/runtime/src/iree/hal/drivers/local_task/profile_test.cc
+++ b/runtime/src/iree/hal/drivers/local_task/profile_test.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/hal/local/profile.h"
+#include "iree/hal/drivers/local_task/profile.h"
 
 #include <cstdint>
 #include <string>
@@ -15,7 +15,7 @@
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
 
-namespace iree::hal::local {
+namespace iree::hal::local_task {
 namespace {
 
 struct RecordingProfileSink {
@@ -71,15 +71,6 @@ struct RecordingProfileSink {
   // Queue event records copied from data chunks.
   std::vector<iree_hal_profile_queue_event_t> queue_events;
 
-  // Dispatch event records copied from data chunks.
-  std::vector<iree_hal_profile_dispatch_event_t> dispatch_events;
-
-  // Queue device event records copied from data chunks.
-  std::vector<iree_hal_profile_queue_device_event_t> queue_device_events;
-
-  // Clock correlation records copied from data chunks.
-  std::vector<iree_hal_profile_clock_correlation_record_t> clock_correlations;
-
   // Host execution event records copied from data chunks.
   std::vector<iree_hal_profile_host_execution_event_t> host_execution_events;
 
@@ -88,12 +79,6 @@ struct RecordingProfileSink {
 
   // Dropped queue event records reported by truncated chunks.
   uint64_t dropped_queue_event_count = 0;
-
-  // Dropped dispatch event records reported by truncated chunks.
-  uint64_t dropped_dispatch_event_count = 0;
-
-  // Dropped queue device event records reported by truncated chunks.
-  uint64_t dropped_queue_device_event_count = 0;
 
   // Dropped host execution event records reported by truncated chunks.
   uint64_t dropped_host_execution_event_count = 0;
@@ -244,37 +229,6 @@ static iree_status_t RecordingProfileSinkWrite(
     for (iree_host_size_t i = 0; i < iovec_count; ++i) {
       IREE_RETURN_IF_ERROR(
           CopyProfileRecords(iovecs[i], &test_sink->queue_events));
-    }
-    return iree_ok_status();
-  }
-  if (iree_string_view_equal(metadata->content_type,
-                             IREE_HAL_PROFILE_CONTENT_TYPE_DISPATCH_EVENTS)) {
-    test_sink->dropped_dispatch_event_count += metadata->dropped_record_count;
-    EXPECT_NE(UINT32_MAX, metadata->physical_device_ordinal);
-    EXPECT_NE(UINT32_MAX, metadata->queue_ordinal);
-    for (iree_host_size_t i = 0; i < iovec_count; ++i) {
-      IREE_RETURN_IF_ERROR(
-          CopyProfileRecords(iovecs[i], &test_sink->dispatch_events));
-    }
-    return iree_ok_status();
-  }
-  if (iree_string_view_equal(
-          metadata->content_type,
-          IREE_HAL_PROFILE_CONTENT_TYPE_QUEUE_DEVICE_EVENTS)) {
-    test_sink->dropped_queue_device_event_count +=
-        metadata->dropped_record_count;
-    for (iree_host_size_t i = 0; i < iovec_count; ++i) {
-      IREE_RETURN_IF_ERROR(
-          CopyProfileRecords(iovecs[i], &test_sink->queue_device_events));
-    }
-    return iree_ok_status();
-  }
-  if (iree_string_view_equal(
-          metadata->content_type,
-          IREE_HAL_PROFILE_CONTENT_TYPE_CLOCK_CORRELATIONS)) {
-    for (iree_host_size_t i = 0; i < iovec_count; ++i) {
-      IREE_RETURN_IF_ERROR(
-          CopyProfileRecords(iovecs[i], &test_sink->clock_correlations));
     }
     return iree_ok_status();
   }
@@ -443,29 +397,27 @@ static const iree_hal_local_executable_vtable_t kFakeLocalExecutableVTable = {
     FakeLocalExecutableIssueCall,
 };
 
-class LocalProfileRecorderTest : public ::testing::Test {
+class TaskProfileRecorderTest : public ::testing::Test {
  protected:
   void SetUp() override {
     RecordingProfileSinkInitialize(&sink_);
     device_record_ = MakeDeviceRecord(1);
     queue_record_ = MakeQueueRecord(0);
-    recorder_options_.name = IREE_SV("local-test");
+    recorder_options_.name = IREE_SV("local-task-test");
     recorder_options_.session_id = 42;
     recorder_options_.device_record_count = 1;
     recorder_options_.device_records = &device_record_;
     recorder_options_.queue_record_count = 1;
     recorder_options_.queue_records = &queue_record_;
-    recorder_options_.dispatch_event_capacity = 4;
     recorder_options_.queue_event_capacity = 4;
-    recorder_options_.queue_device_event_capacity = 4;
     recorder_options_.host_execution_event_capacity = 4;
     recorder_options_.memory_event_capacity = 4;
   }
 
   void TearDown() override {
     if (recorder_) {
-      IREE_EXPECT_OK(iree_hal_local_profile_recorder_end(recorder_));
-      iree_hal_local_profile_recorder_destroy(recorder_);
+      IREE_EXPECT_OK(iree_hal_task_profile_recorder_end(recorder_));
+      iree_hal_task_profile_recorder_destroy(recorder_);
     }
   }
 
@@ -481,13 +433,13 @@ class LocalProfileRecorderTest : public ::testing::Test {
       iree_hal_device_profiling_data_families_t data_families) {
     iree_hal_device_profiling_options_t options =
         MakeProfilingOptions(data_families);
-    return iree_hal_local_profile_recorder_create(
+    return iree_hal_task_profile_recorder_create(
         &recorder_options_, &options, iree_allocator_system(), &recorder_);
   }
 
-  iree_hal_local_profile_queue_scope_t QueueScope() {
-    iree_hal_local_profile_queue_scope_t scope =
-        iree_hal_local_profile_queue_scope_default();
+  iree_hal_task_profile_queue_scope_t QueueScope() {
+    iree_hal_task_profile_queue_scope_t scope =
+        iree_hal_task_profile_queue_scope_default();
     scope.physical_device_ordinal = queue_record_.physical_device_ordinal;
     scope.queue_ordinal = queue_record_.queue_ordinal;
     scope.stream_id = queue_record_.stream_id;
@@ -497,17 +449,17 @@ class LocalProfileRecorderTest : public ::testing::Test {
   RecordingProfileSink sink_;
   iree_hal_profile_device_record_t device_record_;
   iree_hal_profile_queue_record_t queue_record_;
-  iree_hal_local_profile_recorder_options_t recorder_options_ = {};
-  iree_hal_local_profile_recorder_t* recorder_ = nullptr;
+  iree_hal_task_profile_recorder_options_t recorder_options_ = {};
+  iree_hal_task_profile_recorder_t* recorder_ = nullptr;
 };
 
-TEST_F(LocalProfileRecorderTest, NoneCreatesNoRecorder) {
+TEST_F(TaskProfileRecorderTest, NoneCreatesNoRecorder) {
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_NONE));
   EXPECT_EQ(nullptr, recorder_);
   EXPECT_EQ(0, sink_.begin_count);
 }
 
-TEST_F(LocalProfileRecorderTest, BeginWritesMetadata) {
+TEST_F(TaskProfileRecorderTest, BeginWritesMetadata) {
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS));
   EXPECT_NE(nullptr, recorder_);
   EXPECT_EQ(1, sink_.begin_count);
@@ -518,240 +470,20 @@ TEST_F(LocalProfileRecorderTest, BeginWritesMetadata) {
   EXPECT_EQ(0u, sink_.queue_records[0].queue_ordinal);
 }
 
-TEST_F(LocalProfileRecorderTest, RejectsUnsupportedDataFamily) {
+TEST_F(TaskProfileRecorderTest, RejectsUnsupportedDataFamily) {
   IREE_EXPECT_STATUS_IS(
       IREE_STATUS_UNIMPLEMENTED,
       Create(IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS));
 }
 
-TEST_F(LocalProfileRecorderTest, RejectsAdvertisedZeroTimestampFrequency) {
+TEST_F(TaskProfileRecorderTest, RejectsAdvertisedZeroTimestampFrequency) {
   device_record_.flags |= IREE_HAL_PROFILE_DEVICE_FLAG_TIMESTAMP_FREQUENCY;
   device_record_.timestamp_frequency_hz = 0;
   IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
                         Create(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS));
 }
 
-TEST_F(LocalProfileRecorderTest, ProducerFamilyAppendsDispatchEvents) {
-  recorder_options_.producer_data_families =
-      IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS;
-  IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS));
-
-  iree_hal_local_profile_dispatch_event_info_t event_info =
-      iree_hal_local_profile_dispatch_event_info_default();
-  event_info.flags = IREE_HAL_PROFILE_DISPATCH_EVENT_FLAG_INDIRECT_PARAMETERS;
-  event_info.scope = QueueScope();
-  event_info.submission_id = 7;
-  event_info.command_buffer_id = 8;
-  event_info.executable_id = 9;
-  event_info.command_index = 10;
-  event_info.function_ordinal = 11;
-  event_info.workgroup_size[0] = 4;
-  event_info.workgroup_size[1] = 5;
-  event_info.workgroup_size[2] = 6;
-  event_info.start_tick = 1000;
-  event_info.end_tick = 1200;
-  uint64_t event_id = 0;
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_append_dispatch_event(
-      recorder_, &event_info, &event_id));
-  EXPECT_NE(0u, event_id);
-
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
-  ASSERT_EQ(1u, sink_.dispatch_events.size());
-  const iree_hal_profile_dispatch_event_t& recorded_event =
-      sink_.dispatch_events[0];
-  EXPECT_EQ(event_id, recorded_event.event_id);
-  EXPECT_EQ(IREE_HAL_PROFILE_DISPATCH_EVENT_FLAG_INDIRECT_PARAMETERS,
-            recorded_event.flags);
-  EXPECT_EQ(7u, recorded_event.submission_id);
-  EXPECT_EQ(8u, recorded_event.command_buffer_id);
-  EXPECT_EQ(9u, recorded_event.executable_id);
-  EXPECT_EQ(10u, recorded_event.command_index);
-  EXPECT_EQ(11u, recorded_event.function_ordinal);
-  EXPECT_EQ(4u, recorded_event.workgroup_size[0]);
-  EXPECT_EQ(5u, recorded_event.workgroup_size[1]);
-  EXPECT_EQ(6u, recorded_event.workgroup_size[2]);
-  EXPECT_EQ(1000u, recorded_event.start_tick);
-  EXPECT_EQ(1200u, recorded_event.end_tick);
-}
-
-TEST_F(LocalProfileRecorderTest, FullDispatchRingAutoFlushes) {
-  recorder_options_.producer_data_families =
-      IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS;
-  recorder_options_.dispatch_event_capacity = 1;
-  IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS));
-
-  iree_hal_local_profile_dispatch_event_info_t event_info =
-      iree_hal_local_profile_dispatch_event_info_default();
-  event_info.scope = QueueScope();
-  event_info.submission_id = 7;
-  event_info.command_buffer_id = 8;
-  event_info.executable_id = 9;
-  event_info.command_index = 10;
-  event_info.function_ordinal = 11;
-  event_info.workgroup_size[0] = 4;
-  event_info.start_tick = 1000;
-  event_info.end_tick = 1200;
-  uint64_t first_event_id = 0;
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_append_dispatch_event(
-      recorder_, &event_info, &first_event_id));
-  EXPECT_NE(0u, first_event_id);
-
-  event_info.submission_id = 12;
-  event_info.start_tick = 1300;
-  event_info.end_tick = 1500;
-  uint64_t second_event_id = 0;
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_append_dispatch_event(
-      recorder_, &event_info, &second_event_id));
-  EXPECT_NE(0u, second_event_id);
-  EXPECT_NE(first_event_id, second_event_id);
-
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
-  ASSERT_EQ(2u, sink_.dispatch_events.size());
-  EXPECT_EQ(first_event_id, sink_.dispatch_events[0].event_id);
-  EXPECT_EQ(7u, sink_.dispatch_events[0].submission_id);
-  EXPECT_EQ(second_event_id, sink_.dispatch_events[1].event_id);
-  EXPECT_EQ(12u, sink_.dispatch_events[1].submission_id);
-  EXPECT_EQ(0u, sink_.dropped_dispatch_event_count);
-}
-
-TEST_F(LocalProfileRecorderTest, DispatchAutoFlushFailurePreservesRecords) {
-  recorder_options_.producer_data_families =
-      IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS;
-  recorder_options_.dispatch_event_capacity = 1;
-  IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS));
-
-  iree_hal_local_profile_dispatch_event_info_t event_info =
-      iree_hal_local_profile_dispatch_event_info_default();
-  event_info.scope = QueueScope();
-  event_info.submission_id = 7;
-  event_info.command_buffer_id = 8;
-  event_info.executable_id = 9;
-  event_info.command_index = 10;
-  event_info.function_ordinal = 11;
-  event_info.workgroup_size[0] = 4;
-  event_info.start_tick = 1000;
-  event_info.end_tick = 1200;
-  uint64_t first_event_id = 0;
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_append_dispatch_event(
-      recorder_, &event_info, &first_event_id));
-
-  sink_.fail_write_content_type = IREE_HAL_PROFILE_CONTENT_TYPE_DISPATCH_EVENTS;
-  sink_.fail_write_remaining = 1;
-  sink_.fail_write_status_code = IREE_STATUS_UNAVAILABLE;
-  event_info.submission_id = 12;
-  event_info.start_tick = 1300;
-  event_info.end_tick = 1500;
-  uint64_t second_event_id = 0;
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_UNAVAILABLE,
-                        iree_hal_local_profile_recorder_append_dispatch_event(
-                            recorder_, &event_info, &second_event_id));
-  EXPECT_EQ(0u, second_event_id);
-  EXPECT_TRUE(sink_.dispatch_events.empty());
-  EXPECT_EQ(0u, sink_.dropped_dispatch_event_count);
-
-  sink_.fail_write_content_type = iree_string_view_empty();
-  sink_.fail_write_remaining = 0;
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_append_dispatch_event(
-      recorder_, &event_info, &second_event_id));
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
-  ASSERT_EQ(2u, sink_.dispatch_events.size());
-  EXPECT_EQ(first_event_id, sink_.dispatch_events[0].event_id);
-  EXPECT_EQ(second_event_id, sink_.dispatch_events[1].event_id);
-  EXPECT_EQ(0u, sink_.dropped_dispatch_event_count);
-}
-
-TEST_F(LocalProfileRecorderTest, ProducerFamilyAppendsQueueDeviceEvents) {
-  recorder_options_.producer_data_families =
-      IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS;
-  IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS));
-
-  iree_hal_local_profile_queue_device_event_info_t event_info =
-      iree_hal_local_profile_queue_device_event_info_default();
-  event_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_DISPATCH;
-  event_info.flags = IREE_HAL_PROFILE_QUEUE_EVENT_FLAG_SOFTWARE_DEFERRED;
-  event_info.scope = QueueScope();
-  event_info.submission_id = 7;
-  event_info.command_buffer_id = 8;
-  event_info.allocation_id = 9;
-  event_info.operation_count = 1;
-  event_info.payload_length = 64;
-  event_info.start_tick = 1000;
-  event_info.end_tick = 1200;
-  uint64_t event_id = 0;
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_append_queue_device_event(
-      recorder_, &event_info, &event_id));
-  EXPECT_NE(0u, event_id);
-
-  iree_hal_profile_clock_correlation_record_t correlation =
-      iree_hal_profile_clock_correlation_record_default();
-  correlation.flags =
-      IREE_HAL_PROFILE_CLOCK_CORRELATION_FLAG_DEVICE_TICK |
-      IREE_HAL_PROFILE_CLOCK_CORRELATION_FLAG_HOST_CPU_TIMESTAMP;
-  correlation.physical_device_ordinal = QueueScope().physical_device_ordinal;
-  correlation.sample_id = 1;
-  correlation.device_tick = 1000;
-  correlation.host_cpu_timestamp_ns = 5000;
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_write_clock_correlations(
-      recorder_, 1, &correlation));
-
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
-  ASSERT_EQ(1u, sink_.queue_device_events.size());
-  const iree_hal_profile_queue_device_event_t& recorded_event =
-      sink_.queue_device_events[0];
-  EXPECT_EQ(event_id, recorded_event.event_id);
-  EXPECT_EQ(IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_DISPATCH, recorded_event.type);
-  EXPECT_EQ(IREE_HAL_PROFILE_QUEUE_EVENT_FLAG_SOFTWARE_DEFERRED,
-            recorded_event.flags);
-  EXPECT_EQ(7u, recorded_event.submission_id);
-  EXPECT_EQ(8u, recorded_event.command_buffer_id);
-  EXPECT_EQ(9u, recorded_event.allocation_id);
-  EXPECT_EQ(1u, recorded_event.operation_count);
-  EXPECT_EQ(64u, recorded_event.payload_length);
-  EXPECT_EQ(1000u, recorded_event.start_tick);
-  EXPECT_EQ(1200u, recorded_event.end_tick);
-  ASSERT_EQ(1u, sink_.clock_correlations.size());
-  EXPECT_EQ(1u, sink_.clock_correlations[0].sample_id);
-  EXPECT_EQ(1000u, sink_.clock_correlations[0].device_tick);
-}
-
-TEST_F(LocalProfileRecorderTest, FullQueueDeviceRingAutoFlushes) {
-  recorder_options_.producer_data_families =
-      IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS;
-  recorder_options_.queue_device_event_capacity = 1;
-  IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS));
-
-  iree_hal_local_profile_queue_device_event_info_t event_info =
-      iree_hal_local_profile_queue_device_event_info_default();
-  event_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_DISPATCH;
-  event_info.scope = QueueScope();
-  event_info.submission_id = 7;
-  event_info.operation_count = 1;
-  event_info.start_tick = 1000;
-  event_info.end_tick = 1200;
-  uint64_t first_event_id = 0;
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_append_queue_device_event(
-      recorder_, &event_info, &first_event_id));
-  EXPECT_NE(0u, first_event_id);
-
-  event_info.submission_id = 12;
-  event_info.start_tick = 1300;
-  event_info.end_tick = 1500;
-  uint64_t second_event_id = 0;
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_append_queue_device_event(
-      recorder_, &event_info, &second_event_id));
-  EXPECT_NE(0u, second_event_id);
-  EXPECT_NE(first_event_id, second_event_id);
-
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
-  ASSERT_EQ(2u, sink_.queue_device_events.size());
-  EXPECT_EQ(first_event_id, sink_.queue_device_events[0].event_id);
-  EXPECT_EQ(7u, sink_.queue_device_events[0].submission_id);
-  EXPECT_EQ(second_event_id, sink_.queue_device_events[1].event_id);
-  EXPECT_EQ(12u, sink_.queue_device_events[1].submission_id);
-  EXPECT_EQ(0u, sink_.dropped_queue_device_event_count);
-}
-
-TEST_F(LocalProfileRecorderTest, RejectsCaptureFilter) {
+TEST_F(TaskProfileRecorderTest, RejectsCaptureFilter) {
   iree_hal_device_profiling_options_t options =
       MakeProfilingOptions(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS);
   options.capture_filter.flags =
@@ -759,40 +491,11 @@ TEST_F(LocalProfileRecorderTest, RejectsCaptureFilter) {
   options.capture_filter.queue_ordinal = 0;
   IREE_EXPECT_STATUS_IS(
       IREE_STATUS_UNIMPLEMENTED,
-      iree_hal_local_profile_recorder_create(
+      iree_hal_task_profile_recorder_create(
           &recorder_options_, &options, iree_allocator_system(), &recorder_));
 }
 
-TEST_F(LocalProfileRecorderTest,
-       AcceptsCaptureFilterForProducerDispatchEvents) {
-  recorder_options_.producer_data_families =
-      IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS;
-  iree_hal_device_profiling_options_t options =
-      MakeProfilingOptions(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS);
-  options.capture_filter.flags =
-      IREE_HAL_PROFILE_CAPTURE_FILTER_FLAG_EXECUTABLE_FUNCTION_PATTERN;
-  options.capture_filter.executable_function_pattern = IREE_SV("dispatch_*");
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_create(
-      &recorder_options_, &options, iree_allocator_system(), &recorder_));
-}
-
-TEST_F(LocalProfileRecorderTest,
-       RejectsCaptureFilterWhenLocalQueueEventsAreRequested) {
-  recorder_options_.producer_data_families =
-      IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS;
-  iree_hal_device_profiling_options_t options =
-      MakeProfilingOptions(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
-                           IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS);
-  options.capture_filter.flags =
-      IREE_HAL_PROFILE_CAPTURE_FILTER_FLAG_QUEUE_ORDINAL;
-  options.capture_filter.queue_ordinal = 0;
-  IREE_EXPECT_STATUS_IS(
-      IREE_STATUS_UNIMPLEMENTED,
-      iree_hal_local_profile_recorder_create(
-          &recorder_options_, &options, iree_allocator_system(), &recorder_));
-}
-
-TEST_F(LocalProfileRecorderTest, RecordsExecutableMetadataOnce) {
+TEST_F(TaskProfileRecorderTest, RecordsExecutableMetadataOnce) {
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA));
 
   FakeLocalExecutable executable;
@@ -801,9 +504,9 @@ TEST_F(LocalProfileRecorderTest, RecordsExecutableMetadataOnce) {
   iree_hal_executable_t* base_executable =
       reinterpret_cast<iree_hal_executable_t*>(&executable.base);
 
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_record_executable(
+  IREE_EXPECT_OK(iree_hal_task_profile_recorder_record_executable(
       recorder_, base_executable));
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_record_executable(
+  IREE_EXPECT_OK(iree_hal_task_profile_recorder_record_executable(
       recorder_, base_executable));
 
   ASSERT_EQ(1u, sink_.executable_records.size());
@@ -817,33 +520,9 @@ TEST_F(LocalProfileRecorderTest, RecordsExecutableMetadataOnce) {
   iree_hal_local_executable_deinitialize(&executable.base);
 }
 
-TEST_F(LocalProfileRecorderTest, RecordsExecutableMetadataWithExplicitId) {
-  IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA));
-
-  FakeLocalExecutable executable;
-  iree_hal_local_executable_initialize(
-      &kFakeLocalExecutableVTable, iree_allocator_system(), &executable.base);
-  iree_hal_executable_t* base_executable =
-      reinterpret_cast<iree_hal_executable_t*>(&executable.base);
-
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_record_executable_with_id(
-      recorder_, base_executable, 42));
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_record_executable_with_id(
-      recorder_, base_executable, 42));
-
-  ASSERT_EQ(1u, sink_.executable_records.size());
-  ASSERT_EQ(2u, sink_.executable_function_records.size());
-  EXPECT_EQ(42u, sink_.executable_records[0].executable_id);
-  EXPECT_EQ(42u, sink_.executable_function_records[0].executable_id);
-  EXPECT_EQ("dispatch_a", sink_.executable_function_names[0]);
-  EXPECT_EQ("dispatch_b", sink_.executable_function_names[1]);
-
-  iree_hal_local_executable_deinitialize(&executable.base);
-}
-
-TEST_F(LocalProfileRecorderTest, HostExecutionEnablesExecutableMetadata) {
+TEST_F(TaskProfileRecorderTest, HostExecutionEnablesExecutableMetadata) {
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS));
-  EXPECT_TRUE(iree_hal_local_profile_recorder_is_enabled(
+  EXPECT_TRUE(iree_hal_task_profile_recorder_is_enabled(
       recorder_, IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA));
 
   FakeLocalExecutable executable;
@@ -852,7 +531,7 @@ TEST_F(LocalProfileRecorderTest, HostExecutionEnablesExecutableMetadata) {
   iree_hal_executable_t* base_executable =
       reinterpret_cast<iree_hal_executable_t*>(&executable.base);
 
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_record_executable(
+  IREE_EXPECT_OK(iree_hal_task_profile_recorder_record_executable(
       recorder_, base_executable));
 
   ASSERT_EQ(1u, sink_.executable_records.size());
@@ -863,7 +542,7 @@ TEST_F(LocalProfileRecorderTest, HostExecutionEnablesExecutableMetadata) {
   iree_hal_local_executable_deinitialize(&executable.base);
 }
 
-TEST_F(LocalProfileRecorderTest, SinkBeginFailurePropagates) {
+TEST_F(TaskProfileRecorderTest, SinkBeginFailurePropagates) {
   sink_.fail_begin_session_status_code = IREE_STATUS_RESOURCE_EXHAUSTED;
   IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
                         Create(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS));
@@ -871,7 +550,7 @@ TEST_F(LocalProfileRecorderTest, SinkBeginFailurePropagates) {
   EXPECT_EQ(0, sink_.end_count);
 }
 
-TEST_F(LocalProfileRecorderTest, MetadataWriteFailureEndsSession) {
+TEST_F(TaskProfileRecorderTest, MetadataWriteFailureEndsSession) {
   sink_.fail_write_content_type = IREE_HAL_PROFILE_CONTENT_TYPE_QUEUES;
   sink_.fail_write_remaining = 1;
   sink_.fail_write_status_code = IREE_STATUS_UNAVAILABLE;
@@ -882,12 +561,12 @@ TEST_F(LocalProfileRecorderTest, MetadataWriteFailureEndsSession) {
   EXPECT_EQ(IREE_STATUS_UNAVAILABLE, sink_.observed_end_session_status_code);
 }
 
-TEST_F(LocalProfileRecorderTest, AppendsAndFlushesQueueAndHostEvents) {
+TEST_F(TaskProfileRecorderTest, AppendsAndFlushesQueueAndHostEvents) {
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
                         IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS));
 
-  iree_hal_local_profile_queue_event_info_t queue_info =
-      iree_hal_local_profile_queue_event_info_default();
+  iree_hal_task_profile_queue_event_info_t queue_info =
+      iree_hal_task_profile_queue_event_info_default();
   queue_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_DISPATCH;
   queue_info.dependency_strategy =
       IREE_HAL_PROFILE_QUEUE_DEPENDENCY_STRATEGY_INLINE;
@@ -899,12 +578,12 @@ TEST_F(LocalProfileRecorderTest, AppendsAndFlushesQueueAndHostEvents) {
   queue_info.signal_count = 1;
   queue_info.operation_count = 1;
   uint64_t queue_event_id = 0;
-  iree_hal_local_profile_recorder_append_queue_event(recorder_, &queue_info,
-                                                     &queue_event_id);
+  iree_hal_task_profile_recorder_append_queue_event(recorder_, &queue_info,
+                                                    &queue_event_id);
   EXPECT_NE(0u, queue_event_id);
 
-  iree_hal_local_profile_host_execution_event_info_t host_info =
-      iree_hal_local_profile_host_execution_event_info_default();
+  iree_hal_task_profile_host_execution_event_info_t host_info =
+      iree_hal_task_profile_host_execution_event_info_default();
   host_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_DISPATCH;
   host_info.status_code = IREE_STATUS_OK;
   host_info.scope = QueueScope();
@@ -917,11 +596,11 @@ TEST_F(LocalProfileRecorderTest, AppendsAndFlushesQueueAndHostEvents) {
   host_info.end_host_time_ns = 140;
   host_info.operation_count = 1;
   uint64_t host_event_id = 0;
-  iree_hal_local_profile_recorder_append_host_execution_event(
+  iree_hal_task_profile_recorder_append_host_execution_event(
       recorder_, &host_info, &host_event_id);
   EXPECT_NE(0u, host_event_id);
 
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
+  IREE_EXPECT_OK(iree_hal_task_profile_recorder_flush(recorder_));
   ASSERT_EQ(1u, sink_.queue_events.size());
   ASSERT_EQ(1u, sink_.host_execution_events.size());
   EXPECT_EQ(queue_event_id, sink_.queue_events[0].event_id);
@@ -930,7 +609,7 @@ TEST_F(LocalProfileRecorderTest, AppendsAndFlushesQueueAndHostEvents) {
   EXPECT_EQ(host_event_id, sink_.host_execution_events[0].event_id);
 }
 
-TEST_F(LocalProfileRecorderTest, AppendsAndFlushesMemoryEvents) {
+TEST_F(TaskProfileRecorderTest, AppendsAndFlushesMemoryEvents) {
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS));
 
   iree_hal_profile_memory_event_t event =
@@ -952,11 +631,11 @@ TEST_F(LocalProfileRecorderTest, AppendsAndFlushesMemoryEvents) {
   event.alignment = 16;
 
   uint64_t event_id = 0;
-  iree_hal_local_profile_recorder_append_memory_event(recorder_, &event,
-                                                      &event_id);
+  iree_hal_task_profile_recorder_append_memory_event(recorder_, &event,
+                                                     &event_id);
   EXPECT_NE(0u, event_id);
 
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
+  IREE_EXPECT_OK(iree_hal_task_profile_recorder_flush(recorder_));
   ASSERT_EQ(1u, sink_.memory_events.size());
   const iree_hal_profile_memory_event_t& recorded_event =
       sink_.memory_events[0];
@@ -969,52 +648,52 @@ TEST_F(LocalProfileRecorderTest, AppendsAndFlushesMemoryEvents) {
   EXPECT_EQ(256u, recorded_event.length);
 }
 
-TEST_F(LocalProfileRecorderTest, FullQueueRingReportsTruncatedChunk) {
+TEST_F(TaskProfileRecorderTest, FullQueueRingReportsTruncatedChunk) {
   recorder_options_.queue_event_capacity = 1;
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS));
 
-  iree_hal_local_profile_queue_event_info_t queue_info =
-      iree_hal_local_profile_queue_event_info_default();
+  iree_hal_task_profile_queue_event_info_t queue_info =
+      iree_hal_task_profile_queue_event_info_default();
   queue_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_BARRIER;
   queue_info.scope = QueueScope();
   uint64_t captured_event_id = 0;
-  iree_hal_local_profile_recorder_append_queue_event(recorder_, &queue_info,
-                                                     &captured_event_id);
+  iree_hal_task_profile_recorder_append_queue_event(recorder_, &queue_info,
+                                                    &captured_event_id);
   EXPECT_NE(0u, captured_event_id);
 
   uint64_t dropped_event_id = 0;
-  iree_hal_local_profile_recorder_append_queue_event(recorder_, &queue_info,
-                                                     &dropped_event_id);
+  iree_hal_task_profile_recorder_append_queue_event(recorder_, &queue_info,
+                                                    &dropped_event_id);
   EXPECT_EQ(0u, dropped_event_id);
 
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
+  IREE_EXPECT_OK(iree_hal_task_profile_recorder_flush(recorder_));
   ASSERT_EQ(1u, sink_.queue_events.size());
   EXPECT_EQ(captured_event_id, sink_.queue_events[0].event_id);
   EXPECT_EQ(1u, sink_.dropped_queue_event_count);
 }
 
-TEST_F(LocalProfileRecorderTest, FlushesWrappedQueueRing) {
+TEST_F(TaskProfileRecorderTest, FlushesWrappedQueueRing) {
   recorder_options_.queue_event_capacity = 2;
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS));
 
-  iree_hal_local_profile_queue_event_info_t queue_info =
-      iree_hal_local_profile_queue_event_info_default();
+  iree_hal_task_profile_queue_event_info_t queue_info =
+      iree_hal_task_profile_queue_event_info_default();
   queue_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_BARRIER;
   queue_info.scope = QueueScope();
 
   uint64_t first_event_id = 0;
-  iree_hal_local_profile_recorder_append_queue_event(recorder_, &queue_info,
-                                                     &first_event_id);
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
+  iree_hal_task_profile_recorder_append_queue_event(recorder_, &queue_info,
+                                                    &first_event_id);
+  IREE_EXPECT_OK(iree_hal_task_profile_recorder_flush(recorder_));
   ASSERT_EQ(1u, sink_.queue_events.size());
 
   uint64_t second_event_id = 0;
-  iree_hal_local_profile_recorder_append_queue_event(recorder_, &queue_info,
-                                                     &second_event_id);
+  iree_hal_task_profile_recorder_append_queue_event(recorder_, &queue_info,
+                                                    &second_event_id);
   uint64_t third_event_id = 0;
-  iree_hal_local_profile_recorder_append_queue_event(recorder_, &queue_info,
-                                                     &third_event_id);
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
+  iree_hal_task_profile_recorder_append_queue_event(recorder_, &queue_info,
+                                                    &third_event_id);
+  IREE_EXPECT_OK(iree_hal_task_profile_recorder_flush(recorder_));
 
   ASSERT_EQ(3u, sink_.queue_events.size());
   EXPECT_EQ(first_event_id, sink_.queue_events[0].event_id);
@@ -1023,32 +702,32 @@ TEST_F(LocalProfileRecorderTest, FlushesWrappedQueueRing) {
   EXPECT_EQ(0u, sink_.dropped_queue_event_count);
 }
 
-TEST_F(LocalProfileRecorderTest, FlushFailurePreservesPendingRecords) {
+TEST_F(TaskProfileRecorderTest, FlushFailurePreservesPendingRecords) {
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS));
-  iree_hal_local_profile_queue_event_info_t queue_info =
-      iree_hal_local_profile_queue_event_info_default();
+  iree_hal_task_profile_queue_event_info_t queue_info =
+      iree_hal_task_profile_queue_event_info_default();
   queue_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_BARRIER;
   queue_info.scope = QueueScope();
-  iree_hal_local_profile_recorder_append_queue_event(recorder_, &queue_info,
-                                                     nullptr);
+  iree_hal_task_profile_recorder_append_queue_event(recorder_, &queue_info,
+                                                    nullptr);
 
   sink_.fail_write_content_type = IREE_HAL_PROFILE_CONTENT_TYPE_QUEUE_EVENTS;
   sink_.fail_write_remaining = 1;
   sink_.fail_write_status_code = IREE_STATUS_UNAVAILABLE;
   IREE_EXPECT_STATUS_IS(IREE_STATUS_UNAVAILABLE,
-                        iree_hal_local_profile_recorder_flush(recorder_));
+                        iree_hal_task_profile_recorder_flush(recorder_));
 
-  IREE_EXPECT_OK(iree_hal_local_profile_recorder_flush(recorder_));
+  IREE_EXPECT_OK(iree_hal_task_profile_recorder_flush(recorder_));
   EXPECT_EQ(1u, sink_.queue_events.size());
 }
 
-TEST_F(LocalProfileRecorderTest, EndFailurePropagates) {
+TEST_F(TaskProfileRecorderTest, EndFailurePropagates) {
   IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS));
   sink_.fail_end_session_status_code = IREE_STATUS_UNAVAILABLE;
   IREE_EXPECT_STATUS_IS(IREE_STATUS_UNAVAILABLE,
-                        iree_hal_local_profile_recorder_end(recorder_));
+                        iree_hal_task_profile_recorder_end(recorder_));
   EXPECT_EQ(1, sink_.end_count);
 }
 
 }  // namespace
-}  // namespace iree::hal::local
+}  // namespace iree::hal::local_task

--- a/runtime/src/iree/hal/drivers/local_task/profile_test.cc
+++ b/runtime/src/iree/hal/drivers/local_task/profile_test.cc
@@ -7,6 +7,7 @@
 #include "iree/hal/drivers/local_task/profile.h"
 
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -141,23 +142,22 @@ static iree_status_t CopyExecutableFunctionProfileRecords(
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "truncated executable function record");
     }
-    const auto* record =
-        reinterpret_cast<const iree_hal_profile_executable_function_record_t*>(
-            iovec.data + offset);
-    if (record->record_length < sizeof(*record) ||
-        record->record_length > remaining_length) {
+    iree_hal_profile_executable_function_record_t record;
+    memcpy(&record, iovec.data + offset, sizeof(record));
+    if (record.record_length < sizeof(record) ||
+        record.record_length > remaining_length) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "invalid executable function record length");
     }
-    if (record->name_length > record->record_length - sizeof(*record)) {
+    if (record.name_length > record.record_length - sizeof(record)) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "invalid executable function name length");
     }
-    out_records->push_back(*record);
+    out_records->push_back(record);
     out_names->emplace_back(
-        reinterpret_cast<const char*>(iovec.data + offset + sizeof(*record)),
-        record->name_length);
-    offset += record->record_length;
+        reinterpret_cast<const char*>(iovec.data + offset + sizeof(record)),
+        record.name_length);
+    offset += record.record_length;
   }
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -17,13 +17,13 @@
 #include "iree/base/internal/arena.h"
 #include "iree/base/internal/math.h"
 #include "iree/hal/drivers/local_task/block_command_buffer.h"
+#include "iree/hal/drivers/local_task/profile.h"
 #include "iree/hal/drivers/local_task/task_queue.h"
 #include "iree/hal/drivers/local_task/task_semaphore.h"
 #include "iree/hal/drivers/local_task/transient_buffer.h"
 #include "iree/hal/local/atomic.h"
 #include "iree/hal/local/device_spec_builder.h"
 #include "iree/hal/local/executable_environment.h"
-#include "iree/hal/local/profile.h"
 #include "iree/hal/memory/cpu_slab_provider.h"
 #include "iree/hal/memory/passthrough_pool.h"
 #include "iree/hal/memory/tlsf_pool.h"
@@ -83,7 +83,7 @@ typedef struct iree_hal_task_device_t {
   iree_hal_device_spec_t* device_spec;
 
   // Active HAL-native profiling recorder, or NULL when profiling is disabled.
-  iree_hal_local_profile_recorder_t* profile_recorder;
+  iree_hal_task_profile_recorder_t* profile_recorder;
 
   // Next process-local profiling session identifier assigned by this device.
   uint64_t next_profile_session_id;
@@ -1043,12 +1043,12 @@ static uint32_t iree_hal_task_device_profile_count(iree_host_size_t count) {
   return count > UINT32_MAX ? UINT32_MAX : (uint32_t)count;
 }
 
-static iree_hal_local_profile_queue_scope_t
+static iree_hal_task_profile_queue_scope_t
 iree_hal_task_device_profile_queue_scope(const iree_hal_task_device_t* device,
                                          uint32_t queue_ordinal) {
   const uint32_t physical_device_ordinal =
       device->topology_info.topology ? device->topology_info.topology_index : 0;
-  iree_hal_local_profile_queue_scope_t scope = {
+  iree_hal_task_profile_queue_scope_t scope = {
       .physical_device_ordinal = physical_device_ordinal,
       .queue_ordinal = queue_ordinal,
       .stream_id = ((uint64_t)physical_device_ordinal << 32) | queue_ordinal,
@@ -1079,7 +1079,7 @@ static iree_status_t iree_hal_task_device_profiling_begin(
       (void**)&queue_records));
   for (iree_host_size_t i = 0; i < device->queue_count; ++i) {
     const uint32_t queue_ordinal = iree_hal_task_device_profile_count(i);
-    const iree_hal_local_profile_queue_scope_t scope =
+    const iree_hal_task_profile_queue_scope_t scope =
         iree_hal_task_device_profile_queue_scope(device, queue_ordinal);
     queue_records[i] = iree_hal_profile_queue_record_default();
     queue_records[i].physical_device_ordinal = scope.physical_device_ordinal;
@@ -1087,7 +1087,7 @@ static iree_status_t iree_hal_task_device_profiling_begin(
     queue_records[i].stream_id = scope.stream_id;
   }
 
-  iree_hal_local_profile_recorder_options_t recorder_options = {
+  iree_hal_task_profile_recorder_options_t recorder_options = {
       .name = device->identifier,
       .session_id = ++device->next_profile_session_id,
       .device_record_count = 1,
@@ -1095,8 +1095,8 @@ static iree_status_t iree_hal_task_device_profiling_begin(
       .queue_record_count = device->queue_count,
       .queue_records = queue_records,
   };
-  iree_hal_local_profile_recorder_t* recorder = NULL;
-  iree_status_t status = iree_hal_local_profile_recorder_create(
+  iree_hal_task_profile_recorder_t* recorder = NULL;
+  iree_status_t status = iree_hal_task_profile_recorder_create(
       &recorder_options, options, device->host_allocator, &recorder);
   iree_allocator_free(device->host_allocator, queue_records);
   if (!iree_status_is_ok(status) || !recorder) return status;
@@ -1117,17 +1117,17 @@ static iree_status_t iree_hal_task_device_profiling_begin(
 static iree_status_t iree_hal_task_device_profiling_flush(
     iree_hal_device_t* base_device) {
   iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
-  return iree_hal_local_profile_recorder_flush(device->profile_recorder);
+  return iree_hal_task_profile_recorder_flush(device->profile_recorder);
 }
 
 static iree_status_t iree_hal_task_device_profiling_end(
     iree_hal_device_t* base_device) {
   iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
-  iree_hal_local_profile_recorder_t* recorder = device->profile_recorder;
+  iree_hal_task_profile_recorder_t* recorder = device->profile_recorder;
   if (!recorder) return iree_ok_status();
 
-  const iree_hal_local_profile_queue_scope_t empty_scope =
-      iree_hal_local_profile_queue_scope_default();
+  const iree_hal_task_profile_queue_scope_t empty_scope =
+      iree_hal_task_profile_queue_scope_default();
   for (iree_host_size_t i = 0; i < device->queue_count; ++i) {
     iree_hal_task_queue_set_profile_recorder(
         &device->queues[i], /*profile_recorder=*/NULL, empty_scope,
@@ -1137,8 +1137,8 @@ static iree_status_t iree_hal_task_device_profiling_end(
   iree_atomic_store(&device->next_profile_submission_id, 0,
                     iree_memory_order_relaxed);
 
-  iree_status_t status = iree_hal_local_profile_recorder_end(recorder);
-  iree_hal_local_profile_recorder_destroy(recorder);
+  iree_status_t status = iree_hal_task_profile_recorder_end(recorder);
+  iree_hal_task_profile_recorder_destroy(recorder);
   return status;
 }
 

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -138,10 +138,10 @@ static void iree_hal_task_queue_debug_record_destroy(
 // the disabled path does not allocate the profile payload.
 typedef struct iree_hal_task_queue_profile_operation_t {
   // Recorder captured at operation allocation time.
-  iree_hal_local_profile_recorder_t* recorder;
+  iree_hal_task_profile_recorder_t* recorder;
 
   // Queue identity captured at operation allocation time.
-  iree_hal_local_profile_queue_scope_t scope;
+  iree_hal_task_profile_queue_scope_t scope;
 
   // Queue operation type shared by emitted records.
   iree_hal_profile_queue_event_type_t type;
@@ -264,8 +264,8 @@ iree_hal_task_queue_profile_operation(iree_hal_task_queue_op_t* operation) {
 }
 
 static void iree_hal_task_queue_profile_operation_initialize(
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t profile_scope,
+    iree_hal_task_profile_recorder_t* profile_recorder,
+    iree_hal_task_profile_queue_scope_t profile_scope,
     iree_atomic_int64_t* profile_submission_counter,
     iree_hal_task_queue_op_type_t type,
     const iree_hal_semaphore_list_t* signal_semaphores,
@@ -279,7 +279,7 @@ static void iree_hal_task_queue_profile_operation_initialize(
   profile_operation->signal_count =
       iree_hal_task_queue_profile_count(signal_semaphores->count);
   profile_operation->function_ordinal = UINT32_MAX;
-  if (iree_hal_local_profile_recorder_is_enabled(
+  if (iree_hal_task_profile_recorder_is_enabled(
           profile_operation->recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS)) {
     profile_operation->submit_host_time_ns = iree_time_now();
@@ -367,7 +367,7 @@ static void iree_hal_task_queue_profile_record_memory_event(
     uint64_t frontier_entry_count) {
   iree_hal_task_queue_profile_operation_t* profile_operation =
       iree_hal_task_queue_profile_operation(operation);
-  if (!profile_operation || !iree_hal_local_profile_recorder_is_enabled(
+  if (!profile_operation || !iree_hal_task_profile_recorder_is_enabled(
                                 profile_operation->recorder,
                                 IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS)) {
     return;
@@ -400,7 +400,7 @@ static void iree_hal_task_queue_profile_record_memory_event(
     }
   }
   iree_hal_task_queue_profile_populate_memory_event_pool_stats(pool, &event);
-  iree_hal_local_profile_recorder_append_memory_event(
+  iree_hal_task_profile_recorder_append_memory_event(
       profile_operation->recorder, &event, /*out_event_id=*/NULL);
 }
 
@@ -420,7 +420,7 @@ static iree_status_t iree_hal_task_queue_profile_set_dispatch(
   iree_hal_task_queue_profile_operation_t* profile_operation =
       iree_hal_task_queue_profile_operation(operation);
   if (!profile_operation) return iree_ok_status();
-  IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_record_executable(
+  IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_record_executable(
       profile_operation->recorder, executable));
   iree_hal_local_executable_t* local_executable =
       iree_hal_local_executable_cast(executable);
@@ -457,7 +457,7 @@ static iree_status_t iree_hal_task_queue_profile_record_command_buffer(
   iree_hal_task_queue_profile_operation_t* profile_operation =
       iree_hal_task_queue_profile_operation(operation);
   if (!profile_operation) return iree_ok_status();
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           profile_operation->recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA)) {
     return iree_ok_status();
@@ -469,7 +469,7 @@ static iree_status_t iree_hal_task_queue_profile_record_command_buffer(
   iree_hal_block_command_buffer_profile_metadata(
       command_buffer, profile_operation->scope.physical_device_ordinal,
       &command_buffer_record, &operations, &operation_count);
-  IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_record_command_buffer(
+  IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_record_command_buffer(
       profile_operation->recorder, &command_buffer_record, operation_count,
       operations));
 
@@ -478,7 +478,7 @@ static iree_status_t iree_hal_task_queue_profile_record_command_buffer(
       iree_hal_block_command_buffer_profile_executables(command_buffer,
                                                         &executable_count);
   for (iree_host_size_t i = 0; i < executable_count; ++i) {
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_record_executable(
+    IREE_RETURN_IF_ERROR(iree_hal_task_profile_recorder_record_executable(
         profile_operation->recorder, executables[i]));
   }
   return iree_ok_status();
@@ -503,7 +503,7 @@ static void iree_hal_task_queue_profile_record_queue_event(
   iree_hal_task_queue_profile_operation_t* profile_operation =
       iree_hal_task_queue_profile_operation(operation);
   if (!profile_operation || profile_operation->queue_event_recorded) return;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           profile_operation->recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS)) {
     return;
@@ -511,8 +511,8 @@ static void iree_hal_task_queue_profile_record_queue_event(
   profile_operation->queue_event_recorded = true;
   profile_operation->ready_host_time_ns = ready_host_time_ns;
 
-  iree_hal_local_profile_queue_event_info_t event_info =
-      iree_hal_local_profile_queue_event_info_default();
+  iree_hal_task_profile_queue_event_info_t event_info =
+      iree_hal_task_profile_queue_event_info_default();
   event_info.type = profile_operation->type;
   event_info.flags = profile_operation->queue_flags;
   event_info.dependency_strategy = profile_operation->dependency_strategy;
@@ -526,7 +526,7 @@ static void iree_hal_task_queue_profile_record_queue_event(
   event_info.signal_count = profile_operation->signal_count;
   event_info.operation_count = profile_operation->operation_count;
   event_info.payload_length = profile_operation->payload_length;
-  iree_hal_local_profile_recorder_append_queue_event(
+  iree_hal_task_profile_recorder_append_queue_event(
       profile_operation->recorder, &event_info, /*out_event_id=*/NULL);
 }
 
@@ -535,7 +535,7 @@ static void iree_hal_task_queue_profile_record_ready(
   if (operation->type == IREE_HAL_TASK_QUEUE_OP_ALLOCA) return;
   iree_hal_task_queue_profile_operation_t* profile_operation =
       iree_hal_task_queue_profile_operation(operation);
-  if (!profile_operation || !iree_hal_local_profile_recorder_is_enabled(
+  if (!profile_operation || !iree_hal_task_profile_recorder_is_enabled(
                                 profile_operation->recorder,
                                 IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS)) {
     return;
@@ -554,7 +554,7 @@ static void iree_hal_task_queue_profile_start_host_execution(
   iree_hal_task_queue_profile_operation_t* profile_operation =
       iree_hal_task_queue_profile_operation(operation);
   if (!profile_operation) return;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           profile_operation->recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS)) {
     return;
@@ -575,14 +575,14 @@ static void iree_hal_task_queue_profile_finish_host_execution(
   const iree_time_t start_host_time_ns = iree_atomic_exchange(
       &profile_operation->start_host_time_ns, 0, iree_memory_order_acq_rel);
   if (start_host_time_ns == 0) return;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_task_profile_recorder_is_enabled(
           profile_operation->recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS)) {
     return;
   }
 
-  iree_hal_local_profile_host_execution_event_info_t event_info =
-      iree_hal_local_profile_host_execution_event_info_default();
+  iree_hal_task_profile_host_execution_event_info_t event_info =
+      iree_hal_task_profile_host_execution_event_info_default();
   event_info.type = profile_operation->type;
   event_info.flags = profile_operation->host_flags;
   event_info.status_code = operation_status_code;
@@ -600,7 +600,7 @@ static void iree_hal_task_queue_profile_finish_host_execution(
   event_info.end_host_time_ns = iree_time_now();
   event_info.payload_length = profile_operation->payload_length;
   event_info.operation_count = profile_operation->operation_count;
-  iree_hal_local_profile_recorder_append_host_execution_event(
+  iree_hal_task_profile_recorder_append_host_execution_event(
       profile_operation->recorder, &event_info, /*out_event_id=*/NULL);
 }
 
@@ -784,7 +784,7 @@ static iree_status_t iree_hal_task_queue_op_allocate(
 
   // Allocate the operation from the arena.
   iree_hal_task_queue_op_t* operation = NULL;
-  iree_hal_local_profile_recorder_t* profile_recorder = queue->profile_recorder;
+  iree_hal_task_profile_recorder_t* profile_recorder = queue->profile_recorder;
   iree_hal_task_queue_op_flags_t operation_flags =
       IREE_HAL_TASK_QUEUE_OP_FLAG_NONE;
   iree_host_size_t operation_size = sizeof(*operation);
@@ -1478,7 +1478,7 @@ static iree_status_t iree_hal_task_queue_drain_recording(
   iree_status_t status = iree_ok_status();
   if (worker_count > 1 && profile_operation &&
       recording->max_region_dispatch_count > 0 &&
-      iree_hal_local_profile_recorder_is_enabled(
+      iree_hal_task_profile_recorder_is_enabled(
           profile_operation->recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS)) {
     profile_dispatch_capacity = recording->max_region_dispatch_count;
@@ -3502,8 +3502,8 @@ void iree_hal_task_queue_trim(iree_hal_task_queue_t* queue) {
 
 void iree_hal_task_queue_set_profile_recorder(
     iree_hal_task_queue_t* queue,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t profile_scope,
+    iree_hal_task_profile_recorder_t* profile_recorder,
+    iree_hal_task_profile_queue_scope_t profile_scope,
     iree_atomic_int64_t* submission_counter) {
   if (profile_recorder) {
     queue->profile_scope = profile_scope;

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.h
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.h
@@ -36,7 +36,7 @@
 #include "iree/base/internal/atomic_slist.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/local_task/block_processor.h"
-#include "iree/hal/local/profile.h"
+#include "iree/hal/drivers/local_task/profile.h"
 #include "iree/task/executor.h"
 #include "iree/task/process.h"
 #include "iree/task/scope.h"
@@ -472,10 +472,10 @@ struct iree_hal_task_queue_t {
   iree_hal_allocator_t* device_allocator;
 
   // Active local CPU profile recorder, or NULL when profiling is disabled.
-  iree_hal_local_profile_recorder_t* profile_recorder;
+  iree_hal_task_profile_recorder_t* profile_recorder;
 
   // Queue metadata identity used by records during the active profile session.
-  iree_hal_local_profile_queue_scope_t profile_scope;
+  iree_hal_task_profile_queue_scope_t profile_scope;
 
   // Device-owned submission id counter shared by all queues in the session.
   iree_atomic_int64_t* profile_submission_counter;
@@ -611,8 +611,8 @@ void iree_hal_task_queue_trim(iree_hal_task_queue_t* queue);
 // pointer changing underneath them.
 void iree_hal_task_queue_set_profile_recorder(
     iree_hal_task_queue_t* queue,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t profile_scope,
+    iree_hal_task_profile_recorder_t* profile_recorder,
+    iree_hal_task_profile_queue_scope_t profile_scope,
     iree_atomic_int64_t* submission_counter);
 
 iree_status_t iree_hal_task_queue_submit_barrier(

--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -204,6 +204,31 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "profile",
+    srcs = ["profile.c"],
+    hdrs = ["profile.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/utils:profile_event_ring",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "profile_test",
+    srcs = ["profile_test.cc"],
+    deps = [
+        ":profile",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/cts/util:profile_test_util",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "vulkan",
     srcs = [
         "allocator.c",
@@ -251,6 +276,7 @@ iree_runtime_cc_library(
     deps = [
         ":api",
         ":device_spec_builder",
+        ":profile",
         ":transient_buffer",
         "//runtime/src/iree/async",
         "//runtime/src/iree/async/util:proactor_pool",
@@ -263,7 +289,6 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers/vulkan/device:library",
         "//runtime/src/iree/hal/drivers/vulkan/util:libvulkan",
-        "//runtime/src/iree/hal/local:profile",
         "//runtime/src/iree/hal/memory:passthrough_pool",
         "//runtime/src/iree/hal/memory:slab_provider",
         "//runtime/src/iree/hal/memory:tlsf_pool",

--- a/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
@@ -263,6 +263,40 @@ endif()
 if(IREE_HAL_DRIVER_VULKAN)
 iree_cc_library(
   NAME
+    profile
+  HDRS
+    "profile.h"
+  SRCS
+    "profile.c"
+  DEPS
+    iree::base
+    iree::base::threading
+    iree::hal
+    iree::hal::utils::profile_event_ring
+  PUBLIC
+)
+endif()
+
+if(IREE_HAL_DRIVER_VULKAN)
+iree_cc_test(
+  NAME
+    profile_test
+  SRCS
+    "profile_test.cc"
+  DEPS
+    ::profile
+    iree::hal
+    iree::hal::cts::util::profile_test_util
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "iree-build-requirement=runtime.hal.vulkan"
+)
+endif()
+
+if(IREE_HAL_DRIVER_VULKAN)
+iree_cc_library(
+  NAME
     vulkan
   SRCS
     "allocator.c"
@@ -309,6 +343,7 @@ iree_cc_library(
   DEPS
     ::api
     ::device_spec_builder
+    ::profile
     ::transient_buffer
     iree::async
     iree::async::util::proactor_pool
@@ -321,7 +356,6 @@ iree_cc_library(
     iree::hal
     iree::hal::drivers::vulkan::device::library
     iree::hal::drivers::vulkan::util::libvulkan
-    iree::hal::local::profile
     iree::hal::memory::passthrough_pool
     iree::hal::memory::slab_provider
     iree::hal::memory::tlsf_pool

--- a/runtime/src/iree/hal/drivers/vulkan/command_buffer.c
+++ b/runtime/src/iree/hal/drivers/vulkan/command_buffer.c
@@ -910,9 +910,9 @@ static iree_status_t iree_hal_vulkan_command_buffer_profile_operation(
 
 iree_status_t iree_hal_vulkan_command_buffer_record_profile_metadata(
     iree_hal_command_buffer_t* base_command_buffer,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t command_buffer_id) {
-  if (!iree_hal_local_profile_recorder_is_enabled(
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t scope, uint64_t command_buffer_id) {
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
           profile_recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA)) {
     return iree_ok_status();
@@ -933,10 +933,9 @@ iree_status_t iree_hal_vulkan_command_buffer_record_profile_metadata(
     if (command->type != IREE_HAL_VULKAN_COMMAND_TYPE_DISPATCH) continue;
     const iree_hal_vulkan_command_dispatch_t* dispatch =
         iree_hal_vulkan_command_dispatch_payload(command);
-    IREE_RETURN_IF_ERROR(
-        iree_hal_local_profile_recorder_record_executable_with_id(
-            profile_recorder, dispatch->executable,
-            iree_hal_vulkan_executable_profile_id(dispatch->executable)));
+    IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_record_executable(
+        profile_recorder, dispatch->executable,
+        iree_hal_vulkan_executable_profile_id(dispatch->executable)));
   }
 
   if (command_buffer_id == 0) return iree_ok_status();
@@ -973,7 +972,7 @@ iree_status_t iree_hal_vulkan_command_buffer_record_profile_metadata(
     }
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_record_command_buffer(
+    status = iree_hal_vulkan_profile_recorder_record_command_buffer(
         profile_recorder, &command_buffer_record, command_buffer->command_count,
         operation_records);
   }
@@ -982,11 +981,11 @@ iree_status_t iree_hal_vulkan_command_buffer_record_profile_metadata(
 }
 
 static bool iree_hal_vulkan_command_buffer_profile_filter_matches_dispatch(
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t command_buffer_id,
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t scope, uint64_t command_buffer_id,
     uint32_t command_index, const iree_hal_vulkan_pipeline_t* pipeline) {
   const iree_hal_device_profiling_options_t* options =
-      iree_hal_local_profile_recorder_options(profile_recorder);
+      iree_hal_vulkan_profile_recorder_options(profile_recorder);
   if (!options) return false;
   const iree_hal_profile_capture_filter_t* filter = &options->capture_filter;
   if (!iree_hal_profile_capture_filter_matches_location(
@@ -1006,11 +1005,11 @@ static bool iree_hal_vulkan_command_buffer_profile_filter_matches_dispatch(
 
 iree_status_t iree_hal_vulkan_command_buffer_count_profiled_dispatches(
     iree_hal_command_buffer_t* base_command_buffer,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t command_buffer_id,
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t scope, uint64_t command_buffer_id,
     uint32_t* out_dispatch_count) {
   *out_dispatch_count = 0;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
           profile_recorder, IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS)) {
     return iree_ok_status();
   }
@@ -1060,11 +1059,11 @@ iree_status_t iree_hal_vulkan_command_buffer_count_profiled_dispatches(
 
 iree_status_t iree_hal_vulkan_command_buffer_append_dispatch_profile_events(
     iree_hal_command_buffer_t* base_command_buffer,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t submission_id,
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t scope, uint64_t submission_id,
     uint64_t command_buffer_id, const uint64_t* dispatch_ticks,
     iree_host_size_t dispatch_count) {
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
           profile_recorder, IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS)) {
     return iree_ok_status();
   }
@@ -1126,8 +1125,8 @@ iree_status_t iree_hal_vulkan_command_buffer_append_dispatch_profile_events(
           "Vulkan dispatch profiling timestamp range is not monotonic");
     }
 
-    iree_hal_local_profile_dispatch_event_info_t event_info =
-        iree_hal_local_profile_dispatch_event_info_default();
+    iree_hal_vulkan_profile_dispatch_event_info_t event_info =
+        iree_hal_vulkan_profile_dispatch_event_info_default();
     event_info.scope = scope;
     event_info.submission_id = submission_id;
     event_info.command_buffer_id = command_buffer_id;
@@ -1150,7 +1149,7 @@ iree_status_t iree_hal_vulkan_command_buffer_append_dispatch_profile_events(
            sizeof(event_info.workgroup_size));
     event_info.start_tick = ticks[0];
     event_info.end_tick = ticks[1];
-    IREE_RETURN_IF_ERROR(iree_hal_local_profile_recorder_append_dispatch_event(
+    IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_append_dispatch_event(
         profile_recorder, &event_info, /*out_event_id=*/NULL));
     ++dispatch_ordinal;
   }

--- a/runtime/src/iree/hal/drivers/vulkan/command_buffer.h
+++ b/runtime/src/iree/hal/drivers/vulkan/command_buffer.h
@@ -11,8 +11,8 @@
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/vulkan/builtins.h"
 #include "iree/hal/drivers/vulkan/debug_utils.h"
+#include "iree/hal/drivers/vulkan/profile.h"
 #include "iree/hal/drivers/vulkan/util/libvulkan.h"
-#include "iree/hal/local/profile.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -129,14 +129,14 @@ iree_status_t iree_hal_vulkan_command_buffer_publish_bda_replay_data(
 // Emits executable/export metadata referenced by recorded dispatch commands.
 iree_status_t iree_hal_vulkan_command_buffer_record_profile_metadata(
     iree_hal_command_buffer_t* command_buffer,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t command_buffer_id);
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t scope, uint64_t command_buffer_id);
 
 // Counts dispatch commands that match the active profile capture filter.
 iree_status_t iree_hal_vulkan_command_buffer_count_profiled_dispatches(
     iree_hal_command_buffer_t* command_buffer,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t command_buffer_id,
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t scope, uint64_t command_buffer_id,
     uint32_t* out_dispatch_count);
 
 // Appends dispatch profile events from timestamp pairs recorded around each
@@ -148,8 +148,8 @@ iree_status_t iree_hal_vulkan_command_buffer_count_profiled_dispatches(
 // command-buffer dispatches.
 iree_status_t iree_hal_vulkan_command_buffer_append_dispatch_profile_events(
     iree_hal_command_buffer_t* command_buffer,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t submission_id,
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t scope, uint64_t submission_id,
     uint64_t command_buffer_id, const uint64_t* dispatch_ticks,
     iree_host_size_t dispatch_count);
 
@@ -191,10 +191,10 @@ typedef struct iree_hal_vulkan_command_buffer_profile_marker_t {
   uint32_t dispatch_query_count;
 
   // Profile recorder used to apply capture filters to dispatch timestamping.
-  iree_hal_local_profile_recorder_t* recorder;
+  iree_hal_vulkan_profile_recorder_t* recorder;
 
   // Queue metadata identity used to match profile capture filters.
-  iree_hal_local_profile_queue_scope_t scope;
+  iree_hal_vulkan_profile_queue_scope_t scope;
 
   // Session-local command-buffer id used to match profile capture filters.
   uint64_t command_buffer_id;

--- a/runtime/src/iree/hal/drivers/vulkan/logical_device.c
+++ b/runtime/src/iree/hal/drivers/vulkan/logical_device.c
@@ -29,10 +29,10 @@
 #include "iree/hal/drivers/vulkan/executable.h"
 #include "iree/hal/drivers/vulkan/physical_device.h"
 #include "iree/hal/drivers/vulkan/physical_device_selection.h"
+#include "iree/hal/drivers/vulkan/profile.h"
 #include "iree/hal/drivers/vulkan/queue.h"
 #include "iree/hal/drivers/vulkan/semaphore.h"
 #include "iree/hal/drivers/vulkan/syms.h"
-#include "iree/hal/local/profile.h"
 #include "iree/hal/utils/file_registry.h"
 
 //===----------------------------------------------------------------------===//
@@ -175,7 +175,7 @@ struct iree_hal_vulkan_logical_device_t {
   // Active profiling session state.
   struct {
     // Active HAL-native profile recorder, when profiling is enabled.
-    iree_hal_local_profile_recorder_t* recorder;
+    iree_hal_vulkan_profile_recorder_t* recorder;
 
     // Host time domain selected for calibrated profiling samples.
     VkTimeDomainEXT host_time_domain;
@@ -423,7 +423,7 @@ static bool iree_hal_vulkan_profile_clock_alignment_record_clock_tick(
 
 static iree_status_t iree_hal_vulkan_logical_device_write_clock_correlation(
     iree_hal_vulkan_logical_device_t* device) {
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
           device->profile.recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS |
               IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS)) {
@@ -477,16 +477,16 @@ static iree_status_t iree_hal_vulkan_logical_device_write_clock_correlation(
   record.host_system_frequency_hz = host_frequency_hz;
   record.host_time_begin_ns = host_time_begin_ns;
   record.host_time_end_ns = host_time_end_ns;
-  return iree_hal_local_profile_recorder_write_clock_correlations(
+  return iree_hal_vulkan_profile_recorder_write_clock_correlations(
       device->profile.recorder, 1, &record);
 }
 
-static iree_hal_local_profile_queue_scope_t
+static iree_hal_vulkan_profile_queue_scope_t
 iree_hal_vulkan_logical_device_profile_queue_scope(
     const iree_hal_vulkan_logical_device_t* device, uint32_t queue_ordinal) {
   const uint32_t physical_device_ordinal =
       device->topology_info.topology ? device->topology_info.topology_index : 0;
-  return (iree_hal_local_profile_queue_scope_t){
+  return (iree_hal_vulkan_profile_queue_scope_t){
       .physical_device_ordinal = physical_device_ordinal,
       .queue_ordinal = queue_ordinal,
       .stream_id = ((uint64_t)physical_device_ordinal << 32) | queue_ordinal,
@@ -1526,11 +1526,7 @@ static iree_status_t iree_hal_vulkan_logical_device_profiling_begin(
   const iree_hal_device_profiling_options_t resolved_options =
       iree_hal_vulkan_logical_device_resolve_profiling_options(options);
   const iree_hal_device_profiling_data_families_t supported_data_families =
-      IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
-      IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS |
-      IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA |
-      IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS |
-      IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS;
+      iree_hal_vulkan_profile_recorder_supported_data_families();
   const iree_hal_device_profiling_data_families_t unsupported_data_families =
       resolved_options.data_families & ~supported_data_families;
   if (unsupported_data_families != IREE_HAL_DEVICE_PROFILING_DATA_NONE) {
@@ -1586,7 +1582,7 @@ static iree_status_t iree_hal_vulkan_logical_device_profiling_begin(
   for (iree_host_size_t i = 0; i < device->queues.lane_count; ++i) {
     const uint32_t queue_ordinal =
         iree_hal_vulkan_logical_device_profile_count(i);
-    const iree_hal_local_profile_queue_scope_t scope =
+    const iree_hal_vulkan_profile_queue_scope_t scope =
         iree_hal_vulkan_logical_device_profile_queue_scope(device,
                                                            queue_ordinal);
     queue_records[i] = iree_hal_profile_queue_record_default();
@@ -1595,7 +1591,7 @@ static iree_status_t iree_hal_vulkan_logical_device_profiling_begin(
     queue_records[i].stream_id = scope.stream_id;
   }
 
-  iree_hal_local_profile_recorder_options_t recorder_options = {
+  iree_hal_vulkan_profile_recorder_options_t recorder_options = {
       .name = device->identifier,
       .session_id = ++device->profile.next_session_id,
       .device_record_count = 1,
@@ -1606,20 +1602,13 @@ static iree_status_t iree_hal_vulkan_logical_device_profiling_begin(
           IREE_HAL_VULKAN_LOGICAL_DEVICE_PROFILE_DISPATCH_EVENT_CAPACITY,
       .queue_event_capacity =
           IREE_HAL_VULKAN_LOGICAL_DEVICE_PROFILE_QUEUE_EVENT_CAPACITY,
-      .producer_data_families =
-          (dispatch_events_enabled
-               ? IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS
-               : IREE_HAL_DEVICE_PROFILING_DATA_NONE) |
-          (device_queue_events_enabled
-               ? IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS
-               : IREE_HAL_DEVICE_PROFILING_DATA_NONE),
       .queue_device_event_capacity =
           IREE_HAL_VULKAN_LOGICAL_DEVICE_PROFILE_QUEUE_DEVICE_EVENT_CAPACITY,
       .memory_event_capacity =
           IREE_HAL_VULKAN_LOGICAL_DEVICE_PROFILE_MEMORY_EVENT_CAPACITY,
   };
-  iree_hal_local_profile_recorder_t* recorder = NULL;
-  iree_status_t status = iree_hal_local_profile_recorder_create(
+  iree_hal_vulkan_profile_recorder_t* recorder = NULL;
+  iree_status_t status = iree_hal_vulkan_profile_recorder_create(
       &recorder_options, &resolved_options, device->host_allocator, &recorder);
   iree_allocator_free(device->host_allocator, queue_records);
   if (!iree_status_is_ok(status) || !recorder) return status;
@@ -1630,9 +1619,9 @@ static iree_status_t iree_hal_vulkan_logical_device_profiling_begin(
   status = iree_hal_vulkan_logical_device_write_clock_correlation(device);
   if (!iree_status_is_ok(status)) {
     device->profile.recorder = NULL;
-    status =
-        iree_status_join(status, iree_hal_local_profile_recorder_end(recorder));
-    iree_hal_local_profile_recorder_destroy(recorder);
+    status = iree_status_join(status,
+                              iree_hal_vulkan_profile_recorder_end(recorder));
+    iree_hal_vulkan_profile_recorder_destroy(recorder);
     return status;
   }
 
@@ -1658,7 +1647,7 @@ static iree_status_t iree_hal_vulkan_logical_device_profiling_flush(
   iree_status_t status =
       iree_hal_vulkan_logical_device_write_clock_correlation(device);
   if (iree_status_is_ok(status)) {
-    status = iree_hal_local_profile_recorder_flush(device->profile.recorder);
+    status = iree_hal_vulkan_profile_recorder_flush(device->profile.recorder);
   }
   return status;
 }
@@ -1667,7 +1656,7 @@ static iree_status_t iree_hal_vulkan_logical_device_profiling_end(
     iree_hal_device_t* base_device) {
   iree_hal_vulkan_logical_device_t* device =
       iree_hal_vulkan_logical_device_cast(base_device);
-  iree_hal_local_profile_recorder_t* recorder = device->profile.recorder;
+  iree_hal_vulkan_profile_recorder_t* recorder = device->profile.recorder;
   if (!recorder) return iree_ok_status();
 
   for (iree_host_size_t i = 0; i < device->queues.lane_count; ++i) {
@@ -1676,8 +1665,8 @@ static iree_status_t iree_hal_vulkan_logical_device_profiling_end(
   iree_status_t status =
       iree_hal_vulkan_logical_device_write_clock_correlation(device);
 
-  const iree_hal_local_profile_queue_scope_t empty_scope =
-      iree_hal_local_profile_queue_scope_default();
+  const iree_hal_vulkan_profile_queue_scope_t empty_scope =
+      iree_hal_vulkan_profile_queue_scope_default();
   for (iree_host_size_t i = 0; i < device->queues.lane_count; ++i) {
     iree_hal_vulkan_queue_set_profile_recorder(
         &device->queues.lanes[i], /*profile_recorder=*/NULL, empty_scope,
@@ -1690,8 +1679,8 @@ static iree_status_t iree_hal_vulkan_logical_device_profiling_end(
                     iree_memory_order_relaxed);
 
   status =
-      iree_status_join(status, iree_hal_local_profile_recorder_end(recorder));
-  iree_hal_local_profile_recorder_destroy(recorder);
+      iree_status_join(status, iree_hal_vulkan_profile_recorder_end(recorder));
+  iree_hal_vulkan_profile_recorder_destroy(recorder);
   return status;
 }
 

--- a/runtime/src/iree/hal/drivers/vulkan/profile.c
+++ b/runtime/src/iree/hal/drivers/vulkan/profile.c
@@ -1,0 +1,1371 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/vulkan/profile.h"
+
+#include <inttypes.h>
+#include <string.h>
+
+#include "iree/base/threading/mutex.h"
+#include "iree/hal/utils/profile_event_ring.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_vulkan_profile_recorder_t
+//===----------------------------------------------------------------------===//
+
+// Default number of records retained per enabled event stream between flushes.
+#define IREE_HAL_VULKAN_PROFILE_DEFAULT_EVENT_CAPACITY 4096
+
+typedef struct iree_hal_vulkan_profile_id_set_t {
+  // Open-addressed nonzero ids whose metadata was emitted.
+  uint64_t* ids;
+
+  // Power-of-two slot count in |ids|.
+  iree_host_size_t capacity;
+
+  // Number of occupied id slots.
+  iree_host_size_t count;
+} iree_hal_vulkan_profile_id_set_t;
+
+typedef struct iree_hal_vulkan_profile_dispatch_event_record_t {
+  // Queue scope used for chunk metadata when flushing the event.
+  iree_hal_vulkan_profile_queue_scope_t scope;
+
+  // Serialized dispatch event record.
+  iree_hal_profile_dispatch_event_t event;
+} iree_hal_vulkan_profile_dispatch_event_record_t;
+
+struct iree_hal_vulkan_profile_recorder_t {
+  // Host allocator used for recorder-owned storage.
+  iree_allocator_t host_allocator;
+
+  // Guards event rings while producers append and flush snapshots advance.
+  iree_slim_mutex_t mutex;
+
+  // Serializes flush operations while sink callbacks are being invoked.
+  iree_slim_mutex_t flush_mutex;
+
+  // Copied human-readable producer name used on emitted chunks.
+  iree_string_view_t name;
+
+  // Allocated storage backing |name| when the caller provided one.
+  char* name_storage;
+
+  // Owned profiling options for the active session.
+  iree_hal_device_profiling_options_t options;
+
+  // Opaque storage backing borrowed pointers in |options|, or NULL.
+  iree_hal_device_profiling_options_storage_t* options_storage;
+
+  // Process-local profiling session identifier.
+  uint64_t session_id;
+
+  // True while the sink session has begun and has not been ended.
+  bool active;
+
+  // Single allocation backing all enabled event rings.
+  void* event_storage;
+
+  // Ring of producer-owned dispatch event records.
+  iree_hal_profile_event_ring_t dispatch_event_ring;
+
+  // Ring of host queue event records.
+  iree_hal_profile_event_ring_t queue_event_ring;
+
+  // Ring of producer-owned queue device event records.
+  iree_hal_profile_event_ring_t queue_device_event_ring;
+
+  // Ring of memory lifecycle event records.
+  iree_hal_profile_event_ring_t memory_event_ring;
+
+  // Metadata ids already emitted to the session sink.
+  struct {
+    // Executable ids whose metadata was emitted.
+    iree_hal_vulkan_profile_id_set_t executables;
+
+    // Command-buffer ids whose metadata was emitted.
+    iree_hal_vulkan_profile_id_set_t command_buffers;
+  } emitted;
+};
+
+static bool iree_hal_vulkan_profile_recorder_requests_data(
+    const iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_hal_device_profiling_data_families_t data_families) {
+  return iree_hal_device_profiling_options_requests_data(&recorder->options,
+                                                         data_families);
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_validate_records(
+    const iree_hal_vulkan_profile_recorder_options_t* recorder_options) {
+  if (recorder_options->device_record_count == 0 ||
+      !recorder_options->device_records) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan profiling requires at least one device metadata record");
+  }
+  if (recorder_options->queue_record_count == 0 ||
+      !recorder_options->queue_records) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan profiling requires at least one queue metadata record");
+  }
+  for (iree_host_size_t i = 0; i < recorder_options->device_record_count; ++i) {
+    const iree_hal_profile_device_record_t* record =
+        &recorder_options->device_records[i];
+    if (record->record_length != sizeof(*record)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Vulkan profiling device metadata record %" PRIhsz
+                              " has unsupported length %" PRIu32,
+                              i, record->record_length);
+    }
+    if (record->physical_device_ordinal == UINT32_MAX ||
+        record->queue_count == 0) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Vulkan profiling device metadata record %" PRIhsz
+                              " has invalid queue identity",
+                              i);
+    }
+    if (iree_all_bits_set(record->flags,
+                          IREE_HAL_PROFILE_DEVICE_FLAG_TIMESTAMP_FREQUENCY) &&
+        record->timestamp_frequency_hz == 0) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Vulkan profiling device metadata record %" PRIhsz
+                              " advertises a zero timestamp frequency",
+                              i);
+    }
+  }
+  for (iree_host_size_t i = 0; i < recorder_options->queue_record_count; ++i) {
+    const iree_hal_profile_queue_record_t* record =
+        &recorder_options->queue_records[i];
+    if (record->record_length != sizeof(*record)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Vulkan profiling queue metadata record %" PRIhsz
+                              " has unsupported length %" PRIu32,
+                              i, record->record_length);
+    }
+    if (record->physical_device_ordinal == UINT32_MAX ||
+        record->queue_ordinal == UINT32_MAX) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Vulkan profiling queue metadata record %" PRIhsz
+                              " has invalid queue identity",
+                              i);
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t
+iree_hal_vulkan_profile_recorder_validate_profiling_options(
+    const iree_hal_device_profiling_options_t* profiling_options) {
+  if (profiling_options->flags != IREE_HAL_DEVICE_PROFILING_FLAG_NONE) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "unsupported Vulkan profiling flags 0x%x",
+                            profiling_options->flags);
+  }
+  const iree_hal_device_profiling_data_families_t unsupported_data_families =
+      profiling_options->data_families &
+      ~iree_hal_vulkan_profile_recorder_supported_data_families();
+  if (unsupported_data_families != IREE_HAL_DEVICE_PROFILING_DATA_NONE) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "unsupported Vulkan profiling data families 0x%" PRIx64,
+        unsupported_data_families);
+  }
+  if (profiling_options->data_families != IREE_HAL_DEVICE_PROFILING_DATA_NONE &&
+      !profiling_options->sink) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "Vulkan profiling with requested data families "
+                            "requires a profile sink");
+  }
+  if (profiling_options->capture_filter.reserved0 != 0) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan profiling capture filter reserved fields must be zero");
+  }
+  if (!iree_hal_profile_capture_filter_is_default(
+          &profiling_options->capture_filter)) {
+    const iree_hal_device_profiling_data_families_t unfilterable_data_families =
+        profiling_options->data_families &
+        ~(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS |
+          IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA);
+    if (!iree_hal_device_profiling_options_requests_data(
+            profiling_options,
+            IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS) ||
+        unfilterable_data_families != IREE_HAL_DEVICE_PROFILING_DATA_NONE) {
+      return iree_make_status(
+          IREE_STATUS_UNIMPLEMENTED,
+          "Vulkan profiling capture filters require dispatch events and no "
+          "unfilterable data families");
+    }
+  }
+  if (profiling_options->counter_set_count != 0 ||
+      profiling_options->counter_sets) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "Vulkan profiling does not support counter set selections");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_normalize_capacity(
+    iree_host_size_t requested_capacity, iree_host_size_t* out_capacity) {
+  iree_host_size_t capacity =
+      requested_capacity != 0 ? requested_capacity
+                              : IREE_HAL_VULKAN_PROFILE_DEFAULT_EVENT_CAPACITY;
+  capacity = iree_host_size_next_power_of_two(capacity);
+  if (IREE_UNLIKELY(!iree_host_size_is_power_of_two(capacity))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "Vulkan profiling event capacity is too large");
+  }
+  *out_capacity = capacity;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_allocate_events(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_recorder_options_t* recorder_options) {
+  iree_host_size_t dispatch_event_capacity = 0;
+  iree_host_size_t queue_event_capacity = 0;
+  iree_host_size_t queue_device_event_capacity = 0;
+  iree_host_size_t memory_event_capacity = 0;
+  if (iree_hal_vulkan_profile_recorder_requests_data(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS)) {
+    IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_normalize_capacity(
+        recorder_options->dispatch_event_capacity, &dispatch_event_capacity));
+  }
+  if (iree_hal_vulkan_profile_recorder_requests_data(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS)) {
+    IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_normalize_capacity(
+        recorder_options->queue_event_capacity, &queue_event_capacity));
+  }
+  if (iree_hal_vulkan_profile_recorder_requests_data(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS)) {
+    IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_normalize_capacity(
+        recorder_options->queue_device_event_capacity,
+        &queue_device_event_capacity));
+  }
+  if (iree_hal_vulkan_profile_recorder_requests_data(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS)) {
+    IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_normalize_capacity(
+        recorder_options->memory_event_capacity, &memory_event_capacity));
+  }
+
+  iree_host_size_t dispatch_events_offset = 0;
+  iree_host_size_t queue_events_offset = 0;
+  iree_host_size_t queue_device_events_offset = 0;
+  iree_host_size_t memory_events_offset = 0;
+  iree_host_size_t total_size = 0;
+  IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
+      0, &total_size,
+      IREE_STRUCT_FIELD_ALIGNED(
+          dispatch_event_capacity,
+          iree_hal_vulkan_profile_dispatch_event_record_t,
+          iree_alignof(iree_hal_vulkan_profile_dispatch_event_record_t),
+          &dispatch_events_offset),
+      IREE_STRUCT_FIELD_ALIGNED(
+          queue_event_capacity, iree_hal_profile_queue_event_t,
+          iree_alignof(iree_hal_profile_queue_event_t), &queue_events_offset),
+      IREE_STRUCT_FIELD_ALIGNED(
+          queue_device_event_capacity, iree_hal_profile_queue_device_event_t,
+          iree_alignof(iree_hal_profile_queue_device_event_t),
+          &queue_device_events_offset),
+      IREE_STRUCT_FIELD_ALIGNED(memory_event_capacity,
+                                iree_hal_profile_memory_event_t,
+                                iree_alignof(iree_hal_profile_memory_event_t),
+                                &memory_events_offset)));
+  if (total_size == 0) return iree_ok_status();
+
+  void* event_storage = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(recorder->host_allocator,
+                                             total_size, &event_storage));
+  memset(event_storage, 0, total_size);
+  recorder->event_storage = event_storage;
+
+  if (dispatch_event_capacity != 0) {
+    iree_hal_profile_event_ring_initialize(
+        (uint8_t*)event_storage + dispatch_events_offset,
+        sizeof(iree_hal_vulkan_profile_dispatch_event_record_t),
+        dispatch_event_capacity, &recorder->dispatch_event_ring);
+  }
+  if (queue_event_capacity != 0) {
+    iree_hal_profile_event_ring_initialize(
+        (uint8_t*)event_storage + queue_events_offset,
+        sizeof(iree_hal_profile_queue_event_t), queue_event_capacity,
+        &recorder->queue_event_ring);
+  }
+  if (queue_device_event_capacity != 0) {
+    iree_hal_profile_event_ring_initialize(
+        (uint8_t*)event_storage + queue_device_events_offset,
+        sizeof(iree_hal_profile_queue_device_event_t),
+        queue_device_event_capacity, &recorder->queue_device_event_ring);
+  }
+  if (memory_event_capacity != 0) {
+    iree_hal_profile_event_ring_initialize(
+        (uint8_t*)event_storage + memory_events_offset,
+        sizeof(iree_hal_profile_memory_event_t), memory_event_capacity,
+        &recorder->memory_event_ring);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_copy_name(
+    iree_hal_vulkan_profile_recorder_t* recorder, iree_string_view_t name) {
+  if (iree_string_view_is_empty(name)) {
+    recorder->name = IREE_SV("vulkan");
+    return iree_ok_status();
+  }
+  IREE_RETURN_IF_ERROR(iree_allocator_clone(
+      recorder->host_allocator, iree_make_const_byte_span(name.data, name.size),
+      (void**)&recorder->name_storage));
+  recorder->name = iree_make_string_view(recorder->name_storage, name.size);
+  return iree_ok_status();
+}
+
+static iree_hal_profile_chunk_metadata_t
+iree_hal_vulkan_profile_recorder_metadata(
+    const iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_string_view_t content_type) {
+  iree_hal_profile_chunk_metadata_t metadata =
+      iree_hal_profile_chunk_metadata_default();
+  metadata.content_type = content_type;
+  metadata.name = recorder->name;
+  metadata.session_id = recorder->session_id;
+  return metadata;
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_write_records(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_string_view_t content_type, const void* records,
+    iree_host_size_t record_count, iree_host_size_t record_size) {
+  if (record_count == 0) return iree_ok_status();
+  iree_host_size_t byte_length = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(record_count, record_size,
+                                                &byte_length))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "Vulkan profiling chunk size overflow for %" PRIhsz
+                            " records",
+                            record_count);
+  }
+  iree_hal_profile_chunk_metadata_t metadata =
+      iree_hal_vulkan_profile_recorder_metadata(recorder, content_type);
+  iree_const_byte_span_t iovec =
+      iree_make_const_byte_span(records, byte_length);
+  return iree_hal_profile_sink_write(recorder->options.sink, &metadata, 1,
+                                     &iovec);
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_write_metadata(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_recorder_options_t* recorder_options) {
+  IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_write_records(
+      recorder, IREE_HAL_PROFILE_CONTENT_TYPE_DEVICES,
+      recorder_options->device_records, recorder_options->device_record_count,
+      sizeof(*recorder_options->device_records)));
+  return iree_hal_vulkan_profile_recorder_write_records(
+      recorder, IREE_HAL_PROFILE_CONTENT_TYPE_QUEUES,
+      recorder_options->queue_records, recorder_options->queue_record_count,
+      sizeof(*recorder_options->queue_records));
+}
+
+iree_status_t iree_hal_vulkan_profile_recorder_create(
+    const iree_hal_vulkan_profile_recorder_options_t* recorder_options,
+    const iree_hal_device_profiling_options_t* profiling_options,
+    iree_allocator_t host_allocator,
+    iree_hal_vulkan_profile_recorder_t** out_recorder) {
+  IREE_ASSERT_ARGUMENT(recorder_options);
+  IREE_ASSERT_ARGUMENT(profiling_options);
+  IREE_ASSERT_ARGUMENT(out_recorder);
+  *out_recorder = NULL;
+
+  iree_hal_device_profiling_options_t resolved_options = *profiling_options;
+  if (resolved_options.data_families == IREE_HAL_DEVICE_PROFILING_DATA_NONE) {
+    return iree_ok_status();
+  }
+
+  IREE_RETURN_IF_ERROR(
+      iree_hal_vulkan_profile_recorder_validate_profiling_options(
+          &resolved_options));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_vulkan_profile_recorder_validate_records(recorder_options));
+
+  iree_hal_vulkan_profile_recorder_t* recorder = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(host_allocator, sizeof(*recorder),
+                                             (void**)&recorder));
+  memset(recorder, 0, sizeof(*recorder));
+  recorder->host_allocator = host_allocator;
+  recorder->session_id = recorder_options->session_id;
+  iree_slim_mutex_initialize(&recorder->mutex);
+  iree_slim_mutex_initialize(&recorder->flush_mutex);
+
+  bool sink_session_begun = false;
+  iree_status_t status = iree_hal_vulkan_profile_recorder_copy_name(
+      recorder, recorder_options->name);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_device_profiling_options_clone(
+        &resolved_options, host_allocator, &recorder->options,
+        &recorder->options_storage);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_vulkan_profile_recorder_allocate_events(recorder,
+                                                              recorder_options);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_profile_chunk_metadata_t metadata =
+        iree_hal_vulkan_profile_recorder_metadata(
+            recorder, IREE_HAL_PROFILE_CONTENT_TYPE_SESSION);
+    status =
+        iree_hal_profile_sink_begin_session(recorder->options.sink, &metadata);
+    sink_session_begun = iree_status_is_ok(status);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_vulkan_profile_recorder_write_metadata(recorder,
+                                                             recorder_options);
+  }
+
+  if (iree_status_is_ok(status)) {
+    recorder->active = true;
+    *out_recorder = recorder;
+  } else {
+    if (sink_session_begun) {
+      iree_hal_profile_chunk_metadata_t metadata =
+          iree_hal_vulkan_profile_recorder_metadata(
+              recorder, IREE_HAL_PROFILE_CONTENT_TYPE_SESSION);
+      iree_status_code_t status_code = iree_status_code(status);
+      status = iree_status_join(
+          status, iree_hal_profile_sink_end_session(recorder->options.sink,
+                                                    &metadata, status_code));
+    }
+    iree_hal_vulkan_profile_recorder_destroy(recorder);
+  }
+  return status;
+}
+
+void iree_hal_vulkan_profile_recorder_destroy(
+    iree_hal_vulkan_profile_recorder_t* recorder) {
+  if (!recorder) return;
+  IREE_ASSERT(!recorder->active,
+              "active Vulkan profile recorders must be ended before destroy");
+  iree_allocator_t host_allocator = recorder->host_allocator;
+  iree_allocator_free(host_allocator, recorder->event_storage);
+  iree_allocator_free(host_allocator, recorder->emitted.executables.ids);
+  iree_allocator_free(host_allocator, recorder->emitted.command_buffers.ids);
+  iree_hal_device_profiling_options_storage_free(recorder->options_storage,
+                                                 host_allocator);
+  iree_allocator_free(host_allocator, recorder->name_storage);
+  iree_slim_mutex_deinitialize(&recorder->flush_mutex);
+  iree_slim_mutex_deinitialize(&recorder->mutex);
+  iree_allocator_free(host_allocator, recorder);
+}
+
+bool iree_hal_vulkan_profile_recorder_is_enabled(
+    const iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_hal_device_profiling_data_families_t data_families) {
+  return recorder && recorder->active &&
+         iree_hal_device_profiling_options_requests_data(&recorder->options,
+                                                         data_families);
+}
+
+const iree_hal_device_profiling_options_t*
+iree_hal_vulkan_profile_recorder_options(
+    const iree_hal_vulkan_profile_recorder_t* recorder) {
+  return recorder && recorder->active ? &recorder->options : NULL;
+}
+
+static iree_host_size_t iree_hal_vulkan_profile_hash_id(
+    uint64_t id, iree_host_size_t capacity) {
+  id ^= id >> 33;
+  id *= 0xff51afd7ed558ccdull;
+  id ^= id >> 33;
+  id *= 0xc4ceb9fe1a85ec53ull;
+  id ^= id >> 33;
+  return (iree_host_size_t)id & (capacity - 1);
+}
+
+static bool iree_hal_vulkan_profile_id_set_find_slot(
+    const iree_hal_vulkan_profile_id_set_t* set, uint64_t id,
+    iree_host_size_t* out_slot) {
+  IREE_ASSERT(set->capacity != 0);
+  iree_host_size_t slot = iree_hal_vulkan_profile_hash_id(id, set->capacity);
+  while (set->ids[slot] != 0) {
+    if (set->ids[slot] == id) {
+      *out_slot = slot;
+      return true;
+    }
+    slot = (slot + 1) & (set->capacity - 1);
+  }
+  *out_slot = slot;
+  return false;
+}
+
+static iree_status_t iree_hal_vulkan_profile_id_set_reserve(
+    iree_allocator_t host_allocator, iree_hal_vulkan_profile_id_set_t* set,
+    iree_host_size_t minimum_capacity, const char* label) {
+  if (IREE_UNLIKELY(minimum_capacity > IREE_HOST_SIZE_MAX / 2)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "Vulkan profiling %s metadata set is too large",
+                            label);
+  }
+  const iree_host_size_t required_capacity = minimum_capacity * 2;
+  iree_host_size_t capacity = set->capacity;
+  if (required_capacity <= capacity) return iree_ok_status();
+  capacity = capacity != 0 ? capacity : 16;
+  while (required_capacity > capacity) {
+    if (IREE_UNLIKELY(capacity > IREE_HOST_SIZE_MAX / 2)) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "Vulkan profiling %s metadata set is too large",
+                              label);
+    }
+    capacity *= 2;
+  }
+
+  iree_host_size_t byte_length = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(capacity, sizeof(*set->ids),
+                                                &byte_length))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "Vulkan profiling %s metadata set size overflow",
+                            label);
+  }
+  uint64_t* ids = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(host_allocator, byte_length, (void**)&ids));
+  memset(ids, 0, byte_length);
+  iree_hal_vulkan_profile_id_set_t new_set = {
+      .ids = ids,
+      .capacity = capacity,
+  };
+  for (iree_host_size_t i = 0; i < set->capacity; ++i) {
+    const uint64_t id = set->ids[i];
+    if (id == 0) continue;
+    iree_host_size_t slot = 0;
+    iree_hal_vulkan_profile_id_set_find_slot(&new_set, id, &slot);
+    ids[slot] = id;
+  }
+  new_set.count = set->count;
+
+  iree_allocator_free(host_allocator, set->ids);
+  *set = new_set;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_mark_id_emitted(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_hal_vulkan_profile_id_set_t* set, uint64_t id, const char* label,
+    bool* out_should_emit) {
+  *out_should_emit = false;
+
+  iree_slim_mutex_lock(&recorder->mutex);
+  iree_status_t status = iree_hal_vulkan_profile_id_set_reserve(
+      recorder->host_allocator, set, set->count + 1, label);
+  if (iree_status_is_ok(status)) {
+    iree_host_size_t slot = 0;
+    const bool already_emitted =
+        iree_hal_vulkan_profile_id_set_find_slot(set, id, &slot);
+    if (!already_emitted) {
+      set->ids[slot] = id;
+      ++set->count;
+      *out_should_emit = true;
+    }
+  }
+  iree_slim_mutex_unlock(&recorder->mutex);
+  return status;
+}
+
+static bool iree_hal_vulkan_profile_recorder_has_emitted_id(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_id_set_t* set, uint64_t id) {
+  iree_slim_mutex_lock(&recorder->mutex);
+  bool has_emitted = false;
+  if (set->capacity != 0) {
+    iree_host_size_t slot = 0;
+    has_emitted = iree_hal_vulkan_profile_id_set_find_slot(set, id, &slot);
+  }
+  iree_slim_mutex_unlock(&recorder->mutex);
+  return has_emitted;
+}
+
+static iree_status_t iree_hal_vulkan_profile_executable_function_record_length(
+    iree_string_view_t name, iree_host_size_t* out_record_length) {
+  *out_record_length = 0;
+  if (IREE_UNLIKELY(name.size > UINT32_MAX)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "profile executable function name is too long");
+  }
+  iree_host_size_t record_length = 0;
+  IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
+      sizeof(iree_hal_profile_executable_function_record_t), &record_length,
+      IREE_STRUCT_FIELD(name.size, uint8_t, NULL)));
+  if (IREE_UNLIKELY(record_length > UINT32_MAX)) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "profile executable function record length exceeds uint32_t");
+  }
+  *out_record_length = record_length;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_vulkan_profile_executable_function_data_length(
+    iree_hal_executable_t* executable, iree_host_size_t function_count,
+    iree_host_size_t* out_data_length) {
+  *out_data_length = 0;
+  iree_host_size_t data_length = 0;
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = 0; i < function_count && iree_status_is_ok(status);
+       ++i) {
+    iree_hal_executable_function_info_t function_info = {0};
+    status = iree_hal_executable_function_info(
+        executable, iree_hal_executable_function_from_index((uint32_t)i),
+        &function_info);
+    iree_host_size_t record_length = 0;
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_vulkan_profile_executable_function_record_length(
+          function_info.name, &record_length);
+    }
+    if (iree_status_is_ok(status) &&
+        IREE_UNLIKELY(!iree_host_size_checked_add(data_length, record_length,
+                                                  &data_length))) {
+      status = iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "profile executable function metadata length overflow");
+    }
+  }
+  if (iree_status_is_ok(status)) *out_data_length = data_length;
+  return status;
+}
+
+static iree_status_t iree_hal_vulkan_profile_append_executable_function_records(
+    uint64_t executable_id, iree_hal_executable_t* executable,
+    iree_host_size_t function_count, uint8_t* target_data) {
+  uint8_t* cursor = target_data;
+  for (iree_host_size_t i = 0; i < function_count; ++i) {
+    iree_hal_executable_function_info_t function_info = {0};
+    IREE_RETURN_IF_ERROR(iree_hal_executable_function_info(
+        executable, iree_hal_executable_function_from_index((uint32_t)i),
+        &function_info));
+
+    iree_host_size_t record_length = 0;
+    IREE_RETURN_IF_ERROR(
+        iree_hal_vulkan_profile_executable_function_record_length(
+            function_info.name, &record_length));
+
+    iree_hal_profile_executable_function_record_t record =
+        iree_hal_profile_executable_function_record_default();
+    record.record_length = (uint32_t)record_length;
+    record.executable_id = executable_id;
+    record.function_ordinal = (uint32_t)i;
+    record.constant_byte_length = function_info.constant_byte_length;
+    record.binding_count = function_info.binding_count;
+    record.parameter_count = function_info.parameter_count;
+    memcpy(record.workgroup_size, function_info.workgroup_size,
+           sizeof(record.workgroup_size));
+    record.name_length = (uint32_t)function_info.name.size;
+
+    memcpy(cursor, &record, sizeof(record));
+    if (function_info.name.size > 0) {
+      memcpy(cursor + sizeof(record), function_info.name.data,
+             function_info.name.size);
+    }
+    cursor += record_length;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_write_span(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_string_view_t content_type, iree_const_byte_span_t span) {
+  if (span.data_length == 0) return iree_ok_status();
+  iree_hal_profile_chunk_metadata_t metadata =
+      iree_hal_vulkan_profile_recorder_metadata(recorder, content_type);
+  return iree_hal_profile_sink_write(recorder->options.sink, &metadata, 1,
+                                     &span);
+}
+
+iree_status_t iree_hal_vulkan_profile_recorder_record_executable(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_hal_executable_t* executable, uint64_t executable_id) {
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA)) {
+    return iree_ok_status();
+  }
+  if (IREE_UNLIKELY(executable_id == 0)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan profiling executable metadata requires a nonzero id");
+  }
+
+  if (iree_hal_vulkan_profile_recorder_has_emitted_id(
+          recorder, &recorder->emitted.executables, executable_id)) {
+    return iree_ok_status();
+  }
+
+  const iree_host_size_t function_count =
+      iree_hal_executable_function_count(executable);
+  if (IREE_UNLIKELY(function_count > UINT32_MAX)) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "profile executable function count exceeds uint32_t");
+  }
+
+  iree_hal_profile_executable_record_t executable_record =
+      iree_hal_profile_executable_record_default();
+  executable_record.executable_id = executable_id;
+  executable_record.function_count = (uint32_t)function_count;
+
+  iree_host_size_t function_data_length = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_executable_function_data_length(
+      executable, function_count, &function_data_length));
+  uint8_t* function_data = NULL;
+  iree_status_t status = iree_ok_status();
+  if (function_data_length != 0) {
+    status = iree_allocator_malloc(
+        recorder->host_allocator, function_data_length, (void**)&function_data);
+  }
+  if (iree_status_is_ok(status) && function_data_length != 0) {
+    status = iree_hal_vulkan_profile_append_executable_function_records(
+        executable_id, executable, function_count, function_data);
+  }
+
+  bool should_emit = false;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_vulkan_profile_recorder_mark_id_emitted(
+        recorder, &recorder->emitted.executables, executable_id, "executable",
+        &should_emit);
+  }
+  if (iree_status_is_ok(status) && should_emit) {
+    status = iree_hal_vulkan_profile_recorder_write_records(
+        recorder, IREE_HAL_PROFILE_CONTENT_TYPE_EXECUTABLES, &executable_record,
+        /*record_count=*/1, sizeof(executable_record));
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_vulkan_profile_recorder_write_span(
+        recorder, IREE_HAL_PROFILE_CONTENT_TYPE_EXECUTABLE_FUNCTIONS,
+        should_emit
+            ? iree_make_const_byte_span(function_data, function_data_length)
+            : iree_const_byte_span_empty());
+  }
+  iree_allocator_free(recorder->host_allocator, function_data);
+  return status;
+}
+
+iree_status_t iree_hal_vulkan_profile_recorder_record_command_buffer(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_profile_command_buffer_record_t* command_buffer,
+    iree_host_size_t operation_count,
+    const iree_hal_profile_command_operation_record_t* operations) {
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA)) {
+    return iree_ok_status();
+  }
+  if (IREE_UNLIKELY(!command_buffer ||
+                    command_buffer->command_buffer_id == 0)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan profiling command-buffer metadata requires a nonzero id");
+  }
+  if (IREE_UNLIKELY(operation_count != 0 && !operations)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan profiling command-buffer operation records are required");
+  }
+
+  bool should_emit = false;
+  IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_mark_id_emitted(
+      recorder, &recorder->emitted.command_buffers,
+      command_buffer->command_buffer_id, "command-buffer", &should_emit));
+  if (!should_emit) return iree_ok_status();
+
+  IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_write_records(
+      recorder, IREE_HAL_PROFILE_CONTENT_TYPE_COMMAND_BUFFERS, command_buffer,
+      /*record_count=*/1, sizeof(*command_buffer)));
+  return iree_hal_vulkan_profile_recorder_write_records(
+      recorder, IREE_HAL_PROFILE_CONTENT_TYPE_COMMAND_OPERATIONS, operations,
+      operation_count, sizeof(*operations));
+}
+
+static bool iree_hal_vulkan_profile_queue_scope_is_valid(
+    const iree_hal_vulkan_profile_queue_scope_t* scope) {
+  return scope->physical_device_ordinal != UINT32_MAX &&
+         scope->queue_ordinal != UINT32_MAX;
+}
+
+static iree_hal_profile_queue_event_t* iree_hal_vulkan_profile_queue_event_at(
+    const iree_hal_profile_event_ring_t* ring, uint64_t position) {
+  return (iree_hal_profile_queue_event_t*)iree_hal_profile_event_ring_record_at(
+      ring, position);
+}
+
+static iree_hal_vulkan_profile_dispatch_event_record_t*
+iree_hal_vulkan_profile_dispatch_event_at(
+    const iree_hal_profile_event_ring_t* ring, uint64_t position) {
+  return (iree_hal_vulkan_profile_dispatch_event_record_t*)
+      iree_hal_profile_event_ring_record_at(ring, position);
+}
+
+static iree_hal_profile_queue_device_event_t*
+iree_hal_vulkan_profile_queue_device_event_at(
+    const iree_hal_profile_event_ring_t* ring, uint64_t position) {
+  return (iree_hal_profile_queue_device_event_t*)
+      iree_hal_profile_event_ring_record_at(ring, position);
+}
+
+static iree_hal_profile_memory_event_t* iree_hal_vulkan_profile_memory_event_at(
+    const iree_hal_profile_event_ring_t* ring, uint64_t position) {
+  return (iree_hal_profile_memory_event_t*)
+      iree_hal_profile_event_ring_record_at(ring, position);
+}
+
+iree_status_t iree_hal_vulkan_profile_recorder_append_dispatch_event(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_dispatch_event_info_t* event_info,
+    uint64_t* out_event_id) {
+  IREE_ASSERT_ARGUMENT(event_info);
+  if (out_event_id) *out_event_id = 0;
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS)) {
+    return iree_ok_status();
+  }
+  const bool is_valid =
+      iree_hal_vulkan_profile_queue_scope_is_valid(&event_info->scope) &&
+      event_info->executable_id != 0 &&
+      event_info->function_ordinal != UINT32_MAX &&
+      event_info->workgroup_size[0] != 0 &&
+      event_info->start_tick <= event_info->end_tick;
+  IREE_ASSERT(is_valid);
+  if (IREE_UNLIKELY(!is_valid)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan profiling dispatch event has invalid identity, workgroup size, "
+        "or timestamp range");
+  }
+
+  iree_hal_profile_event_ring_t* ring = &recorder->dispatch_event_ring;
+  uint64_t event_position = 0;
+  uint64_t event_id = 0;
+  while (true) {
+    iree_slim_mutex_lock(&recorder->mutex);
+    const iree_host_size_t available_capacity =
+        iree_hal_profile_event_ring_available_capacity(ring);
+    if (available_capacity != 0) {
+      const bool appended = iree_hal_profile_event_ring_try_append(
+          ring, &event_position, &event_id);
+      IREE_ASSERT(appended);
+      if (IREE_LIKELY(appended)) break;
+    }
+    const bool ring_is_enabled = ring->records && ring->capacity != 0;
+    iree_slim_mutex_unlock(&recorder->mutex);
+    if (IREE_UNLIKELY(!ring_is_enabled)) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "Vulkan profiling dispatch event ring is unavailable");
+    }
+    IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_flush(recorder));
+  }
+
+  iree_hal_vulkan_profile_dispatch_event_record_t* record =
+      iree_hal_vulkan_profile_dispatch_event_at(ring, event_position);
+  record->scope = event_info->scope;
+  record->event = iree_hal_profile_dispatch_event_default();
+  record->event.flags = event_info->flags;
+  record->event.event_id = event_id;
+  record->event.submission_id = event_info->submission_id;
+  record->event.command_buffer_id = event_info->command_buffer_id;
+  record->event.executable_id = event_info->executable_id;
+  record->event.command_index = event_info->command_index;
+  record->event.function_ordinal = event_info->function_ordinal;
+  memcpy(record->event.workgroup_count, event_info->workgroup_count,
+         sizeof(record->event.workgroup_count));
+  memcpy(record->event.workgroup_size, event_info->workgroup_size,
+         sizeof(record->event.workgroup_size));
+  record->event.start_tick = event_info->start_tick;
+  record->event.end_tick = event_info->end_tick;
+  if (out_event_id) *out_event_id = event_id;
+  iree_slim_mutex_unlock(&recorder->mutex);
+  return iree_ok_status();
+}
+
+void iree_hal_vulkan_profile_recorder_append_queue_event(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_queue_event_info_t* event_info,
+    uint64_t* out_event_id) {
+  IREE_ASSERT_ARGUMENT(event_info);
+  if (out_event_id) *out_event_id = 0;
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS)) {
+    return;
+  }
+  const bool is_valid =
+      iree_hal_vulkan_profile_queue_scope_is_valid(&event_info->scope) &&
+      event_info->type != IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_NONE;
+  IREE_ASSERT(is_valid);
+  if (IREE_UNLIKELY(!is_valid)) return;
+
+  iree_hal_profile_event_ring_t* ring = &recorder->queue_event_ring;
+  iree_slim_mutex_lock(&recorder->mutex);
+  uint64_t event_position = 0;
+  uint64_t event_id = 0;
+  if (!iree_hal_profile_event_ring_try_append(ring, &event_position,
+                                              &event_id)) {
+    iree_slim_mutex_unlock(&recorder->mutex);
+    return;
+  }
+
+  iree_hal_profile_queue_event_t* event =
+      iree_hal_vulkan_profile_queue_event_at(ring, event_position);
+  *event = iree_hal_profile_queue_event_default();
+  event->type = event_info->type;
+  event->flags = event_info->flags;
+  event->dependency_strategy = event_info->dependency_strategy;
+  event->event_id = event_id;
+  event->host_time_ns = event_info->host_time_ns != 0 ? event_info->host_time_ns
+                                                      : iree_time_now();
+  event->ready_host_time_ns = event_info->ready_host_time_ns;
+  event->submission_id = event_info->submission_id;
+  event->command_buffer_id = event_info->command_buffer_id;
+  event->allocation_id = event_info->allocation_id;
+  event->stream_id = event_info->scope.stream_id;
+  event->physical_device_ordinal = event_info->scope.physical_device_ordinal;
+  event->queue_ordinal = event_info->scope.queue_ordinal;
+  event->wait_count = event_info->wait_count;
+  event->signal_count = event_info->signal_count;
+  event->barrier_count = event_info->barrier_count;
+  event->operation_count = event_info->operation_count;
+  event->payload_length = event_info->payload_length;
+  if (out_event_id) *out_event_id = event_id;
+  iree_slim_mutex_unlock(&recorder->mutex);
+}
+
+iree_status_t iree_hal_vulkan_profile_recorder_append_queue_device_event(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_queue_device_event_info_t* event_info,
+    uint64_t* out_event_id) {
+  IREE_ASSERT_ARGUMENT(event_info);
+  if (out_event_id) *out_event_id = 0;
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS)) {
+    return iree_ok_status();
+  }
+  const bool is_valid =
+      iree_hal_vulkan_profile_queue_scope_is_valid(&event_info->scope) &&
+      event_info->type != IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_NONE &&
+      event_info->start_tick <= event_info->end_tick;
+  IREE_ASSERT(is_valid);
+  if (IREE_UNLIKELY(!is_valid)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan profiling queue device event has invalid identity or timestamp "
+        "range");
+  }
+
+  iree_hal_profile_event_ring_t* ring = &recorder->queue_device_event_ring;
+  uint64_t event_position = 0;
+  uint64_t event_id = 0;
+  while (true) {
+    iree_slim_mutex_lock(&recorder->mutex);
+    const iree_host_size_t available_capacity =
+        iree_hal_profile_event_ring_available_capacity(ring);
+    if (available_capacity != 0) {
+      const bool appended = iree_hal_profile_event_ring_try_append(
+          ring, &event_position, &event_id);
+      IREE_ASSERT(appended);
+      if (IREE_LIKELY(appended)) break;
+    }
+    const bool ring_is_enabled = ring->records && ring->capacity != 0;
+    iree_slim_mutex_unlock(&recorder->mutex);
+    if (IREE_UNLIKELY(!ring_is_enabled)) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "Vulkan profiling queue device event ring is unavailable");
+    }
+    IREE_RETURN_IF_ERROR(iree_hal_vulkan_profile_recorder_flush(recorder));
+  }
+
+  iree_hal_profile_queue_device_event_t* event =
+      iree_hal_vulkan_profile_queue_device_event_at(ring, event_position);
+  *event = iree_hal_profile_queue_device_event_default();
+  event->type = event_info->type;
+  event->flags = event_info->flags;
+  event->event_id = event_id;
+  event->submission_id = event_info->submission_id;
+  event->command_buffer_id = event_info->command_buffer_id;
+  event->allocation_id = event_info->allocation_id;
+  event->stream_id = event_info->scope.stream_id;
+  event->payload_length = event_info->payload_length;
+  event->physical_device_ordinal = event_info->scope.physical_device_ordinal;
+  event->queue_ordinal = event_info->scope.queue_ordinal;
+  event->operation_count = event_info->operation_count;
+  event->start_tick = event_info->start_tick;
+  event->end_tick = event_info->end_tick;
+  if (out_event_id) *out_event_id = event_id;
+  iree_slim_mutex_unlock(&recorder->mutex);
+  return iree_ok_status();
+}
+
+static bool iree_hal_vulkan_profile_memory_event_is_valid(
+    const iree_hal_profile_memory_event_t* event) {
+  if (event->type == IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_NONE) return false;
+  if (event->physical_device_ordinal == UINT32_MAX) return false;
+  if (iree_all_bits_set(event->flags,
+                        IREE_HAL_PROFILE_MEMORY_EVENT_FLAG_QUEUE_OPERATION) &&
+      event->queue_ordinal == UINT32_MAX) {
+    return false;
+  }
+  return true;
+}
+
+void iree_hal_vulkan_profile_recorder_append_memory_event(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_profile_memory_event_t* event, uint64_t* out_event_id) {
+  IREE_ASSERT_ARGUMENT(event);
+  if (out_event_id) *out_event_id = 0;
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
+          recorder, IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS)) {
+    return;
+  }
+  const bool is_valid = iree_hal_vulkan_profile_memory_event_is_valid(event);
+  IREE_ASSERT(is_valid);
+  if (IREE_UNLIKELY(!is_valid)) return;
+
+  iree_hal_profile_event_ring_t* ring = &recorder->memory_event_ring;
+  iree_slim_mutex_lock(&recorder->mutex);
+  uint64_t event_position = 0;
+  uint64_t event_id = 0;
+  if (!iree_hal_profile_event_ring_try_append(ring, &event_position,
+                                              &event_id)) {
+    iree_slim_mutex_unlock(&recorder->mutex);
+    return;
+  }
+
+  iree_hal_profile_memory_event_t* record =
+      iree_hal_vulkan_profile_memory_event_at(ring, event_position);
+  *record = *event;
+  record->record_length = sizeof(*record);
+  record->event_id = event_id;
+  if (record->host_time_ns == 0) {
+    record->host_time_ns = iree_time_now();
+  }
+  if (out_event_id) *out_event_id = event_id;
+  iree_slim_mutex_unlock(&recorder->mutex);
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_write_event_ring(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_string_view_t content_type, iree_hal_profile_event_ring_t* ring) {
+  iree_hal_profile_event_ring_snapshot_t snapshot;
+  iree_slim_mutex_lock(&recorder->mutex);
+  iree_status_t status = iree_hal_profile_event_ring_snapshot(ring, &snapshot);
+  iree_slim_mutex_unlock(&recorder->mutex);
+  IREE_RETURN_IF_ERROR(status);
+
+  if (snapshot.record_count == 0 && snapshot.dropped_record_count == 0) {
+    return iree_ok_status();
+  }
+
+  iree_hal_profile_chunk_metadata_t metadata =
+      iree_hal_vulkan_profile_recorder_metadata(recorder, content_type);
+  if (snapshot.dropped_record_count != 0) {
+    metadata.flags |= IREE_HAL_PROFILE_CHUNK_FLAG_TRUNCATED;
+    metadata.dropped_record_count = snapshot.dropped_record_count;
+  }
+  IREE_RETURN_IF_ERROR(iree_hal_profile_sink_write(
+      recorder->options.sink, &metadata, snapshot.record_span_count,
+      snapshot.record_span_count ? snapshot.record_spans : NULL));
+
+  iree_slim_mutex_lock(&recorder->mutex);
+  iree_hal_profile_event_ring_commit_snapshot(ring, &snapshot);
+  iree_slim_mutex_unlock(&recorder->mutex);
+  return iree_ok_status();
+}
+
+static bool iree_hal_vulkan_profile_dispatch_events_have_same_scope(
+    const iree_hal_vulkan_profile_dispatch_event_record_t* lhs,
+    const iree_hal_vulkan_profile_dispatch_event_record_t* rhs) {
+  return lhs->scope.stream_id == rhs->scope.stream_id &&
+         lhs->scope.physical_device_ordinal ==
+             rhs->scope.physical_device_ordinal &&
+         lhs->scope.queue_ordinal == rhs->scope.queue_ordinal;
+}
+
+static iree_hal_profile_chunk_metadata_t
+iree_hal_vulkan_profile_recorder_dispatch_event_metadata(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_dispatch_event_record_t* record,
+    uint64_t dropped_record_count) {
+  iree_hal_profile_chunk_metadata_t metadata =
+      iree_hal_vulkan_profile_recorder_metadata(
+          recorder, IREE_HAL_PROFILE_CONTENT_TYPE_DISPATCH_EVENTS);
+  if (record) {
+    metadata.stream_id = record->scope.stream_id;
+    metadata.physical_device_ordinal = record->scope.physical_device_ordinal;
+    metadata.queue_ordinal = record->scope.queue_ordinal;
+  }
+  if (dropped_record_count != 0) {
+    metadata.flags |= IREE_HAL_PROFILE_CHUNK_FLAG_TRUNCATED;
+    metadata.dropped_record_count = dropped_record_count;
+  }
+  return metadata;
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_write_dispatch_event_run(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_dispatch_event_record_t* records,
+    iree_host_size_t record_count, uint64_t dropped_record_count) {
+  if (record_count == 0 && dropped_record_count == 0) return iree_ok_status();
+  const iree_hal_vulkan_profile_dispatch_event_record_t* first_record =
+      record_count != 0 ? records : NULL;
+  iree_hal_profile_chunk_metadata_t metadata =
+      iree_hal_vulkan_profile_recorder_dispatch_event_metadata(
+          recorder, first_record, dropped_record_count);
+  if (record_count == 0) {
+    return iree_hal_profile_sink_write(recorder->options.sink, &metadata,
+                                       /*iovec_count=*/0, /*iovecs=*/NULL);
+  }
+
+  iree_hal_profile_dispatch_event_t* events = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc_array(recorder->host_allocator, record_count,
+                                  sizeof(*events), (void**)&events));
+  for (iree_host_size_t i = 0; i < record_count; ++i) {
+    events[i] = records[i].event;
+  }
+  iree_const_byte_span_t iovec =
+      iree_make_const_byte_span(events, record_count * sizeof(*events));
+  iree_status_t status = iree_hal_profile_sink_write(
+      recorder->options.sink, &metadata, /*iovec_count=*/1, &iovec);
+  iree_allocator_free(recorder->host_allocator, events);
+  return status;
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_write_dispatch_event_span(
+    iree_hal_vulkan_profile_recorder_t* recorder, iree_const_byte_span_t span,
+    uint64_t* remaining_dropped_record_count) {
+  IREE_ASSERT(span.data_length %
+                  sizeof(iree_hal_vulkan_profile_dispatch_event_record_t) ==
+              0);
+  const iree_hal_vulkan_profile_dispatch_event_record_t* records =
+      (const iree_hal_vulkan_profile_dispatch_event_record_t*)span.data;
+  const iree_host_size_t record_count =
+      span.data_length /
+      sizeof(iree_hal_vulkan_profile_dispatch_event_record_t);
+  iree_host_size_t run_start = 0;
+  iree_status_t status = iree_ok_status();
+  while (iree_status_is_ok(status) && run_start < record_count) {
+    iree_host_size_t run_end = run_start + 1;
+    while (run_end < record_count &&
+           iree_hal_vulkan_profile_dispatch_events_have_same_scope(
+               &records[run_start], &records[run_end])) {
+      ++run_end;
+    }
+    const uint64_t run_dropped_record_count = *remaining_dropped_record_count;
+    *remaining_dropped_record_count = 0;
+    status = iree_hal_vulkan_profile_recorder_write_dispatch_event_run(
+        recorder, &records[run_start], run_end - run_start,
+        run_dropped_record_count);
+    run_start = run_end;
+  }
+  return status;
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_write_dispatch_event_ring(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_hal_profile_event_ring_t* ring) {
+  iree_hal_profile_event_ring_snapshot_t snapshot;
+  iree_slim_mutex_lock(&recorder->mutex);
+  iree_status_t status = iree_hal_profile_event_ring_snapshot(ring, &snapshot);
+  iree_slim_mutex_unlock(&recorder->mutex);
+  IREE_RETURN_IF_ERROR(status);
+
+  if (snapshot.record_count == 0 && snapshot.dropped_record_count == 0) {
+    return iree_ok_status();
+  }
+
+  uint64_t remaining_dropped_record_count = snapshot.dropped_record_count;
+  for (iree_host_size_t i = 0;
+       i < snapshot.record_span_count && iree_status_is_ok(status); ++i) {
+    status = iree_hal_vulkan_profile_recorder_write_dispatch_event_span(
+        recorder, snapshot.record_spans[i], &remaining_dropped_record_count);
+  }
+  if (iree_status_is_ok(status) && remaining_dropped_record_count != 0) {
+    status = iree_hal_vulkan_profile_recorder_write_dispatch_event_run(
+        recorder, /*records=*/NULL, /*record_count=*/0,
+        remaining_dropped_record_count);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&recorder->mutex);
+    iree_hal_profile_event_ring_commit_snapshot(ring, &snapshot);
+    iree_slim_mutex_unlock(&recorder->mutex);
+  }
+  return status;
+}
+
+static bool iree_hal_vulkan_profile_queue_device_events_have_same_scope(
+    const iree_hal_profile_queue_device_event_t* lhs,
+    const iree_hal_profile_queue_device_event_t* rhs) {
+  return lhs->stream_id == rhs->stream_id &&
+         lhs->physical_device_ordinal == rhs->physical_device_ordinal &&
+         lhs->queue_ordinal == rhs->queue_ordinal;
+}
+
+static iree_hal_profile_chunk_metadata_t
+iree_hal_vulkan_profile_recorder_queue_device_event_metadata(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_profile_queue_device_event_t* event,
+    uint64_t dropped_record_count) {
+  iree_hal_profile_chunk_metadata_t metadata =
+      iree_hal_vulkan_profile_recorder_metadata(
+          recorder, IREE_HAL_PROFILE_CONTENT_TYPE_QUEUE_DEVICE_EVENTS);
+  if (event) {
+    metadata.stream_id = event->stream_id;
+    metadata.physical_device_ordinal = event->physical_device_ordinal;
+    metadata.queue_ordinal = event->queue_ordinal;
+  }
+  if (dropped_record_count != 0) {
+    metadata.flags |= IREE_HAL_PROFILE_CHUNK_FLAG_TRUNCATED;
+    metadata.dropped_record_count = dropped_record_count;
+  }
+  return metadata;
+}
+
+static iree_status_t
+iree_hal_vulkan_profile_recorder_write_queue_device_event_run(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_profile_queue_device_event_t* events,
+    iree_host_size_t event_count, uint64_t dropped_record_count) {
+  if (event_count == 0 && dropped_record_count == 0) return iree_ok_status();
+  const iree_hal_profile_queue_device_event_t* first_event =
+      event_count != 0 ? events : NULL;
+  iree_hal_profile_chunk_metadata_t metadata =
+      iree_hal_vulkan_profile_recorder_queue_device_event_metadata(
+          recorder, first_event, dropped_record_count);
+  iree_const_byte_span_t iovec = iree_make_const_byte_span(
+      events, event_count * sizeof(iree_hal_profile_queue_device_event_t));
+  return iree_hal_profile_sink_write(recorder->options.sink, &metadata,
+                                     event_count != 0 ? 1 : 0,
+                                     event_count != 0 ? &iovec : NULL);
+}
+
+static iree_status_t
+iree_hal_vulkan_profile_recorder_write_queue_device_event_span(
+    iree_hal_vulkan_profile_recorder_t* recorder, iree_const_byte_span_t span,
+    uint64_t* remaining_dropped_record_count) {
+  IREE_ASSERT(
+      span.data_length % sizeof(iree_hal_profile_queue_device_event_t) == 0);
+  const iree_hal_profile_queue_device_event_t* events =
+      (const iree_hal_profile_queue_device_event_t*)span.data;
+  const iree_host_size_t event_count =
+      span.data_length / sizeof(iree_hal_profile_queue_device_event_t);
+  iree_host_size_t run_start = 0;
+  iree_status_t status = iree_ok_status();
+  while (iree_status_is_ok(status) && run_start < event_count) {
+    iree_host_size_t run_end = run_start + 1;
+    while (run_end < event_count &&
+           iree_hal_vulkan_profile_queue_device_events_have_same_scope(
+               &events[run_start], &events[run_end])) {
+      ++run_end;
+    }
+    const uint64_t run_dropped_record_count = *remaining_dropped_record_count;
+    *remaining_dropped_record_count = 0;
+    status = iree_hal_vulkan_profile_recorder_write_queue_device_event_run(
+        recorder, &events[run_start], run_end - run_start,
+        run_dropped_record_count);
+    run_start = run_end;
+  }
+  return status;
+}
+
+static iree_status_t
+iree_hal_vulkan_profile_recorder_write_queue_device_event_ring(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_hal_profile_event_ring_t* ring) {
+  iree_hal_profile_event_ring_snapshot_t snapshot;
+  iree_slim_mutex_lock(&recorder->mutex);
+  iree_status_t status = iree_hal_profile_event_ring_snapshot(ring, &snapshot);
+  iree_slim_mutex_unlock(&recorder->mutex);
+  IREE_RETURN_IF_ERROR(status);
+
+  if (snapshot.record_count == 0 && snapshot.dropped_record_count == 0) {
+    return iree_ok_status();
+  }
+
+  uint64_t remaining_dropped_record_count = snapshot.dropped_record_count;
+  for (iree_host_size_t i = 0;
+       i < snapshot.record_span_count && iree_status_is_ok(status); ++i) {
+    status = iree_hal_vulkan_profile_recorder_write_queue_device_event_span(
+        recorder, snapshot.record_spans[i], &remaining_dropped_record_count);
+  }
+  if (iree_status_is_ok(status) && remaining_dropped_record_count != 0) {
+    status = iree_hal_vulkan_profile_recorder_write_queue_device_event_run(
+        recorder, /*events=*/NULL, /*event_count=*/0,
+        remaining_dropped_record_count);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&recorder->mutex);
+    iree_hal_profile_event_ring_commit_snapshot(ring, &snapshot);
+    iree_slim_mutex_unlock(&recorder->mutex);
+  }
+  return status;
+}
+
+static iree_status_t iree_hal_vulkan_profile_recorder_flush_records(
+    iree_hal_vulkan_profile_recorder_t* recorder) {
+  iree_slim_mutex_lock(&recorder->flush_mutex);
+  iree_status_t status =
+      iree_hal_vulkan_profile_recorder_write_dispatch_event_ring(
+          recorder, &recorder->dispatch_event_ring);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_vulkan_profile_recorder_write_event_ring(
+        recorder, IREE_HAL_PROFILE_CONTENT_TYPE_QUEUE_EVENTS,
+        &recorder->queue_event_ring);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_vulkan_profile_recorder_write_queue_device_event_ring(
+        recorder, &recorder->queue_device_event_ring);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_vulkan_profile_recorder_write_event_ring(
+        recorder, IREE_HAL_PROFILE_CONTENT_TYPE_MEMORY_EVENTS,
+        &recorder->memory_event_ring);
+  }
+  iree_slim_mutex_unlock(&recorder->flush_mutex);
+  return status;
+}
+
+iree_status_t iree_hal_vulkan_profile_recorder_write_clock_correlations(
+    iree_hal_vulkan_profile_recorder_t* recorder, iree_host_size_t record_count,
+    const iree_hal_profile_clock_correlation_record_t* records) {
+  if (!recorder || !recorder->active || record_count == 0) {
+    return iree_ok_status();
+  }
+  if (IREE_UNLIKELY(!records)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan profiling clock correlation records are required");
+  }
+  return iree_hal_vulkan_profile_recorder_write_records(
+      recorder, IREE_HAL_PROFILE_CONTENT_TYPE_CLOCK_CORRELATIONS, records,
+      record_count, sizeof(*records));
+}
+
+iree_status_t iree_hal_vulkan_profile_recorder_flush(
+    iree_hal_vulkan_profile_recorder_t* recorder) {
+  if (!recorder || !recorder->active) return iree_ok_status();
+  return iree_hal_vulkan_profile_recorder_flush_records(recorder);
+}
+
+iree_status_t iree_hal_vulkan_profile_recorder_end(
+    iree_hal_vulkan_profile_recorder_t* recorder) {
+  if (!recorder || !recorder->active) return iree_ok_status();
+
+  iree_status_t status =
+      iree_hal_vulkan_profile_recorder_flush_records(recorder);
+  iree_hal_profile_chunk_metadata_t metadata =
+      iree_hal_vulkan_profile_recorder_metadata(
+          recorder, IREE_HAL_PROFILE_CONTENT_TYPE_SESSION);
+  iree_status_code_t status_code = iree_status_code(status);
+  status = iree_status_join(
+      status, iree_hal_profile_sink_end_session(recorder->options.sink,
+                                                &metadata, status_code));
+  recorder->active = false;
+  return status;
+}

--- a/runtime/src/iree/hal/drivers/vulkan/profile.h
+++ b/runtime/src/iree/hal/drivers/vulkan/profile.h
@@ -1,0 +1,363 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_VULKAN_PROFILE_H_
+#define IREE_HAL_VULKAN_PROFILE_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_hal_vulkan_profile_recorder_t
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_vulkan_profile_recorder_t
+    iree_hal_vulkan_profile_recorder_t;
+
+// Returns the HAL-native profiling data families produced by Vulkan recorders.
+static inline iree_hal_device_profiling_data_families_t
+iree_hal_vulkan_profile_recorder_supported_data_families(void) {
+  return IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
+         IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS |
+         IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS |
+         IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA |
+         IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS;
+}
+
+// Metadata needed to begin a Vulkan driver profiling session.
+//
+// The recorder writes the supplied device and queue records during creation and
+// does not retain the record arrays. |name| is copied into recorder-owned
+// storage because flush/end can happen after profiling_begin returns.
+typedef struct iree_hal_vulkan_profile_recorder_options_t {
+  // Human-readable producer name used on session and metadata chunks.
+  iree_string_view_t name;
+
+  // Process-local profiling session identifier assigned by the caller.
+  uint64_t session_id;
+
+  // Number of physical device metadata records in |device_records|.
+  iree_host_size_t device_record_count;
+
+  // Borrowed physical device metadata records emitted at session begin.
+  const iree_hal_profile_device_record_t* device_records;
+
+  // Number of queue metadata records in |queue_records|.
+  iree_host_size_t queue_record_count;
+
+  // Borrowed queue metadata records emitted at session begin.
+  const iree_hal_profile_queue_record_t* queue_records;
+
+  // Maximum dispatch events retained between flushes; 0 selects the default.
+  iree_host_size_t dispatch_event_capacity;
+
+  // Maximum queue events retained between flushes; 0 selects the default.
+  iree_host_size_t queue_event_capacity;
+
+  // Maximum queue device events retained between flushes; 0 selects the
+  // default.
+  iree_host_size_t queue_device_event_capacity;
+
+  // Maximum memory events retained between flushes; 0 selects the default.
+  iree_host_size_t memory_event_capacity;
+} iree_hal_vulkan_profile_recorder_options_t;
+
+// Queue identity shared by Vulkan profiling records.
+typedef struct iree_hal_vulkan_profile_queue_scope_t {
+  // Session-local physical device ordinal associated with the record.
+  uint32_t physical_device_ordinal;
+
+  // Session-local queue ordinal associated with the record.
+  uint32_t queue_ordinal;
+
+  // Producer-defined stream identifier matching queue metadata.
+  uint64_t stream_id;
+} iree_hal_vulkan_profile_queue_scope_t;
+
+// Returns a queue scope with absent ordinals and no stream id.
+static inline iree_hal_vulkan_profile_queue_scope_t
+iree_hal_vulkan_profile_queue_scope_default(void) {
+  iree_hal_vulkan_profile_queue_scope_t scope;
+  memset(&scope, 0, sizeof(scope));
+  scope.physical_device_ordinal = UINT32_MAX;
+  scope.queue_ordinal = UINT32_MAX;
+  return scope;
+}
+
+// Device-timestamped dispatch data used to append one dispatch event.
+typedef struct iree_hal_vulkan_profile_dispatch_event_info_t {
+  // Flags describing how the dispatch was produced.
+  iree_hal_profile_dispatch_event_flags_t flags;
+
+  // Queue metadata identity associated with the dispatch event chunk.
+  iree_hal_vulkan_profile_queue_scope_t scope;
+
+  // Queue submission epoch containing this dispatch.
+  uint64_t submission_id;
+
+  // Session-local command-buffer identifier, or 0 for direct dispatch.
+  uint64_t command_buffer_id;
+
+  // Session-local executable identifier.
+  uint64_t executable_id;
+
+  // Command ordinal within a command buffer, or UINT32_MAX for direct dispatch.
+  uint32_t command_index;
+
+  // Executable function ordinal dispatched.
+  uint32_t function_ordinal;
+
+  // Workgroup counts submitted for each dimension.
+  uint32_t workgroup_count[3];
+
+  // Workgroup sizes submitted for each dimension.
+  uint32_t workgroup_size[3];
+
+  // Device timestamp captured when dispatch execution started.
+  uint64_t start_tick;
+
+  // Device timestamp captured when dispatch execution completed.
+  uint64_t end_tick;
+} iree_hal_vulkan_profile_dispatch_event_info_t;
+
+// Returns default dispatch event append data.
+static inline iree_hal_vulkan_profile_dispatch_event_info_t
+iree_hal_vulkan_profile_dispatch_event_info_default(void) {
+  iree_hal_vulkan_profile_dispatch_event_info_t info;
+  memset(&info, 0, sizeof(info));
+  info.scope = iree_hal_vulkan_profile_queue_scope_default();
+  info.command_index = UINT32_MAX;
+  info.function_ordinal = UINT32_MAX;
+  return info;
+}
+
+// Queue operation data used to append one queue event record.
+typedef struct iree_hal_vulkan_profile_queue_event_info_t {
+  // Kind of queue operation represented by the event.
+  iree_hal_profile_queue_event_type_t type;
+
+  // Flags describing queue operation properties.
+  iree_hal_profile_queue_event_flags_t flags;
+
+  // Strategy used for wait dependencies on this operation.
+  iree_hal_profile_queue_dependency_strategy_t dependency_strategy;
+
+  // Queue metadata identity shared by the appended record.
+  iree_hal_vulkan_profile_queue_scope_t scope;
+
+  // IREE monotonic host timestamp when submitted, or 0 to sample now.
+  iree_time_t host_time_ns;
+
+  // IREE monotonic host timestamp when ready to execute, or 0 when unknown.
+  iree_time_t ready_host_time_ns;
+
+  // Queue submission epoch associated with this operation, or 0 when absent.
+  uint64_t submission_id;
+
+  // Session-local command-buffer identifier, or 0 when not applicable.
+  uint64_t command_buffer_id;
+
+  // Producer-defined allocation identifier, or 0 when not applicable.
+  uint64_t allocation_id;
+
+  // Number of wait semaphores supplied to the queue operation.
+  uint32_t wait_count;
+
+  // Number of signal semaphores supplied to the queue operation.
+  uint32_t signal_count;
+
+  // Number of dedicated dependency barrier packets emitted for this operation.
+  uint32_t barrier_count;
+
+  // Number of encoded payload operations represented by this queue operation.
+  uint32_t operation_count;
+
+  // Type-specific payload byte length, or 0 when not applicable.
+  uint64_t payload_length;
+} iree_hal_vulkan_profile_queue_event_info_t;
+
+// Returns default queue event append data.
+static inline iree_hal_vulkan_profile_queue_event_info_t
+iree_hal_vulkan_profile_queue_event_info_default(void) {
+  iree_hal_vulkan_profile_queue_event_info_t info;
+  memset(&info, 0, sizeof(info));
+  info.scope = iree_hal_vulkan_profile_queue_scope_default();
+  return info;
+}
+
+// Queue operation data used to append one device-timestamped queue event.
+typedef struct iree_hal_vulkan_profile_queue_device_event_info_t {
+  // Kind of queue operation represented by the event.
+  iree_hal_profile_queue_event_type_t type;
+
+  // Flags describing queue operation properties.
+  iree_hal_profile_queue_event_flags_t flags;
+
+  // Queue metadata identity shared by the appended record.
+  iree_hal_vulkan_profile_queue_scope_t scope;
+
+  // Queue submission epoch associated with this operation, or 0 when absent.
+  uint64_t submission_id;
+
+  // Session-local command-buffer identifier, or 0 when not applicable.
+  uint64_t command_buffer_id;
+
+  // Producer-defined allocation identifier, or 0 when not applicable.
+  uint64_t allocation_id;
+
+  // Number of encoded payload operations represented by this queue operation.
+  uint32_t operation_count;
+
+  // Type-specific payload byte length, or 0 when not applicable.
+  uint64_t payload_length;
+
+  // Device timestamp captured when queue-visible work started.
+  uint64_t start_tick;
+
+  // Device timestamp captured when queue-visible work completed.
+  uint64_t end_tick;
+} iree_hal_vulkan_profile_queue_device_event_info_t;
+
+// Returns default queue device event append data.
+static inline iree_hal_vulkan_profile_queue_device_event_info_t
+iree_hal_vulkan_profile_queue_device_event_info_default(void) {
+  iree_hal_vulkan_profile_queue_device_event_info_t info;
+  memset(&info, 0, sizeof(info));
+  info.scope = iree_hal_vulkan_profile_queue_scope_default();
+  return info;
+}
+
+// Begins a Vulkan profiling session and returns its recorder.
+//
+// Returns OK with |out_recorder| set to NULL when
+// |profiling_options->data_families| is NONE. Otherwise the requested families
+// must be a subset of
+// iree_hal_vulkan_profile_recorder_supported_data_families() and
+// |profiling_options->sink| must be non-NULL.
+iree_status_t iree_hal_vulkan_profile_recorder_create(
+    const iree_hal_vulkan_profile_recorder_options_t* recorder_options,
+    const iree_hal_device_profiling_options_t* profiling_options,
+    iree_allocator_t host_allocator,
+    iree_hal_vulkan_profile_recorder_t** out_recorder);
+
+// Destroys |recorder| and releases retained session resources.
+//
+// Callers should end active sessions with iree_hal_vulkan_profile_recorder_end
+// before destroying the recorder so sink end-session failures can be observed.
+void iree_hal_vulkan_profile_recorder_destroy(
+    iree_hal_vulkan_profile_recorder_t* recorder);
+
+// Returns true when |recorder| is active and any of |data_families| is enabled.
+bool iree_hal_vulkan_profile_recorder_is_enabled(
+    const iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_hal_device_profiling_data_families_t data_families);
+
+// Returns the resolved profiling options held by |recorder|, or NULL.
+const iree_hal_device_profiling_options_t*
+iree_hal_vulkan_profile_recorder_options(
+    const iree_hal_vulkan_profile_recorder_t* recorder);
+
+// Emits executable function metadata for |executable_id| once per recorder
+// session.
+//
+// |executable_id| must be a producer-defined nonzero identifier that remains
+// stable for the lifetime of |executable|. The caller supplies the stable
+// Vulkan executable id used by dispatch records in this session.
+iree_status_t iree_hal_vulkan_profile_recorder_record_executable(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    iree_hal_executable_t* executable, uint64_t executable_id);
+
+// Emits command-buffer and operation metadata once per recorder session.
+//
+// Returns OK without work when metadata is not enabled. The caller owns
+// |command_buffer| and |operations|; the recorder does not retain them.
+iree_status_t iree_hal_vulkan_profile_recorder_record_command_buffer(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_profile_command_buffer_record_t* command_buffer,
+    iree_host_size_t operation_count,
+    const iree_hal_profile_command_operation_record_t* operations);
+
+// Appends one producer-owned dispatch event to |recorder|.
+//
+// |out_event_id| may be NULL. When provided it receives the assigned event id,
+// or 0 if dispatch events were not requested. Dispatch events are lossless
+// profiling records. A full ring is flushed synchronously before appending; if
+// that flush fails, the pending records are preserved and the failure is
+// returned to the producer instead of silently truncating device timelines.
+iree_status_t iree_hal_vulkan_profile_recorder_append_dispatch_event(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_dispatch_event_info_t* event_info,
+    uint64_t* out_event_id);
+
+// Appends one host-timestamped queue event to |recorder|.
+//
+// |out_event_id| may be NULL. When provided it receives the assigned event id,
+// or 0 if queue events were not requested or the event ring was full. Ring
+// capacity pressure is reported later as truncated chunks during flush.
+void iree_hal_vulkan_profile_recorder_append_queue_event(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_queue_event_info_t* event_info,
+    uint64_t* out_event_id);
+
+// Appends one device-timestamped queue event to |recorder|.
+//
+// |out_event_id| may be NULL. When provided it receives the assigned event id,
+// or 0 if queue device events were not requested. Unlike host queue events,
+// queue device events are lossless profiling records. A full ring is flushed
+// synchronously before appending; if that flush fails, the pending records are
+// preserved and the failure is returned to the producer instead of silently
+// truncating device timelines.
+iree_status_t iree_hal_vulkan_profile_recorder_append_queue_device_event(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_vulkan_profile_queue_device_event_info_t* event_info,
+    uint64_t* out_event_id);
+
+// Appends one host-timestamped memory lifecycle event to |recorder|.
+//
+// |event| is copied into the recorder. The recorder overwrites record_length
+// and event_id and samples host_time_ns when it is zero. Queue-operation memory
+// events must provide a valid physical device and queue ordinal. |out_event_id|
+// may be NULL. When provided it receives the assigned event id, or 0 if memory
+// events were not requested or the event ring was full. Ring capacity pressure
+// is reported later as truncated chunks during flush.
+void iree_hal_vulkan_profile_recorder_append_memory_event(
+    iree_hal_vulkan_profile_recorder_t* recorder,
+    const iree_hal_profile_memory_event_t* event, uint64_t* out_event_id);
+
+// Writes clock-correlation records to the active session sink.
+//
+// The caller must provide real producer-obtained clock samples. This helper is
+// intentionally not buffered: correlations are cold-path session calibration
+// records, and failures must be reported directly to the profiling operation.
+iree_status_t iree_hal_vulkan_profile_recorder_write_clock_correlations(
+    iree_hal_vulkan_profile_recorder_t* recorder, iree_host_size_t record_count,
+    const iree_hal_profile_clock_correlation_record_t* records);
+
+// Writes all buffered profile records to the session sink.
+iree_status_t iree_hal_vulkan_profile_recorder_flush(
+    iree_hal_vulkan_profile_recorder_t* recorder);
+
+// Flushes and ends the profiling session.
+//
+// The sink receives the terminal status code derived from the first failing
+// flush or end-session operation. A second call after a successful end is a
+// no-op.
+iree_status_t iree_hal_vulkan_profile_recorder_end(
+    iree_hal_vulkan_profile_recorder_t* recorder);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_VULKAN_PROFILE_H_

--- a/runtime/src/iree/hal/drivers/vulkan/profile_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/profile_test.cc
@@ -1,0 +1,308 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/vulkan/profile.h"
+
+#include <cstdint>
+
+#include "iree/hal/api.h"
+#include "iree/hal/cts/util/profile_test_util.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::vulkan {
+namespace {
+
+using ::iree::hal::cts::TestProfileSink;
+using ::iree::hal::cts::TestProfileSinkAsBase;
+using ::iree::hal::cts::TestProfileSinkInitialize;
+
+// Profile sink wrapper that injects one selected write failure before
+// forwarding all other callbacks to a recording sink.
+struct FaultInjectingProfileSink {
+  // HAL resource header for the sink.
+  iree_hal_resource_t resource;
+
+  // Borrowed sink receiving callbacks that are not faulted.
+  iree_hal_profile_sink_t* delegate = nullptr;
+
+  // Content type whose write callback should fail, or empty when disabled.
+  iree_string_view_t fail_write_content_type = iree_string_view_empty();
+
+  // Number of matching write callbacks that should fail.
+  int fail_write_remaining = 0;
+
+  // Status code returned from matching write callbacks.
+  iree_status_code_t fail_write_status_code = IREE_STATUS_OK;
+};
+
+static FaultInjectingProfileSink* FaultInjectingProfileSinkCast(
+    iree_hal_profile_sink_t* sink) {
+  return reinterpret_cast<FaultInjectingProfileSink*>(sink);
+}
+
+static void FaultInjectingProfileSinkDestroy(iree_hal_profile_sink_t* sink) {
+  (void)sink;
+}
+
+static iree_status_t FaultInjectingProfileSinkBeginSession(
+    iree_hal_profile_sink_t* sink,
+    const iree_hal_profile_chunk_metadata_t* metadata) {
+  FaultInjectingProfileSink* fault_sink = FaultInjectingProfileSinkCast(sink);
+  return iree_hal_profile_sink_begin_session(fault_sink->delegate, metadata);
+}
+
+static iree_status_t FaultInjectingProfileSinkWrite(
+    iree_hal_profile_sink_t* sink,
+    const iree_hal_profile_chunk_metadata_t* metadata,
+    iree_host_size_t iovec_count, const iree_const_byte_span_t* iovecs) {
+  FaultInjectingProfileSink* fault_sink = FaultInjectingProfileSinkCast(sink);
+  if (fault_sink->fail_write_remaining != 0 &&
+      iree_string_view_equal(metadata->content_type,
+                             fault_sink->fail_write_content_type)) {
+    --fault_sink->fail_write_remaining;
+    return iree_make_status(fault_sink->fail_write_status_code,
+                            "injected profile sink write failure");
+  }
+  return iree_hal_profile_sink_write(fault_sink->delegate, metadata,
+                                     iovec_count, iovecs);
+}
+
+static iree_status_t FaultInjectingProfileSinkEndSession(
+    iree_hal_profile_sink_t* sink,
+    const iree_hal_profile_chunk_metadata_t* metadata,
+    iree_status_code_t session_status_code) {
+  FaultInjectingProfileSink* fault_sink = FaultInjectingProfileSinkCast(sink);
+  return iree_hal_profile_sink_end_session(fault_sink->delegate, metadata,
+                                           session_status_code);
+}
+
+static const iree_hal_profile_sink_vtable_t kFaultInjectingProfileSinkVTable = {
+    /*.destroy=*/FaultInjectingProfileSinkDestroy,
+    /*.begin_session=*/FaultInjectingProfileSinkBeginSession,
+    /*.write=*/FaultInjectingProfileSinkWrite,
+    /*.end_session=*/FaultInjectingProfileSinkEndSession,
+};
+
+static void FaultInjectingProfileSinkInitialize(
+    iree_hal_profile_sink_t* delegate, FaultInjectingProfileSink* out_sink) {
+  iree_hal_resource_initialize(&kFaultInjectingProfileSinkVTable,
+                               &out_sink->resource);
+  out_sink->delegate = delegate;
+}
+
+static iree_hal_profile_sink_t* FaultInjectingProfileSinkAsBase(
+    FaultInjectingProfileSink* sink) {
+  return reinterpret_cast<iree_hal_profile_sink_t*>(sink);
+}
+
+class VulkanProfileRecorderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    TestProfileSinkInitialize(&recording_sink_);
+    FaultInjectingProfileSinkInitialize(TestProfileSinkAsBase(&recording_sink_),
+                                        &fault_sink_);
+
+    device_record_ = iree_hal_profile_device_record_default();
+    device_record_.physical_device_ordinal = 0;
+    device_record_.queue_count = 1;
+    device_record_.flags = IREE_HAL_PROFILE_DEVICE_FLAG_TIMESTAMP_FREQUENCY;
+    device_record_.timestamp_frequency_hz = 1000000000ull;
+
+    queue_record_ = iree_hal_profile_queue_record_default();
+    queue_record_.physical_device_ordinal = 0;
+    queue_record_.queue_ordinal = 0;
+    queue_record_.stream_id = 1;
+
+    recorder_options_.name = IREE_SV("vulkan-test");
+    recorder_options_.session_id = 42;
+    recorder_options_.device_record_count = 1;
+    recorder_options_.device_records = &device_record_;
+    recorder_options_.queue_record_count = 1;
+    recorder_options_.queue_records = &queue_record_;
+    recorder_options_.dispatch_event_capacity = 4;
+    recorder_options_.queue_event_capacity = 4;
+    recorder_options_.queue_device_event_capacity = 4;
+    recorder_options_.memory_event_capacity = 4;
+  }
+
+  void TearDown() override {
+    if (!recorder_) return;
+    IREE_EXPECT_OK(iree_hal_vulkan_profile_recorder_end(recorder_));
+    iree_hal_vulkan_profile_recorder_destroy(recorder_);
+  }
+
+  iree_hal_device_profiling_options_t MakeProfilingOptions(
+      iree_hal_device_profiling_data_families_t data_families) {
+    iree_hal_device_profiling_options_t options = {0};
+    options.data_families = data_families;
+    options.sink = FaultInjectingProfileSinkAsBase(&fault_sink_);
+    return options;
+  }
+
+  iree_status_t Create(
+      iree_hal_device_profiling_data_families_t data_families) {
+    iree_hal_device_profiling_options_t options =
+        MakeProfilingOptions(data_families);
+    return iree_hal_vulkan_profile_recorder_create(
+        &recorder_options_, &options, iree_allocator_system(), &recorder_);
+  }
+
+  iree_hal_vulkan_profile_queue_scope_t QueueScope() {
+    iree_hal_vulkan_profile_queue_scope_t scope =
+        iree_hal_vulkan_profile_queue_scope_default();
+    scope.physical_device_ordinal = queue_record_.physical_device_ordinal;
+    scope.queue_ordinal = queue_record_.queue_ordinal;
+    scope.stream_id = queue_record_.stream_id;
+    return scope;
+  }
+
+  iree_hal_vulkan_profile_dispatch_event_info_t DispatchEventInfo() {
+    iree_hal_vulkan_profile_dispatch_event_info_t event_info =
+        iree_hal_vulkan_profile_dispatch_event_info_default();
+    event_info.scope = QueueScope();
+    event_info.submission_id = 7;
+    event_info.executable_id = 5;
+    event_info.function_ordinal = 0;
+    event_info.workgroup_count[0] = 1;
+    event_info.workgroup_count[1] = 1;
+    event_info.workgroup_count[2] = 1;
+    event_info.workgroup_size[0] = 1;
+    event_info.workgroup_size[1] = 1;
+    event_info.workgroup_size[2] = 1;
+    event_info.start_tick = 1000;
+    event_info.end_tick = 1200;
+    return event_info;
+  }
+
+  TestProfileSink recording_sink_;
+  FaultInjectingProfileSink fault_sink_;
+  iree_hal_profile_device_record_t device_record_;
+  iree_hal_profile_queue_record_t queue_record_;
+  iree_hal_vulkan_profile_recorder_options_t recorder_options_ = {};
+  iree_hal_vulkan_profile_recorder_t* recorder_ = nullptr;
+};
+
+TEST_F(VulkanProfileRecorderTest, AppendsVulkanEventStreams) {
+  IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
+                        IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS |
+                        IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS |
+                        IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS));
+
+  iree_hal_vulkan_profile_queue_event_info_t queue_info =
+      iree_hal_vulkan_profile_queue_event_info_default();
+  queue_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_EXECUTE;
+  queue_info.scope = QueueScope();
+  queue_info.submission_id = 7;
+  queue_info.operation_count = 1;
+  iree_hal_vulkan_profile_recorder_append_queue_event(recorder_, &queue_info,
+                                                      nullptr);
+
+  iree_hal_vulkan_profile_dispatch_event_info_t dispatch_info =
+      DispatchEventInfo();
+  IREE_EXPECT_OK(iree_hal_vulkan_profile_recorder_append_dispatch_event(
+      recorder_, &dispatch_info, nullptr));
+
+  iree_hal_vulkan_profile_queue_device_event_info_t queue_device_info =
+      iree_hal_vulkan_profile_queue_device_event_info_default();
+  queue_device_info.type = IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_EXECUTE;
+  queue_device_info.scope = QueueScope();
+  queue_device_info.submission_id = 7;
+  queue_device_info.operation_count = 1;
+  queue_device_info.start_tick = 900;
+  queue_device_info.end_tick = 1300;
+  IREE_EXPECT_OK(iree_hal_vulkan_profile_recorder_append_queue_device_event(
+      recorder_, &queue_device_info, nullptr));
+
+  iree_hal_profile_memory_event_t memory_event =
+      iree_hal_profile_memory_event_default();
+  memory_event.type = IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_QUEUE_ALLOCA;
+  memory_event.flags = IREE_HAL_PROFILE_MEMORY_EVENT_FLAG_QUEUE_OPERATION;
+  memory_event.result = IREE_STATUS_OK;
+  memory_event.allocation_id = 9;
+  memory_event.submission_id = 7;
+  memory_event.physical_device_ordinal = 0;
+  memory_event.queue_ordinal = 0;
+  memory_event.length = 64;
+  iree_hal_vulkan_profile_recorder_append_memory_event(recorder_, &memory_event,
+                                                       nullptr);
+
+  iree_hal_profile_clock_correlation_record_t correlation =
+      iree_hal_profile_clock_correlation_record_default();
+  correlation.flags =
+      IREE_HAL_PROFILE_CLOCK_CORRELATION_FLAG_DEVICE_TICK |
+      IREE_HAL_PROFILE_CLOCK_CORRELATION_FLAG_HOST_CPU_TIMESTAMP |
+      IREE_HAL_PROFILE_CLOCK_CORRELATION_FLAG_HOST_SYSTEM_TIMESTAMP |
+      IREE_HAL_PROFILE_CLOCK_CORRELATION_FLAG_HOST_TIME_BRACKET;
+  correlation.physical_device_ordinal = 0;
+  correlation.sample_id = 1;
+  correlation.device_tick = 1000;
+  correlation.host_cpu_timestamp_ns = 5000;
+  correlation.host_system_timestamp = 6000;
+  correlation.host_system_frequency_hz = 1000000000ull;
+  correlation.host_time_begin_ns = 4900;
+  correlation.host_time_end_ns = 5100;
+  IREE_EXPECT_OK(iree_hal_vulkan_profile_recorder_write_clock_correlations(
+      recorder_, 1, &correlation));
+
+  IREE_EXPECT_OK(iree_hal_vulkan_profile_recorder_flush(recorder_));
+  EXPECT_EQ(1u, recording_sink_.queue_events.size());
+  EXPECT_EQ(1u, recording_sink_.dispatch_events.size());
+  EXPECT_EQ(1u, recording_sink_.queue_device_events.size());
+  EXPECT_EQ(1u, recording_sink_.memory_events.size());
+  EXPECT_EQ(1u, recording_sink_.clock_correlations.size());
+}
+
+TEST_F(VulkanProfileRecorderTest, DispatchAutoFlushFailurePreservesRecords) {
+  recorder_options_.dispatch_event_capacity = 1;
+  IREE_EXPECT_OK(Create(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS));
+
+  iree_hal_vulkan_profile_dispatch_event_info_t first_info =
+      DispatchEventInfo();
+  uint64_t first_event_id = 0;
+  IREE_EXPECT_OK(iree_hal_vulkan_profile_recorder_append_dispatch_event(
+      recorder_, &first_info, &first_event_id));
+
+  fault_sink_.fail_write_content_type =
+      IREE_HAL_PROFILE_CONTENT_TYPE_DISPATCH_EVENTS;
+  fault_sink_.fail_write_remaining = 1;
+  fault_sink_.fail_write_status_code = IREE_STATUS_DATA_LOSS;
+
+  iree_hal_vulkan_profile_dispatch_event_info_t second_info =
+      DispatchEventInfo();
+  second_info.submission_id = 8;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS,
+                        iree_hal_vulkan_profile_recorder_append_dispatch_event(
+                            recorder_, &second_info, nullptr));
+  EXPECT_TRUE(recording_sink_.dispatch_events.empty());
+
+  uint64_t second_event_id = 0;
+  IREE_EXPECT_OK(iree_hal_vulkan_profile_recorder_append_dispatch_event(
+      recorder_, &second_info, &second_event_id));
+  IREE_EXPECT_OK(iree_hal_vulkan_profile_recorder_flush(recorder_));
+  ASSERT_EQ(2u, recording_sink_.dispatch_events.size());
+  EXPECT_EQ(first_event_id, recording_sink_.dispatch_events[0].event_id);
+  EXPECT_EQ(second_event_id, recording_sink_.dispatch_events[1].event_id);
+}
+
+TEST_F(VulkanProfileRecorderTest, AcceptsDispatchCaptureFilter) {
+  iree_hal_device_profiling_options_t options =
+      MakeProfilingOptions(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS);
+  options.capture_filter.flags =
+      IREE_HAL_PROFILE_CAPTURE_FILTER_FLAG_EXECUTABLE_FUNCTION_PATTERN;
+  options.capture_filter.executable_function_pattern = IREE_SV("dispatch_*");
+  IREE_EXPECT_OK(iree_hal_vulkan_profile_recorder_create(
+      &recorder_options_, &options, iree_allocator_system(), &recorder_));
+}
+
+TEST_F(VulkanProfileRecorderTest, RejectsTaskExecutionData) {
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_UNIMPLEMENTED,
+      Create(IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS));
+}
+
+}  // namespace
+}  // namespace iree::hal::vulkan

--- a/runtime/src/iree/hal/drivers/vulkan/queue.c
+++ b/runtime/src/iree/hal/drivers/vulkan/queue.c
@@ -340,10 +340,10 @@ struct iree_hal_vulkan_queue_pending_submission_t {
   // HAL-native profiling metadata captured for this submission.
   struct {
     // Recorder active when the submission was captured. Borrowed.
-    iree_hal_local_profile_recorder_t* recorder;
+    iree_hal_vulkan_profile_recorder_t* recorder;
 
     // Queue metadata scope active when the submission was captured.
-    iree_hal_local_profile_queue_scope_t scope;
+    iree_hal_vulkan_profile_queue_scope_t scope;
 
     // Queue event type corresponding to |kind|.
     iree_hal_profile_queue_event_type_t type;
@@ -1975,14 +1975,14 @@ static void iree_hal_vulkan_queue_release_native_command_buffer(
 
 static bool iree_hal_vulkan_queue_profile_requests_queue_device_event(
     const iree_hal_vulkan_queue_pending_submission_t* submission) {
-  return iree_hal_local_profile_recorder_is_enabled(
+  return iree_hal_vulkan_profile_recorder_is_enabled(
       submission->profile.recorder,
       IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS);
 }
 
 static bool iree_hal_vulkan_queue_profile_requests_dispatch_events(
     const iree_hal_vulkan_queue_pending_submission_t* submission) {
-  return iree_hal_local_profile_recorder_is_enabled(
+  return iree_hal_vulkan_profile_recorder_is_enabled(
       submission->profile.recorder,
       IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS);
 }
@@ -3036,8 +3036,8 @@ static uint64_t iree_hal_vulkan_queue_profile_payload_length(
 static void iree_hal_vulkan_queue_profile_submission_initialize(
     iree_hal_vulkan_queue_t* queue,
     iree_hal_vulkan_queue_pending_submission_t* submission) {
-  iree_hal_local_profile_recorder_t* recorder = queue->profile_recorder;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  iree_hal_vulkan_profile_recorder_t* recorder = queue->profile_recorder;
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
           recorder, IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
                         IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS |
                         IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS |
@@ -3132,7 +3132,7 @@ static void iree_hal_vulkan_queue_profile_record_submission(
       submission->profile.queue_event_recorded) {
     return;
   }
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
           submission->profile.recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS)) {
     return;
@@ -3141,8 +3141,8 @@ static void iree_hal_vulkan_queue_profile_record_submission(
   submission->profile.ready_host_time_ns = iree_time_now();
   iree_hal_vulkan_queue_profile_populate_submission_metrics(submission);
 
-  iree_hal_local_profile_queue_event_info_t event_info =
-      iree_hal_local_profile_queue_event_info_default();
+  iree_hal_vulkan_profile_queue_event_info_t event_info =
+      iree_hal_vulkan_profile_queue_event_info_default();
   event_info.type = submission->profile.type;
   event_info.flags = submission->profile.flags;
   event_info.dependency_strategy = submission->profile.dependency_strategy;
@@ -3160,7 +3160,7 @@ static void iree_hal_vulkan_queue_profile_record_submission(
       submission->signal_semaphore_list.count);
   event_info.operation_count = submission->profile.operation_count;
   event_info.payload_length = submission->profile.payload_length;
-  iree_hal_local_profile_recorder_append_queue_event(
+  iree_hal_vulkan_profile_recorder_append_queue_event(
       submission->profile.recorder, &event_info, /*out_event_id=*/NULL);
 }
 
@@ -3185,11 +3185,11 @@ static bool iree_hal_vulkan_queue_profile_submission_requires_native_timestamp(
 }
 
 static bool iree_hal_vulkan_queue_profile_filter_matches_dispatch(
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t scope, uint64_t command_buffer_id,
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t scope, uint64_t command_buffer_id,
     uint32_t command_index, const iree_hal_vulkan_pipeline_t* pipeline) {
   const iree_hal_device_profiling_options_t* options =
-      iree_hal_local_profile_recorder_options(profile_recorder);
+      iree_hal_vulkan_profile_recorder_options(profile_recorder);
   if (!options) return false;
   const iree_hal_profile_capture_filter_t* filter = &options->capture_filter;
   if (!iree_hal_profile_capture_filter_matches_location(
@@ -3270,8 +3270,8 @@ static iree_status_t iree_hal_vulkan_queue_append_dispatch_profile_event(
         "Vulkan dispatch profiling timestamp range is not monotonic");
   }
 
-  iree_hal_local_profile_dispatch_event_info_t event_info =
-      iree_hal_local_profile_dispatch_event_info_default();
+  iree_hal_vulkan_profile_dispatch_event_info_t event_info =
+      iree_hal_vulkan_profile_dispatch_event_info_default();
   event_info.scope = submission->profile.scope;
   event_info.submission_id = submission->profile.submission_id;
   event_info.command_buffer_id = 0;
@@ -3292,20 +3292,20 @@ static iree_status_t iree_hal_vulkan_queue_append_dispatch_profile_event(
          sizeof(event_info.workgroup_size));
   event_info.start_tick = ticks[0];
   event_info.end_tick = ticks[1];
-  return iree_hal_local_profile_recorder_append_dispatch_event(
+  return iree_hal_vulkan_profile_recorder_append_dispatch_event(
       submission->profile.recorder, &event_info, /*out_event_id=*/NULL);
 }
 
 static iree_status_t iree_hal_vulkan_queue_record_dispatch_profile_metadata(
     iree_hal_vulkan_queue_pending_submission_t* submission) {
-  iree_hal_local_profile_recorder_t* profile_recorder =
+  iree_hal_vulkan_profile_recorder_t* profile_recorder =
       submission->queue->profile_recorder;
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
           profile_recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_EXECUTABLE_METADATA)) {
     return iree_ok_status();
   }
-  return iree_hal_local_profile_recorder_record_executable_with_id(
+  return iree_hal_vulkan_profile_recorder_record_executable(
       profile_recorder, submission->dispatch.executable,
       iree_hal_vulkan_executable_profile_id(submission->dispatch.executable));
 }
@@ -3525,8 +3525,8 @@ static iree_status_t iree_hal_vulkan_queue_profile_record_queue_device_event(
   submission->profile.queue_device_event_recorded = true;
 
   iree_hal_vulkan_queue_profile_populate_submission_metrics(submission);
-  iree_hal_local_profile_queue_device_event_info_t event_info =
-      iree_hal_local_profile_queue_device_event_info_default();
+  iree_hal_vulkan_profile_queue_device_event_info_t event_info =
+      iree_hal_vulkan_profile_queue_device_event_info_default();
   event_info.type = submission->profile.type;
   event_info.flags = submission->profile.flags;
   event_info.scope = submission->profile.scope;
@@ -3541,7 +3541,7 @@ static iree_status_t iree_hal_vulkan_queue_profile_record_queue_device_event(
       submission->profile.query_values[submission->profile.queue_start_query];
   event_info.end_tick =
       submission->profile.query_values[submission->profile.queue_end_query];
-  return iree_hal_local_profile_recorder_append_queue_device_event(
+  return iree_hal_vulkan_profile_recorder_append_queue_device_event(
       submission->profile.recorder, &event_info, /*out_event_id=*/NULL);
 }
 
@@ -3566,7 +3566,7 @@ static void iree_hal_vulkan_queue_profile_record_memory_event(
     iree_hal_pool_t* pool, iree_hal_buffer_params_t params,
     const iree_hal_pool_reservation_t* reservation, uint64_t backing_id,
     iree_device_size_t length, uint64_t frontier_entry_count) {
-  if (!iree_hal_local_profile_recorder_is_enabled(
+  if (!iree_hal_vulkan_profile_recorder_is_enabled(
           submission->profile.recorder,
           IREE_HAL_DEVICE_PROFILING_DATA_MEMORY_EVENTS)) {
     return;
@@ -3600,7 +3600,7 @@ static void iree_hal_vulkan_queue_profile_record_memory_event(
     }
   }
   iree_hal_vulkan_queue_profile_populate_memory_event_pool_stats(pool, &event);
-  iree_hal_local_profile_recorder_append_memory_event(
+  iree_hal_vulkan_profile_recorder_append_memory_event(
       submission->profile.recorder, &event, /*out_event_id=*/NULL);
 }
 
@@ -6274,8 +6274,8 @@ void iree_hal_vulkan_queue_retire_frontier(iree_hal_vulkan_queue_t* queue) {
 
 void iree_hal_vulkan_queue_set_profile_recorder(
     iree_hal_vulkan_queue_t* queue,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t profile_scope,
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t profile_scope,
     iree_atomic_int64_t* submission_counter,
     iree_hal_vulkan_profile_clock_alignment_t* clock_alignment) {
   if (profile_recorder) {

--- a/runtime/src/iree/hal/drivers/vulkan/queue.h
+++ b/runtime/src/iree/hal/drivers/vulkan/queue.h
@@ -19,10 +19,10 @@
 #include "iree/hal/drivers/vulkan/api.h"
 #include "iree/hal/drivers/vulkan/builtins.h"
 #include "iree/hal/drivers/vulkan/debug_utils.h"
+#include "iree/hal/drivers/vulkan/profile.h"
 #include "iree/hal/drivers/vulkan/queue_stats.h"
 #include "iree/hal/drivers/vulkan/semaphore.h"
 #include "iree/hal/drivers/vulkan/util/libvulkan.h"
-#include "iree/hal/local/profile.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -391,10 +391,10 @@ typedef struct iree_hal_vulkan_queue_t {
   iree_thread_t* completion_thread;
 
   // Active HAL-native profile recorder, when profiling is enabled. Borrowed.
-  iree_hal_local_profile_recorder_t* profile_recorder;
+  iree_hal_vulkan_profile_recorder_t* profile_recorder;
 
   // Queue identity emitted with HAL-native profile records.
-  iree_hal_local_profile_queue_scope_t profile_scope;
+  iree_hal_vulkan_profile_queue_scope_t profile_scope;
 
   // Shared submission id source for HAL-native profile records. Borrowed.
   iree_atomic_int64_t* profile_submission_counter;
@@ -433,8 +433,8 @@ void iree_hal_vulkan_queue_retire_frontier(iree_hal_vulkan_queue_t* queue);
 // Assigns the active HAL-native profile recorder for this queue.
 void iree_hal_vulkan_queue_set_profile_recorder(
     iree_hal_vulkan_queue_t* queue,
-    iree_hal_local_profile_recorder_t* profile_recorder,
-    iree_hal_local_profile_queue_scope_t profile_scope,
+    iree_hal_vulkan_profile_recorder_t* profile_recorder,
+    iree_hal_vulkan_profile_queue_scope_t profile_scope,
     iree_atomic_int64_t* submission_counter,
     iree_hal_vulkan_profile_clock_alignment_t* clock_alignment);
 

--- a/runtime/src/iree/hal/local/BUILD.bazel
+++ b/runtime/src/iree/hal/local/BUILD.bazel
@@ -230,28 +230,3 @@ iree_runtime_cc_test(
         "//runtime/src/iree/testing:gtest_main",
     ],
 )
-
-iree_runtime_cc_library(
-    name = "profile",
-    srcs = ["profile.c"],
-    hdrs = ["profile.h"],
-    deps = [
-        ":executable_loader",
-        "//runtime/src/iree/base",
-        "//runtime/src/iree/base/threading",
-        "//runtime/src/iree/hal",
-        "//runtime/src/iree/hal/utils:profile_event_ring",
-    ],
-)
-
-iree_runtime_cc_test(
-    name = "profile_test",
-    srcs = ["profile_test.cc"],
-    deps = [
-        ":executable_loader",
-        ":profile",
-        "//runtime/src/iree/hal",
-        "//runtime/src/iree/testing:gtest",
-        "//runtime/src/iree/testing:gtest_main",
-    ],
-)

--- a/runtime/src/iree/hal/local/CMakeLists.txt
+++ b/runtime/src/iree/hal/local/CMakeLists.txt
@@ -260,33 +260,4 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
-iree_cc_library(
-  NAME
-    profile
-  HDRS
-    "profile.h"
-  SRCS
-    "profile.c"
-  DEPS
-    ::executable_loader
-    iree::base
-    iree::base::threading
-    iree::hal
-    iree::hal::utils::profile_event_ring
-  PUBLIC
-)
-
-iree_cc_test(
-  NAME
-    profile_test
-  SRCS
-    "profile_test.cc"
-  DEPS
-    ::executable_loader
-    ::profile
-    iree::hal
-    iree::testing::gtest
-    iree::testing::gtest_main
-)
-
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
The profiling recorder under `hal/local` had grown into a shared implementation for two unrelated execution models. Local-task contributed host execution and scheduler-region events, while Vulkan contributed dispatch and device-timestamped queue events through a producer opt-in escape hatch. That made Vulkan depend on local CPU implementation code and forced both drivers to carry each other's state and policy.

This gives local-task and Vulkan private profile recorders with only their native event families, capacities, and append APIs. Local-task owns queue, host-execution, memory, and command-region recording; Vulkan owns queue, dispatch, device-queue, memory, and clock-correlation recording. The producer-data-family extension point disappears, and Vulkan no longer references `hal/local`.

The profile wire schema, sink API, and neutral event-ring primitive remain shared because their representation and behavior are identical. Recorder lifetime, buffering, metadata IDs, capture policy, and producer-specific event validation are now driver-owned so the implementations can evolve independently without reintroducing a cross-driver dependency.

Recorder tests move with their producers and cover each driver's supported event streams and rejection boundary. The obsolete sanitizer exclusion for the former shared test target is removed.
