### PR TITLE
[HAL/LocalTask] Restrict local implementation visibility

### DIFF
--- a/runtime/src/iree/hal/local/BUILD.bazel
+++ b/runtime/src/iree/hal/local/BUILD.bazel
@@ -11,8 +11,24 @@ load("//runtime/build_tools/bazel:cc.bzl", "iree_runtime_cc_library")
 load("//runtime/build_tools/bazel:cc_benchmark.bzl", "iree_runtime_cc_benchmark")
 load("//runtime/build_tools/bazel:cc_test.bzl", "iree_runtime_cc_test")
 
+# Packages that own or assemble the local CPU HAL implementation. This is
+# intentionally exact so other HAL drivers cannot couple to its implementation
+# details without explicitly changing the ownership boundary.
+package_group(
+    name = "implementation_consumers",
+    packages = [
+        "//libhrx/src/libhrx",
+        "//runtime/src/iree/hal/drivers/local_task/...",
+        "//runtime/src/iree/hal/local/...",
+        "//runtime/src/iree/modules/hal/loader",
+        "//runtime/src/iree/tooling",
+    ],
+)
+
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//runtime/src/iree/hal/local:implementation_consumers",
+    ],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/hal/local/elf/BUILD.bazel
+++ b/runtime/src/iree/hal/local/elf/BUILD.bazel
@@ -15,7 +15,9 @@ load(
 )
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//runtime/src/iree/hal/local:implementation_consumers",
+    ],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/hal/local/elf/testdata/BUILD.bazel
+++ b/runtime/src/iree/hal/local/elf/testdata/BUILD.bazel
@@ -8,7 +8,9 @@ load("//build_tools/embed_data:build_defs.bzl", "iree_c_embed_data")
 load("//runtime/build_tools/bazel:cc.bzl", "iree_runtime_cc_binary")
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//runtime/src/iree/hal/local:implementation_consumers",
+    ],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/hal/local/loaders/BUILD.bazel
+++ b/runtime/src/iree/hal/local/loaders/BUILD.bazel
@@ -8,7 +8,9 @@ load("//build_tools/bazel:cmake.bzl", "iree_cmake_extra_content")
 load("//runtime/build_tools/bazel:cc.bzl", "iree_runtime_cc_library")
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//runtime/src/iree/hal/local:implementation_consumers",
+    ],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/hal/local/loaders/registration/BUILD.bazel
+++ b/runtime/src/iree/hal/local/loaders/registration/BUILD.bazel
@@ -8,7 +8,9 @@ load("//build_tools/bazel:select.bzl", "iree_select")
 load("//runtime/build_tools/bazel:cc.bzl", "iree_runtime_cc_library")
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//runtime/src/iree/hal/local:implementation_consumers",
+    ],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/hal/local/plugins/BUILD.bazel
+++ b/runtime/src/iree/hal/local/plugins/BUILD.bazel
@@ -8,7 +8,9 @@ load("//build_tools/bazel:cmake.bzl", "iree_cmake_extra_content")
 load("//runtime/build_tools/bazel:cc.bzl", "iree_runtime_cc_library")
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//runtime/src/iree/hal/local:implementation_consumers",
+    ],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/hal/local/plugins/registration/BUILD.bazel
+++ b/runtime/src/iree/hal/local/plugins/registration/BUILD.bazel
@@ -8,7 +8,9 @@ load("//build_tools/bazel:select.bzl", "iree_select")
 load("//runtime/build_tools/bazel:cc.bzl", "iree_runtime_cc_library")
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = [
+        "//runtime/src/iree/hal/local:implementation_consumers",
+    ],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )


### PR DESCRIPTION
Local-task is now the only HAL driver that uses the host execution implementation under `hal/local`. The synchronous and null drivers are gone, while Vulkan's transient-buffer and profile recorder were split into driver-owned implementations. Despite that contraction, every local package—core executable interfaces, ELF support, loaders, plugins, and registration—remains publicly visible to every Bazel package, leaving the old cross-driver coupling shape available to return silently.

Replace those public defaults with one explicit package group covering the implementation itself, local-task, the HAL loader module, and the tooling and libhrx packages that assemble executable-loader registration. Vulkan, AMDGPU, WebGPU, and any new driver can no longer acquire a dependency on local CPU implementation code without an intentional edit to the reviewed ownership boundary.

This is a package ownership fence, not a rearrangement of the retained CPU executable ABI. Local-task remains a P0 production target, the loader and plugin registration surfaces remain available to the runtime entry points that need them, and the source and generated CMake graphs are unchanged.
