### PR TITLE
[Infra] Parse Bazel package groups in CMake conversion

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -1159,6 +1159,10 @@ class BuildFileFunctions(object):
     def package(self, **kwargs):
         pass
 
+    def package_group(self, name, packages=None, includes=None, **kwargs):
+        """Ignores a Bazel-only package visibility group."""
+        self._check_no_unhandled_kwargs("package_group", kwargs)
+
     def iree_build_test(self, **kwargs):
         pass
 

--- a/build_tools/bazel_to_cmake/config_test.py
+++ b/build_tools/bazel_to_cmake/config_test.py
@@ -109,6 +109,26 @@ class ConfigTest(unittest.TestCase):
             ["root:other::thing"],
         )
 
+    def test_package_group_has_no_cmake_target(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        repo_cfg = SimpleNamespace(PROJECTS=[], REPO_MAP={"@hrx": ""})
+
+        cmake = bazel_to_cmake_converter.convert_build_file(
+            """
+package_group(
+    name = "implementation_consumers",
+    packages = ["//runtime/src/iree/hal/local/..."],
+    includes = ["//runtime:other_consumers"],
+)
+""",
+            repo_cfg,
+            str(repo_root / "runtime"),
+            repo_root=str(repo_root),
+        )
+
+        self.assertEqual(cmake.count("iree_add_all_subdirs()"), 1)
+        self.assertNotIn("implementation_consumers", cmake)
+
     def test_loom_c_root_targets_strip_filesystem_staging_prefix(self):
         repo_root = Path(__file__).resolve().parents[2]
         loom = bazel_to_cmake_config.include_project(


### PR DESCRIPTION
Bazel-to-CMake conversion of a staged BUILD file currently crashes on `package_group(...)` even though package groups already define runtime's FlatCC visibility boundaries. The converter executes BUILD syntax through a curated Python namespace; `package(...)` and other Bazel-only analysis declarations are represented as no-ops, but `package_group` was absent from that namespace. Any edit selecting a BUILD file containing one therefore fails before its actual targets are converted.

Teach the converter to accept the standard package-group shape of `name`, `packages`, and `includes` while continuing to reject unknown attributes. Package groups intentionally emit no CMake target: they name sets of Bazel packages for target visibility and have no standalone build artifact. A conversion-path test executes a realistic group and verifies that conversion proceeds without leaking the group into generated CMake.
