### PR TITLE
[Runtime] Make native threading a target invariant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,18 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Native runtime targets require thread creation. Browser WebAssembly uses its
+# host event loop, while bare-metal WebAssembly has no thread creation service.
+# Neither target links a thread library. This is a target capability, not a
+# build option.
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _IREE_TARGET_SYSTEM_PROCESSOR)
+if(EMSCRIPTEN OR _IREE_TARGET_SYSTEM_PROCESSOR MATCHES "^wasm(32|64)$")
+  set(IREE_TARGET_HAS_THREADS OFF)
+else()
+  set(IREE_TARGET_HAS_THREADS ON)
+endif()
+unset(_IREE_TARGET_SYSTEM_PROCESSOR)
+
 set(HRX_IDE_FOLDER HRX)
 set(IREE_IDE_FOLDER IREE)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -141,7 +153,7 @@ hrx_configure_ipo()
 if(IREE_BUILD_TESTS)
   iree_configure_googletest()
 endif()
-if(IREE_ENABLE_THREADING AND (IREE_BUILD_TESTS OR IREE_BUILD_BENCHMARKS))
+if(IREE_TARGET_HAS_THREADS AND (IREE_BUILD_TESTS OR IREE_BUILD_BENCHMARKS))
   iree_configure_google_benchmark()
 endif()
 iree_configure_libbacktrace()

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -357,13 +357,6 @@ if(CMAKE_CXX_FLAGS AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
-if(IREE_ENABLE_THREADING)
-  iree_select_compiler_opts(IREE_DEFAULT_COPTS
-    ALL
-      "-DIREE_THREADING_ENABLE=1"
-  )
-endif()
-
 if(IREE_SYNCHRONIZATION_DISABLE_UNSAFE)
   iree_select_compiler_opts(IREE_DEFAULT_COPTS
     ALL
@@ -372,28 +365,14 @@ if(IREE_SYNCHRONIZATION_DISABLE_UNSAFE)
 endif()
 
 # Find and add threads as dependency.
-if(NOT ANDROID AND IREE_ENABLE_THREADING)
+if(IREE_TARGET_HAS_THREADS AND NOT ANDROID)
   set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
   set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  find_package(Threads)
+  find_package(Threads REQUIRED)
   set(IREE_THREADS_DEPS Threads::Threads)
 else()
-  # Android provides its own pthreads support with no linking required.
-endif()
-
-# Emscripten needs -pthread specified in link _and_ compile options when using
-# atomics, shared memory, or pthreads. If we bring our own threading impl and
-# try to omit this, we get this error:
-#   `--shared-memory is disallowed because it was not compiled with 'atomics'
-#    or 'bulk-memory' features`
-# TODO(scotttodd): Figure out how to use atomics and/or shared memory without
-#                  Specifying this flag
-# https://emscripten.org/docs/porting/pthreads.html#compiling-with-pthreads-enabled
-if(EMSCRIPTEN AND IREE_ENABLE_THREADING)
-  iree_select_compiler_opts(IREE_DEFAULT_COPTS
-    ALL
-      "-pthread"
-  )
+  # Android provides pthreads through its platform libc. WebAssembly targets
+  # have no native thread services and must not link pthread support.
 endif()
 
 if(ANDROID)

--- a/build_tools/third_party/README.md
+++ b/build_tools/third_party/README.md
@@ -196,7 +196,7 @@ dependency. The top-level project configuration owns enablement policy:
 if(IREE_BUILD_TESTS)
   iree_configure_googletest()
 endif()
-if(IREE_ENABLE_THREADING AND IREE_BUILD_BENCHMARKS)
+if(IREE_TARGET_HAS_THREADS AND IREE_BUILD_BENCHMARKS)
   iree_configure_google_benchmark()
 endif()
 if(IREE_HAL_DRIVER_AMDGPU)

--- a/runtime/project.cmake
+++ b/runtime/project.cmake
@@ -28,7 +28,6 @@ set(IREE_TRACING_MODE_DEFAULT "2" CACHE STRING
 set(IREE_TRACING_MODE ${IREE_TRACING_MODE_DEFAULT} CACHE STRING
   "Tracing feature/verbosity mode. See iree/base/tracing.h for more.")
 
-option(IREE_ENABLE_THREADING "Builds IREE with thread library support." ON)
 option(IREE_SYNCHRONIZATION_DISABLE_UNSAFE
   "Disables synchronization primitives for single-threaded bare-metal targets only."
   OFF)
@@ -60,7 +59,7 @@ if(NOT DEFINED IREE_HAL_DRIVER_AMDGPU_DEFAULT)
   set(IREE_HAL_DRIVER_AMDGPU_DEFAULT ${IREE_HAL_DRIVER_DEFAULTS})
 endif()
 if(NOT DEFINED IREE_HAL_DRIVER_LOCAL_TASK_DEFAULT)
-  set(IREE_HAL_DRIVER_LOCAL_TASK_DEFAULT ON)
+  set(IREE_HAL_DRIVER_LOCAL_TASK_DEFAULT ${IREE_TARGET_HAS_THREADS})
 endif()
 if(NOT DEFINED IREE_HAL_DRIVER_VULKAN_DEFAULT)
   set(IREE_HAL_DRIVER_VULKAN_DEFAULT ${IREE_HAL_DRIVER_DEFAULTS})
@@ -74,6 +73,10 @@ option(IREE_HAL_DRIVER_AMDGPU
 option(IREE_HAL_DRIVER_LOCAL_TASK
   "Enables the local-task runtime HAL driver."
   ${IREE_HAL_DRIVER_LOCAL_TASK_DEFAULT})
+if(IREE_HAL_DRIVER_LOCAL_TASK AND NOT IREE_TARGET_HAS_THREADS)
+  message(FATAL_ERROR
+    "IREE_HAL_DRIVER_LOCAL_TASK requires native thread creation support")
+endif()
 option(IREE_HAL_DRIVER_VULKAN
   "Enables the Vulkan runtime HAL driver."
   ${IREE_HAL_DRIVER_VULKAN_DEFAULT})

--- a/runtime/src/iree/base/config.h
+++ b/runtime/src/iree/base/config.h
@@ -141,13 +141,6 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 #define IREE_SYNCHRONIZATION_DISABLE_UNSAFE 0
 #endif  // !IREE_SYNCHRONIZATION_DISABLE_UNSAFE
 
-#if !defined(IREE_THREADING_ENABLE)
-// On platforms without threads (no pthreads or equivalent available) or in
-// applications where no threads are transitively used, all thread support code
-// can be stripped out.
-#define IREE_THREADING_ENABLE 1
-#endif  // !IREE_THREADING_ENABLE
-
 //===----------------------------------------------------------------------===//
 // File I/O
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/hal/replay/recorder.c
+++ b/runtime/src/iree/hal/replay/recorder.c
@@ -15,6 +15,8 @@
 #elif defined(IREE_PLATFORM_LINUX)
 #include <sys/syscall.h>
 #include <unistd.h>
+#elif defined(IREE_PLATFORM_WINDOWS)
+#include <windows.h>
 #endif  // IREE_PLATFORM_*
 
 #include "iree/base/internal/atomics.h"
@@ -60,7 +62,7 @@ struct iree_hal_replay_recorder_t {
 };
 
 static uint64_t iree_hal_replay_current_thread_id(void) {
-#if defined(IREE_SYNCHRONIZATION_DISABLE_UNSAFE)
+#if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
   return 0;
 #elif defined(IREE_PLATFORM_ANDROID)
   return (uint64_t)gettid();

--- a/runtime/src/iree/hal/replay/recorder_test.cc
+++ b/runtime/src/iree/hal/replay/recorder_test.cc
@@ -140,6 +140,8 @@ iree::testing::TempFilePath WriteTempFile(iree_const_byte_span_t contents) {
         // IREE_PLATFORM_LINUX)
 
 struct ReplayRecordSummary {
+  // Capture-time thread identifier on the session record.
+  uint64_t session_thread_id = 0;
   iree_host_size_t session_record_count = 0;
   iree_host_size_t device_object_record_count = 0;
   iree_host_size_t allocator_object_record_count = 0;
@@ -200,6 +202,7 @@ static ReplayRecordSummary ParseReplayRecordSummary(
     EXPECT_EQ(expected_sequence_ordinal++, record.header.sequence_ordinal);
     switch (record.header.record_type) {
       case IREE_HAL_REPLAY_FILE_RECORD_TYPE_SESSION:
+        summary.session_thread_id = record.header.thread_id;
         ++summary.session_record_count;
         break;
       case IREE_HAL_REPLAY_FILE_RECORD_TYPE_OBJECT:
@@ -402,6 +405,24 @@ static iree_status_t CountHostCall(void* user_data, const uint64_t args[4],
   (void)context;
   ++*(int*)user_data;
   return iree_ok_status();
+}
+
+TEST(ReplayRecorderTest, RecordsAvailableThreadIdentifier) {
+  std::vector<uint8_t> storage(4096, 0);
+  iree_hal_replay_recorder_t* recorder = CreateHostAllocationRecorder(&storage);
+  IREE_ASSERT_OK(iree_hal_replay_recorder_close(recorder));
+  iree_hal_replay_recorder_release(recorder);
+
+  ReplayRecordSummary summary = ParseReplayRecordSummary(storage);
+  EXPECT_EQ(1u, summary.session_record_count);
+#if IREE_SYNCHRONIZATION_DISABLE_UNSAFE
+  EXPECT_EQ(0u, summary.session_thread_id);
+#elif defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_APPLE) || \
+    defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_WINDOWS)
+  EXPECT_NE(0u, summary.session_thread_id);
+#else
+  EXPECT_EQ(0u, summary.session_thread_id);
+#endif  // native thread identifiers available
 }
 
 TEST(ReplayRecorderTest, RecordsNamedScopes) {

--- a/runtime/src/iree/task/BUILD.bazel
+++ b/runtime/src/iree/task/BUILD.bazel
@@ -17,8 +17,8 @@ package(
 
 iree_cmake_extra_content(
     content = """
-# Task-based executor requires threading support.
-if(NOT IREE_ENABLE_THREADING)
+# The task executor requires native thread creation.
+if(NOT IREE_TARGET_HAS_THREADS)
   return()
 endif()
 """,

--- a/runtime/src/iree/task/CMakeLists.txt
+++ b/runtime/src/iree/task/CMakeLists.txt
@@ -7,8 +7,8 @@
 # To disable autogeneration for this file entirely, delete this header.        #
 ################################################################################
 
-# Task-based executor requires threading support.
-if(NOT IREE_ENABLE_THREADING)
+# The task executor requires native thread creation.
+if(NOT IREE_TARGET_HAS_THREADS)
   return()
 endif()
 

--- a/runtime/src/iree/testing/CMakeLists.txt
+++ b/runtime/src/iree/testing/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 iree_add_all_subdirs()
 
-if(IREE_ENABLE_THREADING AND IREE_BUILD_BENCHMARKS)
+if(IREE_TARGET_HAS_THREADS AND IREE_BUILD_BENCHMARKS)
   iree_cc_library(
     NAME
       benchmark

--- a/runtime/src/iree/tools/iree-dump-cpuinfo/BUILD.bazel
+++ b/runtime/src/iree/tools/iree-dump-cpuinfo/BUILD.bazel
@@ -16,7 +16,7 @@ package(
 
 iree_cmake_extra_content(
     content = """
-if(IREE_ENABLE_THREADING)
+if(IREE_TARGET_HAS_THREADS)
 """,
     inline = True,
 )

--- a/runtime/src/iree/tools/iree-dump-cpuinfo/CMakeLists.txt
+++ b/runtime/src/iree/tools/iree-dump-cpuinfo/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 iree_add_all_subdirs()
 
-if(IREE_ENABLE_THREADING)
+if(IREE_TARGET_HAS_THREADS)
 
 iree_cc_binary(
   NAME


### PR DESCRIPTION
`IREE_ENABLE_THREADING` did not produce a coherent threadless runtime. It only pruned the task executor and several benchmark/tool CMake targets while thread creation and synchronization code remained live, local-task stayed enabled by default, and Bazel had no corresponding configuration. This removes that misleading build state and treats native thread creation as a target capability.

Native targets now always resolve their platform thread service. Browser and bare-metal WebAssembly targets derive the threadless capability, omit the task executor by default, and reject an explicit local-task configuration that cannot work. `IREE_SYNCHRONIZATION_DISABLE_UNSAFE` remains the separate single-threaded synchronization policy, while the unused `IREE_THREADING_ENABLE` preprocessor definition is removed.

The same audit found that replay checked whether `IREE_SYNCHRONIZATION_DISABLE_UNSAFE` was defined instead of whether it was enabled. Because the runtime configuration always defines the macro, native captures recorded every thread ID as zero. Replay now tests the macro value, declares its Windows API dependency directly, and has behavioral coverage for native session thread identifiers.

### Reviewer notes

The main review surface is the target-capability derivation and its local-task invariant in the root/runtime CMake configuration. The replay change is small but corrects persisted capture metadata on every native platform.
