### PR TITLE
[Loom] Preserve refined ABI and type-only query uses

### DIFF
--- a/loom/src/loom/ops/kernel/test/verify.loom-test
+++ b/loom/src/loom/ops/kernel/test/verify.loom-test
@@ -57,6 +57,16 @@ func.def @valid_launch(%count: index, %output: tensor<4xi32>) {
 
 // ====
 
+kernel.decl @refined_buffer_argument_contract() launch(%storage: buffer)
+
+func.def @valid_view_launch(%storage: buffer, %offset: offset) {
+  %view = buffer.view %storage[%offset] : buffer -> view<4xi32>
+  kernel.launch @refined_buffer_argument_contract(%view) : (view<4xi32>)
+  func.return
+}
+
+// ====
+
 kernel.decl @host_launch_only() launch()
 
 kernel.def @launch_rejected_inside_device_kernel() {

--- a/loom/src/loom/ops/kernel/verify.c
+++ b/loom/src/loom/ops/kernel/verify.c
@@ -143,7 +143,8 @@ static iree_status_t loom_kernel_emit_entry_related(
 static bool loom_kernel_entry_type_matches(
     const loom_module_t* module, loom_type_t actual_type,
     loom_type_t expected_type, const loom_type_value_remap_t* value_remap) {
-  if (loom_type_kind(actual_type) == LOOM_TYPE_TENSOR &&
+  const loom_type_kind_t actual_kind = loom_type_kind(actual_type);
+  if ((actual_kind == LOOM_TYPE_TENSOR || actual_kind == LOOM_TYPE_VIEW) &&
       loom_type_kind(expected_type) == LOOM_TYPE_BUFFER) {
     return true;
   }

--- a/loom/src/loom/target/arch/amdgpu/lower/preamble.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/preamble.c
@@ -379,7 +379,8 @@ static bool loom_amdgpu_source_value_has_uses(loom_low_lower_context_t* context,
       source_value >= module->values.count) {
     return false;
   }
-  return !loom_value_has_no_uses(loom_module_value(module, source_value));
+  return !loom_value_has_no_uses(loom_module_value(module, source_value)) ||
+         loom_module_value_has_type_uses(module, source_value);
 }
 
 static bool loom_amdgpu_preamble_query_launch_facts_satisfied(

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_launch_config.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_launch_config.loom-test
@@ -235,6 +235,32 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 4, 
 
 // ====
 
+amdgpu.target<gfx11-generic> @target
+
+kernel.def target(@target) @dynamic_workgroup_count_used_by_type(%workgroups_y: index) {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %workgroups_y, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%output: buffer) {
+  %count_y = kernel.workgroup.count<y> : index
+  %base = index.constant 0 : offset
+  %output_view = buffer.view %output[%base] : buffer -> view<[%count_y]xi32>
+  %value = scalar.constant 7 : i32
+  view.store %value, %output_view[0] : i32, view<[%count_y]xi32>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) @dynamic_workgroup_count_used_by_type() asm {
+  %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %12 = v_mov_b32 7
+  %13 = v_mov_b32 0
+  global_store_b32_saddr %13, %12, %output_view
+  return
+}
+
+// ====
+
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @target_subgroup_queries_use_wavefront_size() {


### PR DESCRIPTION
Loom now preserves two structural contracts that were previously mistaken for ordinary value mismatches or dead queries.

Kernel entry ABIs remain storage-oriented: a `buffer` parameter can be launched with a typed `view` just as it can with a tensor. The view is a refinement of the same opaque storage rather than a different device ABI, so command programs can pass typed subranges without erasing useful shape and element information before the launch boundary.

AMDGPU preamble lowering now counts dynamic type references as real SSA uses. A workgroup-count query used only to size a view has no ordinary operand user, but its value still controls the program's memory shape. Keeping that query live until source-to-low type lowering completes prevents target lowering from dropping the value prematurely.

Together these fixes make typed command-program bindings and type-driven launch geometry compose through the same kernel contract used by direct launches.
