### PR TITLE
[Loom] Add scheduler-independent JIT task composition

### DIFF
--- a/loom/binding/c/BUILD.bazel
+++ b/loom/binding/c/BUILD.bazel
@@ -268,3 +268,30 @@ loom_cc_library(
         "//loom/binding/c/target/spirv/vulkaninfo",
     ],
 )
+
+iree_cmake_extra_content(
+    content = """
+if(IREE_TARGET_HAS_THREADS)
+""",
+    inline = True,
+)
+
+loom_cc_library(
+    name = "task_pool",
+    srcs = ["src/task_pool.c"],
+    hdrs = ["include/loomc/task_pool.h"],
+    includes = ["include"],
+    deps = [
+        ":loomc",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/task",
+    ],
+)
+
+iree_cmake_extra_content(
+    content = """
+endif()
+""",
+    inline = True,
+)

--- a/loom/binding/c/BUILD.bazel
+++ b/loom/binding/c/BUILD.bazel
@@ -48,6 +48,7 @@ LOOMC_PUBLIC_HDRS = [
     "include/loomc/sanitizer.h",
     "include/loomc/source.h",
     "include/loomc/status.h",
+    "include/loomc/task.h",
     "include/loomc/target.h",
     "include/loomc/workspace.h",
 ]
@@ -152,6 +153,7 @@ loom_cc_library(
         "src/source.c",
         "src/status.c",
         "src/target.c",
+        "src/task.c",
         "src/workspace.c",
     ],
     hdrs = LOOMC_PUBLIC_HDRS + [

--- a/loom/binding/c/BUILD.bazel
+++ b/loom/binding/c/BUILD.bazel
@@ -279,10 +279,26 @@ if(IREE_TARGET_HAS_THREADS)
 loom_cc_library(
     name = "task_pool",
     srcs = ["src/task_pool.c"],
-    hdrs = ["include/loomc/task_pool.h"],
+    hdrs = [
+        "include/loomc/iree/task_pool.h",
+        "include/loomc/task_pool.h",
+    ],
     includes = ["include"],
     deps = [
         ":loomc",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/task",
+    ],
+)
+
+loom_cc_library(
+    name = "task_queue",
+    srcs = ["src/task_queue.c"],
+    hdrs = ["include/loomc/task_queue.h"],
+    includes = ["include"],
+    deps = [
+        ":loomc",
+        ":task_pool",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/threading",
         "//runtime/src/iree/task",

--- a/loom/binding/c/CMakeLists.txt
+++ b/loom/binding/c/CMakeLists.txt
@@ -219,6 +219,28 @@ loom_cc_library(
 )
 endif()
 
+if(IREE_TARGET_HAS_THREADS)
+
+loom_cc_library(
+  NAME
+    task_pool
+  HDRS
+    "include/loomc/task_pool.h"
+  SRCS
+    "src/task_pool.c"
+  DEPS
+    ::loomc
+    iree::base
+    iree::base::threading
+    iree::task
+  INCLUDES
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  PUBLIC
+)
+
+endif()
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
 include(CMakePackageConfigHelpers)

--- a/loom/binding/c/CMakeLists.txt
+++ b/loom/binding/c/CMakeLists.txt
@@ -225,11 +225,30 @@ loom_cc_library(
   NAME
     task_pool
   HDRS
+    "include/loomc/iree/task_pool.h"
     "include/loomc/task_pool.h"
   SRCS
     "src/task_pool.c"
   DEPS
     ::loomc
+    iree::base
+    iree::task
+  INCLUDES
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  PUBLIC
+)
+
+loom_cc_library(
+  NAME
+    task_queue
+  HDRS
+    "include/loomc/task_queue.h"
+  SRCS
+    "src/task_queue.c"
+  DEPS
+    ::loomc
+    ::task_pool
     iree::base
     iree::base::threading
     iree::task

--- a/loom/binding/c/CMakeLists.txt
+++ b/loom/binding/c/CMakeLists.txt
@@ -40,6 +40,7 @@ loom_cc_library(
     "include/loomc/source.h"
     "include/loomc/status.h"
     "include/loomc/target.h"
+    "include/loomc/task.h"
     "include/loomc/workspace.h"
     "src/config.h"
     "src/context.h"
@@ -89,6 +90,7 @@ loom_cc_library(
     "src/source.c"
     "src/status.c"
     "src/target.c"
+    "src/task.c"
     "src/workspace.c"
   DEPS
     iree::base
@@ -199,6 +201,7 @@ loom_cc_library(
     "include/loomc/target/spirv/profile.h"
     "include/loomc/target/spirv/vulkan.h"
     "include/loomc/target/spirv/vulkaninfo.h"
+    "include/loomc/task.h"
     "include/loomc/workspace.h"
   DEPS
     ::loomc

--- a/loom/binding/c/benchmark/BUILD.bazel
+++ b/loom/binding/c/benchmark/BUILD.bazel
@@ -134,14 +134,15 @@ if(IREE_TARGET_HAS_THREADS)
 )
 
 loom_cc_benchmark(
-    name = "task_pool_benchmark",
-    srcs = ["task_pool_benchmark.cc"],
+    name = "task_queue_benchmark",
+    srcs = ["task_queue_benchmark.cc"],
     args = [
-        "--benchmark_filter=BM_TaskPoolSubmitOnly/4/64",
+        "--benchmark_filter=BM_TaskQueueSubmitOnly/4/64",
     ],
     deps = [
         "//loom/binding/c:loomc",
         "//loom/binding/c:task_pool",
+        "//loom/binding/c:task_queue",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/threading",
         "//runtime/src/iree/testing:benchmark_main",

--- a/loom/binding/c/benchmark/BUILD.bazel
+++ b/loom/binding/c/benchmark/BUILD.bazel
@@ -7,6 +7,7 @@
 load("//build_tools/embed_data:build_defs.bzl", "iree_c_embed_data")
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
+    "iree_cmake_extra_content",
     "loom_cc_benchmark",
     "loom_cc_library",
 )
@@ -123,4 +124,33 @@ loom_cc_benchmark(
         "//runtime/src/iree/base",
         "//runtime/src/iree/testing:benchmark_main",
     ],
+)
+
+iree_cmake_extra_content(
+    content = """
+if(IREE_TARGET_HAS_THREADS)
+""",
+    inline = True,
+)
+
+loom_cc_benchmark(
+    name = "task_pool_benchmark",
+    srcs = ["task_pool_benchmark.cc"],
+    args = [
+        "--benchmark_filter=BM_TaskPoolSubmitOnly/4/64",
+    ],
+    deps = [
+        "//loom/binding/c:loomc",
+        "//loom/binding/c:task_pool",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/testing:benchmark_main",
+    ],
+)
+
+iree_cmake_extra_content(
+    content = """
+endif()
+""",
+    inline = True,
 )

--- a/loom/binding/c/benchmark/CMakeLists.txt
+++ b/loom/binding/c/benchmark/CMakeLists.txt
@@ -138,17 +138,18 @@ if(IREE_TARGET_HAS_THREADS)
 
 loom_cc_benchmark(
   NAME
-    task_pool_benchmark
+    task_queue_benchmark
   SRCS
-    "task_pool_benchmark.cc"
+    "task_queue_benchmark.cc"
   DEPS
     iree::base
     iree::base::threading
     iree::testing::benchmark_main
     loom::binding::c::loomc
     loom::binding::c::task_pool
+    loom::binding::c::task_queue
   ARGS
-    "--benchmark_filter=BM_TaskPoolSubmitOnly/4/64"
+    "--benchmark_filter=BM_TaskQueueSubmitOnly/4/64"
   TESTONLY
 )
 

--- a/loom/binding/c/benchmark/CMakeLists.txt
+++ b/loom/binding/c/benchmark/CMakeLists.txt
@@ -134,4 +134,24 @@ loom_cc_benchmark(
   TESTONLY
 )
 
+if(IREE_TARGET_HAS_THREADS)
+
+loom_cc_benchmark(
+  NAME
+    task_pool_benchmark
+  SRCS
+    "task_pool_benchmark.cc"
+  DEPS
+    iree::base
+    iree::base::threading
+    iree::testing::benchmark_main
+    loom::binding::c::loomc
+    loom::binding::c::task_pool
+  ARGS
+    "--benchmark_filter=BM_TaskPoolSubmitOnly/4/64"
+  TESTONLY
+)
+
+endif()
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/loom/binding/c/benchmark/task_pool_benchmark.cc
+++ b/loom/binding/c/benchmark/task_pool_benchmark.cc
@@ -1,0 +1,176 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <memory>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "iree/base/api.h"
+#include "iree/base/threading/notification.h"
+#include "loomc/iree.h"
+#include "loomc/task_pool.h"
+
+namespace {
+
+template <typename T, void (*Free)(T*)>
+struct HandleDeleter {
+  void operator()(T* value) const { Free(value); }
+};
+
+using TaskPoolPtr =
+    std::unique_ptr<loomc_task_pool_t,
+                    HandleDeleter<loomc_task_pool_t, loomc_task_pool_free>>;
+
+typedef struct task_batch_t {
+  // Number of tasks that have not completed execution.
+  iree_atomic_int32_t remaining_count;
+
+  // Posted when the final task completes.
+  iree_notification_t notification;
+} task_batch_t;
+
+typedef struct benchmark_task_t {
+  // Generic task base reinitialized before each submission.
+  loomc_task_t base;
+
+  // Shared batch completion state.
+  task_batch_t* batch;
+} benchmark_task_t;
+
+static void CompleteBenchmarkTask(benchmark_task_t* task) {
+  const int32_t previous = iree_atomic_fetch_sub(&task->batch->remaining_count,
+                                                 1, iree_memory_order_acq_rel);
+  if (previous == 1) {
+    iree_notification_post(&task->batch->notification, IREE_ALL_WAITERS);
+  }
+}
+
+static void ExecuteBenchmarkTask(loomc_task_t* base_task,
+                                 loomc_host_size_t worker_ordinal) {
+  (void)base_task;
+  (void)worker_ordinal;
+}
+
+static void DestroyBenchmarkTask(loomc_task_t* base_task) {
+  CompleteBenchmarkTask(reinterpret_cast<benchmark_task_t*>(base_task));
+}
+
+static const loomc_task_vtable_t kBenchmarkTaskVtable = {
+    /*.execute=*/ExecuteBenchmarkTask,
+    /*.destroy=*/DestroyBenchmarkTask,
+};
+
+static bool TaskBatchComplete(void* user_data) {
+  const task_batch_t* batch = static_cast<const task_batch_t*>(user_data);
+  return iree_atomic_load(&batch->remaining_count, iree_memory_order_acquire) ==
+         0;
+}
+
+class TaskPoolBenchmarkFixture {
+ public:
+  TaskPoolBenchmarkFixture(loomc_host_size_t worker_count,
+                           loomc_host_size_t task_count)
+      : tasks_(task_count) {
+    loomc_task_pool_options_t options = {
+        /*.type=*/LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS,
+        /*.structure_size=*/sizeof(loomc_task_pool_options_t),
+        /*.next=*/nullptr,
+        /*.max_worker_count=*/worker_count,
+        /*.worker_stack_size=*/0,
+    };
+    loomc_task_pool_t* pool = nullptr;
+    IREE_CHECK_OK(iree_status_from_loomc(
+        loomc_task_pool_allocate(&options, loomc_allocator_system(), &pool)));
+    pool_.reset(pool);
+    sink_ = loomc_task_pool_sink(pool_.get());
+    iree_atomic_store(&batch_.remaining_count, 0, iree_memory_order_relaxed);
+    iree_notification_initialize(&batch_.notification);
+    for (benchmark_task_t& task : tasks_) task.batch = &batch_;
+  }
+
+  ~TaskPoolBenchmarkFixture() {
+    pool_.reset();
+    iree_notification_deinitialize(&batch_.notification);
+  }
+
+  loomc_host_size_t task_count() const { return tasks_.size(); }
+
+  void SubmitBatch() {
+    iree_atomic_store(&batch_.remaining_count, (int32_t)tasks_.size(),
+                      iree_memory_order_release);
+    for (benchmark_task_t& task : tasks_) {
+      loomc_task_initialize(&kBenchmarkTaskVtable, &task.base);
+      IREE_CHECK_OK(
+          iree_status_from_loomc(loomc_task_sink_submit(sink_, &task.base)));
+    }
+  }
+
+  void AwaitBatch() {
+    iree_notification_await(&batch_.notification, TaskBatchComplete, &batch_,
+                            iree_infinite_timeout());
+  }
+
+ private:
+  // Standard worker pool under measurement.
+  TaskPoolPtr pool_;
+
+  // Borrowed sink backed by |pool_|.
+  loomc_task_sink_t sink_ = {0};
+
+  // Completion state shared by every task in one iteration.
+  task_batch_t batch_;
+
+  // Reusable task storage excluded from iteration allocation costs.
+  std::vector<benchmark_task_t> tasks_;
+};
+
+// Measures caller time spent initializing and submitting already-allocated
+// tasks. Final task completion is kept outside of the timed region.
+static void BM_TaskPoolSubmitOnly(benchmark::State& state) {
+  TaskPoolBenchmarkFixture fixture((loomc_host_size_t)state.range(0),
+                                   (loomc_host_size_t)state.range(1));
+  for (auto _ : state) {
+    fixture.SubmitBatch();
+    state.PauseTiming();
+    fixture.AwaitBatch();
+    state.ResumeTiming();
+  }
+  state.SetItemsProcessed(state.iterations() * fixture.task_count());
+}
+BENCHMARK(BM_TaskPoolSubmitOnly)
+    ->Args({1, 1})
+    ->Args({1, 64})
+    ->Args({4, 1})
+    ->Args({4, 64})
+    ->Args({4, 1024})
+    ->Args({8, 1})
+    ->Args({8, 64})
+    ->Args({8, 1024})
+    ->UseRealTime();
+
+// Measures the user-visible round trip from task initialization and submission
+// through completion of the entire batch.
+static void BM_TaskPoolEndToEnd(benchmark::State& state) {
+  TaskPoolBenchmarkFixture fixture((loomc_host_size_t)state.range(0),
+                                   (loomc_host_size_t)state.range(1));
+  for (auto _ : state) {
+    fixture.SubmitBatch();
+    fixture.AwaitBatch();
+  }
+  state.SetItemsProcessed(state.iterations() * fixture.task_count());
+}
+BENCHMARK(BM_TaskPoolEndToEnd)
+    ->Args({1, 1})
+    ->Args({1, 64})
+    ->Args({4, 1})
+    ->Args({4, 64})
+    ->Args({4, 1024})
+    ->Args({8, 1})
+    ->Args({8, 64})
+    ->Args({8, 1024})
+    ->UseRealTime();
+
+}  // namespace

--- a/loom/binding/c/benchmark/task_queue_benchmark.cc
+++ b/loom/binding/c/benchmark/task_queue_benchmark.cc
@@ -12,6 +12,7 @@
 #include "iree/base/threading/notification.h"
 #include "loomc/iree.h"
 #include "loomc/task_pool.h"
+#include "loomc/task_queue.h"
 
 namespace {
 
@@ -23,6 +24,9 @@ struct HandleDeleter {
 using TaskPoolPtr =
     std::unique_ptr<loomc_task_pool_t,
                     HandleDeleter<loomc_task_pool_t, loomc_task_pool_free>>;
+using TaskQueuePtr =
+    std::unique_ptr<loomc_task_queue_t,
+                    HandleDeleter<loomc_task_queue_t, loomc_task_queue_free>>;
 
 typedef struct task_batch_t {
   // Number of tasks that have not completed execution.
@@ -69,10 +73,10 @@ static bool TaskBatchComplete(void* user_data) {
          0;
 }
 
-class TaskPoolBenchmarkFixture {
+class TaskQueueBenchmarkFixture {
  public:
-  TaskPoolBenchmarkFixture(loomc_host_size_t worker_count,
-                           loomc_host_size_t task_count)
+  TaskQueueBenchmarkFixture(loomc_host_size_t worker_count,
+                            loomc_host_size_t task_count)
       : tasks_(task_count) {
     loomc_task_pool_options_t options = {
         /*.type=*/LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS,
@@ -85,14 +89,18 @@ class TaskPoolBenchmarkFixture {
     IREE_CHECK_OK(iree_status_from_loomc(
         loomc_task_pool_allocate(&options, loomc_allocator_system(), &pool)));
     pool_.reset(pool);
-    sink_ = loomc_task_pool_sink(pool_.get());
+    loomc_task_queue_t* queue = nullptr;
+    IREE_CHECK_OK(iree_status_from_loomc(loomc_task_queue_allocate(
+        pool_.get(), loomc_allocator_system(), &queue)));
+    queue_.reset(queue);
+    sink_ = loomc_task_queue_sink(queue_.get());
     iree_atomic_store(&batch_.remaining_count, 0, iree_memory_order_relaxed);
     iree_notification_initialize(&batch_.notification);
     for (benchmark_task_t& task : tasks_) task.batch = &batch_;
   }
 
-  ~TaskPoolBenchmarkFixture() {
-    pool_.reset();
+  ~TaskQueueBenchmarkFixture() {
+    queue_.reset();
     iree_notification_deinitialize(&batch_.notification);
   }
 
@@ -114,10 +122,13 @@ class TaskPoolBenchmarkFixture {
   }
 
  private:
-  // Standard worker pool under measurement.
+  // Shared worker population under measurement.
   TaskPoolPtr pool_;
 
-  // Borrowed sink backed by |pool_|.
+  // Task scheduling domain attached to `pool_`.
+  TaskQueuePtr queue_;
+
+  // Borrowed sink backed by `queue_`.
   loomc_task_sink_t sink_ = {0};
 
   // Completion state shared by every task in one iteration.
@@ -129,9 +140,9 @@ class TaskPoolBenchmarkFixture {
 
 // Measures caller time spent initializing and submitting already-allocated
 // tasks. Final task completion is kept outside of the timed region.
-static void BM_TaskPoolSubmitOnly(benchmark::State& state) {
-  TaskPoolBenchmarkFixture fixture((loomc_host_size_t)state.range(0),
-                                   (loomc_host_size_t)state.range(1));
+static void BM_TaskQueueSubmitOnly(benchmark::State& state) {
+  TaskQueueBenchmarkFixture fixture((loomc_host_size_t)state.range(0),
+                                    (loomc_host_size_t)state.range(1));
   for (auto _ : state) {
     fixture.SubmitBatch();
     state.PauseTiming();
@@ -140,7 +151,7 @@ static void BM_TaskPoolSubmitOnly(benchmark::State& state) {
   }
   state.SetItemsProcessed(state.iterations() * fixture.task_count());
 }
-BENCHMARK(BM_TaskPoolSubmitOnly)
+BENCHMARK(BM_TaskQueueSubmitOnly)
     ->Args({1, 1})
     ->Args({1, 64})
     ->Args({4, 1})
@@ -153,16 +164,16 @@ BENCHMARK(BM_TaskPoolSubmitOnly)
 
 // Measures the user-visible round trip from task initialization and submission
 // through completion of the entire batch.
-static void BM_TaskPoolEndToEnd(benchmark::State& state) {
-  TaskPoolBenchmarkFixture fixture((loomc_host_size_t)state.range(0),
-                                   (loomc_host_size_t)state.range(1));
+static void BM_TaskQueueEndToEnd(benchmark::State& state) {
+  TaskQueueBenchmarkFixture fixture((loomc_host_size_t)state.range(0),
+                                    (loomc_host_size_t)state.range(1));
   for (auto _ : state) {
     fixture.SubmitBatch();
     fixture.AwaitBatch();
   }
   state.SetItemsProcessed(state.iterations() * fixture.task_count());
 }
-BENCHMARK(BM_TaskPoolEndToEnd)
+BENCHMARK(BM_TaskQueueEndToEnd)
     ->Args({1, 1})
     ->Args({1, 64})
     ->Args({4, 1})

--- a/loom/binding/c/example/BUILD.bazel
+++ b/loom/binding/c/example/BUILD.bazel
@@ -96,6 +96,7 @@ loom_cc_binary(
     deps = [
         "//loom/binding/c:loomc",
         "//loom/binding/c:task_pool",
+        "//loom/binding/c:task_queue",
     ],
 )
 

--- a/loom/binding/c/example/BUILD.bazel
+++ b/loom/binding/c/example/BUILD.bazel
@@ -9,6 +9,7 @@ load("//build_tools/embed_data:build_defs.bzl", "iree_c_embed_data")
 load("//build_tools/sanitizer:suppressions.bzl", "vulkan_suppressions")
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
+    "iree_cmake_extra_content",
     "loom_cc_binary",
     "loom_cc_test",
     "loom_config_compatible_with",
@@ -80,6 +81,34 @@ loom_cc_binary(
 iree_executable_test(
     name = "product_frontier_test",
     src = ":product_frontier",
+)
+
+iree_cmake_extra_content(
+    content = """
+if(IREE_TARGET_HAS_THREADS)
+""",
+    inline = True,
+)
+
+loom_cc_binary(
+    name = "jit_task_pool",
+    srcs = ["jit_task_pool.c"],
+    deps = [
+        "//loom/binding/c:loomc",
+        "//loom/binding/c:task_pool",
+    ],
+)
+
+iree_executable_test(
+    name = "jit_task_pool_test",
+    src = ":jit_task_pool",
+)
+
+iree_cmake_extra_content(
+    content = """
+endif()
+""",
+    inline = True,
 )
 
 loom_cc_binary(

--- a/loom/binding/c/example/CMakeLists.txt
+++ b/loom/binding/c/example/CMakeLists.txt
@@ -60,6 +60,27 @@ iree_native_test(
     ::product_frontier
 )
 
+if(IREE_TARGET_HAS_THREADS)
+
+loom_cc_binary(
+  NAME
+    jit_task_pool
+  SRCS
+    "jit_task_pool.c"
+  DEPS
+    loom::binding::c::loomc
+    loom::binding::c::task_pool
+)
+
+iree_native_test(
+  NAME
+    "jit_task_pool_test"
+  SRC
+    ::jit_task_pool
+)
+
+endif()
+
 if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV)
 loom_cc_binary(
   NAME

--- a/loom/binding/c/example/CMakeLists.txt
+++ b/loom/binding/c/example/CMakeLists.txt
@@ -70,6 +70,7 @@ loom_cc_binary(
   DEPS
     loom::binding::c::loomc
     loom::binding::c::task_pool
+    loom::binding::c::task_queue
 )
 
 iree_native_test(

--- a/loom/binding/c/example/jit_task_pool.c
+++ b/loom/binding/c/example/jit_task_pool.c
@@ -1,0 +1,388 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdio.h>
+#include <string.h>
+
+#include "loomc/loomc.h"
+#include "loomc/task_pool.h"
+
+static const char kSourceText[] =
+    "config.decl @variant : %value: index where [range(%value, 1, 9)]\n"
+    "func.def public @entry() -> (index) {\n"
+    "  %value = config.get @variant : index\n"
+    "  func.return %value : index\n"
+    "}\n";
+
+enum { JIT_VARIANT_COUNT = 8 };
+
+static const char* const kVariantConfigTexts[JIT_VARIANT_COUNT] = {
+    "config.def @variant = 1 : index\n", "config.def @variant = 2 : index\n",
+    "config.def @variant = 3 : index\n", "config.def @variant = 4 : index\n",
+    "config.def @variant = 5 : index\n", "config.def @variant = 6 : index\n",
+    "config.def @variant = 7 : index\n", "config.def @variant = 8 : index\n",
+};
+
+typedef struct jit_service_t {
+  // Allocator shared by all process- and task-owned objects.
+  loomc_allocator_t allocator;
+
+  // Shared context for source deserialization and compilation.
+  loomc_context_t* context;
+
+  // Immutable source compiled by each example task.
+  loomc_source_t* source;
+
+  // Immutable typed configuration module borrowed by each request.
+  loomc_module_t* config_modules[JIT_VARIANT_COUNT];
+
+  // Immutable prepared compiler shared by every worker.
+  loomc_compiler_t* compiler;
+
+  // Immutable prepared pass program shared by every worker.
+  loomc_pass_program_t* pass_program;
+
+  // Optional standard scheduler accepting generic tasks.
+  loomc_task_pool_t* task_pool;
+
+  // Mutable compiler scratch indexed by dense worker ordinal.
+  loomc_workspace_t** workspaces;
+
+  // Number of initialized entries in `workspaces`.
+  loomc_host_size_t workspace_count;
+} jit_service_t;
+
+typedef struct jit_output_t {
+  // Terminal infrastructure status produced by the task.
+  loomc_status_t status;
+
+  // Terminal compiler result produced by the task.
+  loomc_result_t* result;
+} jit_output_t;
+
+// --8<-- [start:task-record]
+typedef struct jit_task_t {
+  // Generic task base owned by the accepting sink.
+  loomc_task_t base;
+
+  // Shared immutable service state and worker-local workspace table.
+  jit_service_t* service;
+
+  // Immutable typed configuration module for this compilation request.
+  const loomc_module_t* config_module;
+
+  // Caller-owned output slot that outlives task execution.
+  jit_output_t* output;
+} jit_task_t;
+// --8<-- [end:task-record]
+
+static void print_status(loomc_status_t status) {
+  char buffer[1024] = {0};
+  loomc_host_size_t length = 0;
+  loomc_status_format(status, sizeof(buffer), buffer, &length);
+  fprintf(stderr, "%.*s\n", (int)length, buffer);
+}
+
+static void print_result_diagnostics(const loomc_result_t* result) {
+  if (result == NULL) return;
+  for (loomc_host_size_t i = 0; i < loomc_result_diagnostic_count(result);
+       ++i) {
+    const loomc_diagnostic_t* diagnostic =
+        loomc_result_diagnostic_at(result, i);
+    if (diagnostic == NULL) continue;
+    fprintf(stderr, "%.*s: %.*s\n", (int)diagnostic->code.size,
+            diagnostic->code.data, (int)diagnostic->message.size,
+            diagnostic->message.data);
+  }
+}
+
+// --8<-- [start:execute]
+static void execute_jit_task(loomc_task_t* base_task,
+                             loomc_host_size_t worker_ordinal) {
+  jit_task_t* task = (jit_task_t*)base_task;
+  jit_service_t* service = task->service;
+  loomc_workspace_t* workspace = service->workspaces[worker_ordinal];
+
+  loomc_module_t* module = NULL;
+  loomc_result_t* result = NULL;
+  loomc_status_t status = loomc_module_deserialize_text_from_source(
+      service->context, workspace, service->source, NULL, service->allocator,
+      &module, &result);
+
+  if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
+    loomc_result_release(result);
+    result = NULL;
+
+    const loomc_compile_options_t options = {
+        .type = LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
+        .structure_size = sizeof(options),
+        .artifact_flags = LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_BYTECODE,
+        .config_flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+        .config_module = task->config_module,
+    };
+    status = loomc_compile_module(service->compiler, workspace,
+                                  service->pass_program, module, &options,
+                                  service->allocator, &result);
+  }
+
+  task->output->status = status;
+  task->output->result = result;
+  loomc_module_release(module);
+  loomc_workspace_trim(workspace);
+}
+// --8<-- [end:execute]
+
+static void destroy_jit_task(loomc_task_t* base_task) {
+  jit_task_t* task = (jit_task_t*)base_task;
+  loomc_allocator_free(task->service->allocator, task);
+}
+
+static const loomc_task_vtable_t kJitTaskVtable = {
+    .execute = execute_jit_task,
+    .destroy = destroy_jit_task,
+};
+
+static void jit_service_initialize(jit_service_t* service) {
+  memset(service, 0, sizeof(*service));
+  service->allocator = loomc_allocator_system();
+}
+
+static void jit_service_deinitialize(jit_service_t* service) {
+  loomc_task_pool_free(service->task_pool);
+  for (loomc_host_size_t i = 0; i < JIT_VARIANT_COUNT; ++i) {
+    loomc_module_release(service->config_modules[i]);
+  }
+  for (loomc_host_size_t i = 0; i < service->workspace_count; ++i) {
+    loomc_workspace_release(service->workspaces[i]);
+  }
+  loomc_allocator_free(service->allocator, service->workspaces);
+  loomc_pass_program_release(service->pass_program);
+  loomc_compiler_release(service->compiler);
+  loomc_source_release(service->source);
+  loomc_context_release(service->context);
+}
+
+static loomc_status_t require_successful_result(const loomc_result_t* result,
+                                                const char* message) {
+  if (result != NULL && loomc_result_succeeded(result)) {
+    return loomc_ok_status();
+  }
+  print_result_diagnostics(result);
+  return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION, message);
+}
+
+// --8<-- [start:configure]
+static loomc_status_t configure_jit_service(jit_service_t* service) {
+  loomc_status_t status =
+      loomc_context_create(NULL, service->allocator, &service->context);
+
+  const loomc_source_options_t source_options = {
+      .type = LOOMC_STRUCTURE_TYPE_SOURCE_OPTIONS,
+      .structure_size = sizeof(source_options),
+      .format = LOOMC_SOURCE_FORMAT_TEXT,
+      .identifier = loomc_make_cstring_view("jit_task_pool.loom"),
+      .contents = loomc_make_byte_span(kSourceText, sizeof(kSourceText) - 1),
+      .storage = LOOMC_SOURCE_STORAGE_BORROWED,
+  };
+  if (loomc_status_is_ok(status)) {
+    status = loomc_source_create(&source_options, service->allocator,
+                                 &service->source);
+  }
+  if (loomc_status_is_ok(status)) {
+    status = loomc_compiler_create(service->context, NULL, service->allocator,
+                                   &service->compiler);
+  }
+
+  loomc_result_t* pass_result = NULL;
+  if (loomc_status_is_ok(status)) {
+    status = loomc_pass_program_create_from_pipeline_text(
+        service->context, loomc_make_cstring_view("canonicalize,cse,dce"), NULL,
+        service->allocator, &service->pass_program, &pass_result);
+  }
+  if (loomc_status_is_ok(status)) {
+    status =
+        require_successful_result(pass_result, "pass program creation failed");
+  }
+  loomc_result_release(pass_result);
+
+  const loomc_task_pool_options_t pool_options = {
+      .type = LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS,
+      .structure_size = sizeof(pool_options),
+      .max_worker_count = 4,
+  };
+  if (loomc_status_is_ok(status)) {
+    status = loomc_task_pool_allocate(&pool_options, service->allocator,
+                                      &service->task_pool);
+  }
+  if (loomc_status_is_ok(status)) {
+    const loomc_host_size_t worker_count =
+        loomc_task_pool_worker_count(service->task_pool);
+    status = loomc_allocator_malloc(service->allocator,
+                                    worker_count * sizeof(*service->workspaces),
+                                    (void**)&service->workspaces);
+    for (loomc_host_size_t i = 0;
+         loomc_status_is_ok(status) && i < worker_count; ++i) {
+      status = loomc_workspace_create(NULL, service->allocator,
+                                      &service->workspaces[i]);
+      if (loomc_status_is_ok(status)) ++service->workspace_count;
+    }
+  }
+  for (loomc_host_size_t i = 0;
+       loomc_status_is_ok(status) && i < JIT_VARIANT_COUNT; ++i) {
+    const char* config_text = kVariantConfigTexts[i];
+    const loomc_source_options_t config_source_options = {
+        .type = LOOMC_STRUCTURE_TYPE_SOURCE_OPTIONS,
+        .structure_size = sizeof(config_source_options),
+        .format = LOOMC_SOURCE_FORMAT_TEXT,
+        .identifier = loomc_make_cstring_view("jit_task_pool_config.loom"),
+        .contents = loomc_make_byte_span(config_text, strlen(config_text)),
+        .storage = LOOMC_SOURCE_STORAGE_BORROWED,
+    };
+    loomc_source_t* config_source = NULL;
+    loomc_result_t* config_result = NULL;
+    status = loomc_source_create(&config_source_options, service->allocator,
+                                 &config_source);
+    if (loomc_status_is_ok(status)) {
+      status = loomc_module_deserialize_text_from_source(
+          service->context, service->workspaces[0], config_source, NULL,
+          service->allocator, &service->config_modules[i], &config_result);
+    }
+    if (loomc_status_is_ok(status)) {
+      status = require_successful_result(config_result,
+                                         "config deserialization failed");
+    }
+    loomc_result_release(config_result);
+    loomc_source_release(config_source);
+  }
+  if (service->workspace_count != 0) {
+    loomc_workspace_trim(service->workspaces[0]);
+  }
+  return status;
+}
+// --8<-- [end:configure]
+
+static loomc_status_t allocate_jit_task(jit_service_t* service,
+                                        const loomc_module_t* config_module,
+                                        jit_output_t* output,
+                                        loomc_task_t** out_task) {
+  *out_task = NULL;
+  jit_task_t* task = NULL;
+  loomc_status_t status =
+      loomc_allocator_malloc(service->allocator, sizeof(*task), (void**)&task);
+  if (loomc_status_is_ok(status)) {
+    loomc_task_initialize(&kJitTaskVtable, &task->base);
+    task->service = service;
+    task->config_module = config_module;
+    task->output = output;
+    *out_task = &task->base;
+  }
+  return status;
+}
+
+// --8<-- [start:submit]
+static loomc_status_t submit_jit_tasks(jit_service_t* service,
+                                       jit_output_t* outputs,
+                                       loomc_host_size_t output_count) {
+  loomc_task_sink_t sink = loomc_task_pool_sink(service->task_pool);
+  loomc_status_t status = loomc_ok_status();
+  for (loomc_host_size_t i = 0; loomc_status_is_ok(status) && i < output_count;
+       ++i) {
+    loomc_task_t* task = NULL;
+    status = allocate_jit_task(service, service->config_modules[i], &outputs[i],
+                               &task);
+    if (loomc_status_is_ok(status)) {
+      status = loomc_task_sink_submit(sink, task);
+    }
+    if (!loomc_status_is_ok(status) && task != NULL) {
+      // Rejection preserves the ownership offered to the sink.
+      loomc_task_destroy(task);
+    }
+  }
+
+  // This short-lived example uses shutdown as its batch join. A persistent
+  // compiler service tracks request completion separately and shuts its one
+  // process-wide pool down only during service teardown.
+  if (loomc_status_is_ok(status)) {
+    status = loomc_task_pool_shutdown(service->task_pool);
+  }
+  if (loomc_status_is_ok(status)) {
+    status = loomc_task_pool_await_shutdown(service->task_pool);
+  }
+  if (!loomc_status_is_ok(status)) {
+    // Drain accepted work before caller-owned output storage is inspected or
+    // released. The void teardown path preserves the earlier operation error.
+    loomc_task_pool_free(service->task_pool);
+    service->task_pool = NULL;
+  }
+  return status;
+}
+// --8<-- [end:submit]
+
+static loomc_status_t inspect_outputs(jit_output_t* outputs,
+                                      loomc_host_size_t output_count) {
+  loomc_status_t status = loomc_ok_status();
+  for (loomc_host_size_t i = 0; i < output_count; ++i) {
+    if (!loomc_status_is_ok(outputs[i].status)) {
+      if (loomc_status_is_ok(status)) {
+        status = outputs[i].status;
+        outputs[i].status = loomc_ok_status();
+      }
+      continue;
+    }
+    if (!loomc_result_succeeded(outputs[i].result)) {
+      print_result_diagnostics(outputs[i].result);
+      if (loomc_status_is_ok(status)) {
+        status = loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                                   "a JIT task failed compilation");
+      }
+      continue;
+    }
+    if (loomc_result_artifact_count(outputs[i].result) != 1 &&
+        loomc_status_is_ok(status)) {
+      status = loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                                 "a JIT task produced unexpected artifacts");
+    }
+  }
+  return status;
+}
+
+static void deinitialize_outputs(jit_output_t* outputs,
+                                 loomc_host_size_t output_count) {
+  for (loomc_host_size_t i = 0; i < output_count; ++i) {
+    loomc_status_free(outputs[i].status);
+    loomc_result_release(outputs[i].result);
+  }
+}
+
+static loomc_status_t run_jit_task_pool_example(void) {
+  jit_service_t service;
+  jit_service_initialize(&service);
+  jit_output_t outputs[JIT_VARIANT_COUNT] = {0};
+  const loomc_host_size_t output_count = sizeof(outputs) / sizeof(outputs[0]);
+
+  loomc_status_t status = configure_jit_service(&service);
+  if (loomc_status_is_ok(status)) {
+    status = submit_jit_tasks(&service, outputs, output_count);
+  }
+  if (loomc_status_is_ok(status)) {
+    status = inspect_outputs(outputs, output_count);
+  }
+  if (loomc_status_is_ok(status)) {
+    printf("compiled=%zu\n", (size_t)output_count);
+  }
+
+  deinitialize_outputs(outputs, output_count);
+  jit_service_deinitialize(&service);
+  return status;
+}
+
+int main(void) {
+  loomc_status_t status = run_jit_task_pool_example();
+  if (loomc_status_is_ok(status)) return 0;
+  print_status(status);
+  loomc_status_free(status);
+  return 1;
+}

--- a/loom/binding/c/example/jit_task_pool.c
+++ b/loom/binding/c/example/jit_task_pool.c
@@ -9,6 +9,7 @@
 
 #include "loomc/loomc.h"
 #include "loomc/task_pool.h"
+#include "loomc/task_queue.h"
 
 static const char kSourceText[] =
     "config.decl @variant : %value: index where [range(%value, 1, 9)]\n"
@@ -45,8 +46,11 @@ typedef struct jit_service_t {
   // Immutable prepared pass program shared by every worker.
   loomc_pass_program_t* pass_program;
 
-  // Optional standard scheduler accepting generic tasks.
+  // Optional standard worker population shared by attached work sources.
   loomc_task_pool_t* task_pool;
+
+  // Compiler task scheduling domain attached to `task_pool`.
+  loomc_task_queue_t* compile_queue;
 
   // Mutable compiler scratch indexed by dense worker ordinal.
   loomc_workspace_t** workspaces;
@@ -151,6 +155,7 @@ static void jit_service_initialize(jit_service_t* service) {
 }
 
 static void jit_service_deinitialize(jit_service_t* service) {
+  loomc_task_queue_free(service->compile_queue);
   loomc_task_pool_free(service->task_pool);
   for (loomc_host_size_t i = 0; i < JIT_VARIANT_COUNT; ++i) {
     loomc_module_release(service->config_modules[i]);
@@ -216,6 +221,10 @@ static loomc_status_t configure_jit_service(jit_service_t* service) {
   if (loomc_status_is_ok(status)) {
     status = loomc_task_pool_allocate(&pool_options, service->allocator,
                                       &service->task_pool);
+  }
+  if (loomc_status_is_ok(status)) {
+    status = loomc_task_queue_allocate(service->task_pool, service->allocator,
+                                       &service->compile_queue);
   }
   if (loomc_status_is_ok(status)) {
     const loomc_host_size_t worker_count =
@@ -286,7 +295,7 @@ static loomc_status_t allocate_jit_task(jit_service_t* service,
 static loomc_status_t submit_jit_tasks(jit_service_t* service,
                                        jit_output_t* outputs,
                                        loomc_host_size_t output_count) {
-  loomc_task_sink_t sink = loomc_task_pool_sink(service->task_pool);
+  loomc_task_sink_t sink = loomc_task_queue_sink(service->compile_queue);
   loomc_status_t status = loomc_ok_status();
   for (loomc_host_size_t i = 0; loomc_status_is_ok(status) && i < output_count;
        ++i) {
@@ -303,19 +312,20 @@ static loomc_status_t submit_jit_tasks(jit_service_t* service,
   }
 
   // This short-lived example uses shutdown as its batch join. A persistent
-  // compiler service tracks request completion separately and shuts its one
-  // process-wide pool down only during service teardown.
+  // compiler service tracks request completion separately and shuts its
+  // compiler queue down only during service teardown. Other queues and native
+  // processes attached to the same pool remain independently runnable.
   if (loomc_status_is_ok(status)) {
-    status = loomc_task_pool_shutdown(service->task_pool);
+    status = loomc_task_queue_shutdown(service->compile_queue);
   }
   if (loomc_status_is_ok(status)) {
-    status = loomc_task_pool_await_shutdown(service->task_pool);
+    status = loomc_task_queue_await_shutdown(service->compile_queue);
   }
   if (!loomc_status_is_ok(status)) {
     // Drain accepted work before caller-owned output storage is inspected or
     // released. The void teardown path preserves the earlier operation error.
-    loomc_task_pool_free(service->task_pool);
-    service->task_pool = NULL;
+    loomc_task_queue_free(service->compile_queue);
+    service->compile_queue = NULL;
   }
   return status;
 }

--- a/loom/binding/c/include/loomc/base.h
+++ b/loom/binding/c/include/loomc/base.h
@@ -292,6 +292,9 @@ typedef enum loomc_structure_type_e {
 
   /// `loomc_cmd_program_request_options_t`.
   LOOMC_STRUCTURE_TYPE_CMD_PROGRAM_REQUEST_OPTIONS = 39,
+
+  /// `loomc_task_pool_options_t`.
+  LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS = 40,
 } loomc_structure_type_t;
 
 /// One loose string option entry.

--- a/loom/binding/c/include/loomc/iree/task_pool.h
+++ b/loom/binding/c/include/loomc/iree/task_pool.h
@@ -1,0 +1,54 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef LOOMC_IREE_TASK_POOL_H_
+#define LOOMC_IREE_TASK_POOL_H_
+
+#include "iree/task/executor.h"
+#include "loomc/task_pool.h"
+
+/// @file
+/// Optional adapters between Loom task pools and IREE task executors.
+///
+/// IREE-hosted applications use these adapters to share one worker executor
+/// between Loom task queues, HAL materializers, and application-owned
+/// cooperative processes. Core LoomC headers remain independent from IREE task
+/// types.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Allocates a Loom task pool retaining an existing IREE task executor.
+///
+/// @param executor Executor to retain for the returned pool.
+/// @param allocator Host allocator used for pool storage.
+/// @param out_pool Receives the allocated pool on success.
+/// @return OK after retaining `executor` and allocating the pool.
+///
+/// @ownership
+/// The caller retains its existing executor reference. The returned pool owns
+/// one additional reference released by `loomc_task_pool_free`.
+LOOMC_API_EXPORT loomc_status_t loomc_task_pool_allocate_from_iree_executor(
+    iree_task_executor_t* executor, loomc_allocator_t allocator,
+    loomc_task_pool_t** out_pool);
+
+/// Returns the borrowed IREE task executor owned by `pool`.
+///
+/// @param pool Pool to query, or NULL.
+/// @return Borrowed executor, or NULL for a NULL pool.
+///
+/// A consumer that may outlive `pool` retains the returned executor before the
+/// pool is freed. Cooperative processes attached to the executor own their
+/// process state and teardown independently from Loom task queues.
+LOOMC_API_EXPORT iree_task_executor_t* iree_task_executor_from_loomc_task_pool(
+    const loomc_task_pool_t* pool);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOMC_IREE_TASK_POOL_H_

--- a/loom/binding/c/include/loomc/loomc.h
+++ b/loom/binding/c/include/loomc/loomc.h
@@ -36,6 +36,7 @@
 #include "loomc/source.h"
 #include "loomc/status.h"
 #include "loomc/target.h"
+#include "loomc/task.h"
 #include "loomc/workspace.h"
 
 #endif  // LOOMC_LOOMC_H_

--- a/loom/binding/c/include/loomc/task.h
+++ b/loom/binding/c/include/loomc/task.h
@@ -15,8 +15,8 @@
 /// A task is a queueable base embedded in application or LoomC work records.
 /// Task sinks provide the ownership boundary needed to compose LoomC with a
 /// caller's event loop, deterministic queue, custom scheduler, or the optional
-/// standard task pool. The protocol carries no compiler, product, cache,
-/// thread-pool, or IREE task state.
+/// standard task queue attached to a shared pool. The protocol carries no
+/// compiler, product, cache, thread-pool, or IREE task state.
 
 #ifdef __cplusplus
 extern "C" {

--- a/loom/binding/c/include/loomc/task.h
+++ b/loom/binding/c/include/loomc/task.h
@@ -1,0 +1,130 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef LOOMC_TASK_H_
+#define LOOMC_TASK_H_
+
+#include "loomc/status.h"
+
+/// @file
+/// Generic caller-scheduled work.
+///
+/// A task is a queueable base embedded in application or LoomC work records.
+/// Task sinks provide the ownership boundary needed to compose LoomC with a
+/// caller's event loop, deterministic queue, custom scheduler, or the optional
+/// standard task pool. The protocol carries no compiler, product, cache,
+/// thread-pool, or IREE task state.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Base embedded at offset zero in one caller-defined work record.
+///
+/// A task has one ownership reference and is not reference counted. Successful
+/// submission transfers that reference to the sink, which executes the task
+/// exactly once and then destroys it exactly once. Failed submission leaves
+/// destruction to the caller.
+typedef struct loomc_task_t loomc_task_t;
+
+/// Stateless callbacks for one task representation.
+typedef struct loomc_task_vtable_t {
+  /// Executes `task` exactly once without destroying its storage.
+  ///
+  /// `worker_ordinal` identifies the sink execution lane running this task.
+  /// Ordinals are dense and mutually exclusive: two task callbacks never run
+  /// concurrently with the same ordinal. Concrete tasks may use the ordinal to
+  /// index caller-owned worker-local state.
+  ///
+  /// The callback terminalizes every outcome owned by the task before
+  /// returning.
+  void(LOOMC_API_PTR* execute)(loomc_task_t* task,
+                               loomc_host_size_t worker_ordinal);
+
+  /// Destroys `task` storage after execution or rejected-submission cleanup.
+  void(LOOMC_API_PTR* destroy)(loomc_task_t* task);
+} loomc_task_vtable_t;
+
+struct loomc_task_t {
+  /// Static callbacks implementing the concrete task.
+  const loomc_task_vtable_t* vtable;
+
+  /// Sink-owned intrusive link while the accepted task is queued.
+  ///
+  /// Task initialization sets this to NULL. A sink may use it only between
+  /// accepting the task and invoking its terminal callback, and must clear it
+  /// before execution. Exclusive task ownership permits one queue membership
+  /// at a time.
+  loomc_task_t* next;
+};
+
+/// Initializes a caller-allocated task base.
+///
+/// @param vtable Static callback table that outlives `out_task`.
+/// @param out_task Task base to initialize.
+///
+/// Both arguments and all vtable callbacks are required. The initialized task
+/// must be submitted or destroyed exactly once before its storage is reused.
+LOOMC_API_EXPORT void loomc_task_initialize(const loomc_task_vtable_t* vtable,
+                                            loomc_task_t* out_task);
+
+/// Executes and then destroys an accepted task.
+///
+/// @param task Task ownership reference to consume.
+/// @param worker_ordinal Dense mutually exclusive execution-lane ordinal.
+///
+/// Queue implementations call this exactly once for each task they accept.
+/// The vtable is captured before execution so the destroy callback may reclaim
+/// task storage.
+LOOMC_API_EXPORT void loomc_task_execute(loomc_task_t* task,
+                                         loomc_host_size_t worker_ordinal);
+
+/// Destroys a task without executing it.
+///
+/// @param task Task ownership reference to consume.
+///
+/// Callers use this after a rejected submission they choose not to retry.
+LOOMC_API_EXPORT void loomc_task_destroy(loomc_task_t* task);
+
+/// Accepts ownership of one generic task.
+///
+/// @param user_data Sink-owned state.
+/// @param task Task offered for submission.
+/// @return OK after accepting ownership, or a non-OK status without accepting
+/// ownership.
+///
+/// An accepted task is eventually executed exactly once and then destroyed
+/// exactly once, possibly before this callback returns. A rejected task is not
+/// executed or destroyed by the sink.
+typedef loomc_status_t(LOOMC_API_PTR* loomc_task_submit_fn_t)(
+    void* user_data, loomc_task_t* task);
+
+/// Borrowed destination for generic tasks.
+typedef struct loomc_task_sink_t {
+  /// Callback accepting one task.
+  loomc_task_submit_fn_t submit;
+
+  /// Opaque state passed to `submit`.
+  void* user_data;
+} loomc_task_sink_t;
+
+/// Submits a task and transfers ownership on success.
+///
+/// @param sink Borrowed task destination.
+/// @param task Task ownership reference offered to `sink`.
+/// @return The sink submission status.
+///
+/// This validates the public protocol before entering the sink callback and
+/// never accesses `task` after an OK return because an inline sink may already
+/// have destroyed it.
+LOOMC_API_EXPORT loomc_status_t loomc_task_sink_submit(loomc_task_sink_t sink,
+                                                       loomc_task_t* task);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOMC_TASK_H_

--- a/loom/binding/c/include/loomc/task_pool.h
+++ b/loom/binding/c/include/loomc/task_pool.h
@@ -7,17 +7,20 @@
 #ifndef LOOMC_TASK_POOL_H_
 #define LOOMC_TASK_POOL_H_
 
-#include "loomc/task.h"
+#include "loomc/status.h"
 
 /// @file
-/// Optional standard worker pool for generic LoomC tasks.
+/// Optional standard worker population for concurrent application work.
 ///
-/// The pool implements `loomc_task_sink_t` and can run arbitrary application
-/// and compiler work in one persistent worker population. It owns scheduling
-/// policy only: caches, compilers, workspaces, requests, products, and
-/// application state remain separately composed by the caller. Applications
-/// with an existing scheduler use the same task sink protocol without linking
-/// this package or the IREE task runtime.
+/// A pool retains one worker executor but no work queue or scheduling policy.
+/// Callers attach one `loomc_task_queue_t` for each independent Loom task
+/// domain, while IREE-hosted applications may attach other cooperative
+/// processes such as HAL executable or command-buffer materializers. This lets
+/// compilation and materialization overlap without creating competing worker
+/// populations or forcing unrelated work through one FIFO.
+///
+/// Applications with an existing scheduler use `loomc_task_sink_t` without
+/// linking this package or the IREE task runtime.
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,57 +72,27 @@ typedef struct loomc_task_pool_options_t {
 /// @return OK when the pool and all worker threads were created.
 ///
 /// @ownership
-/// The caller owns `out_pool` and frees it with `loomc_task_pool_free` after
-/// every object that may submit through its sink has completed.
+/// The caller owns `out_pool` and frees it with `loomc_task_pool_free`. Task
+/// queues and native cooperative processes attached to the pool retain the
+/// underlying worker executor independently and may outlive the pool handle.
 LOOMC_API_EXPORT loomc_status_t loomc_task_pool_allocate(
     const loomc_task_pool_options_t* options, loomc_allocator_t allocator,
     loomc_task_pool_t** out_pool);
 
-/// Returns the number of worker threads owned by `pool`.
+/// Returns the number of worker threads represented by `pool`.
 ///
 /// @param pool Pool to inspect, or NULL.
 /// @return Worker count, or zero for a NULL pool.
 LOOMC_API_EXPORT loomc_host_size_t
 loomc_task_pool_worker_count(const loomc_task_pool_t* pool);
 
-/// Returns a borrowed generic task sink backed by `pool`.
-///
-/// @param pool Pool accepting submitted work, or NULL.
-/// @return Borrowed sink, or an empty sink for a NULL pool.
-///
-/// The sink remains valid until shutdown begins. Rejected submission leaves
-/// task ownership with the caller according to the generic sink contract.
-LOOMC_API_EXPORT loomc_task_sink_t
-loomc_task_pool_sink(loomc_task_pool_t* pool);
-
-/// Stops accepting new tasks and begins draining accepted work.
-///
-/// @param pool Pool to shut down.
-/// @return OK after shutdown begins.
-///
-/// This operation is thread safe and idempotent. Tasks already executing
-/// finish normally. Their attempts to submit additional work are rejected, so
-/// owners of recursively expanding work await that work before shutting down
-/// its sink.
-LOOMC_API_EXPORT loomc_status_t
-loomc_task_pool_shutdown(loomc_task_pool_t* pool);
-
-/// Waits until every accepted task and every pool worker has released `pool`.
-///
-/// @param pool Pool whose shutdown has already begun.
-/// @return OK after every worker releases the pool.
-///
-/// Shutdown must have begun before this call. The calling thread must not be a
-/// task executing on `pool`, because a worker cannot wait for its own release.
-LOOMC_API_EXPORT loomc_status_t
-loomc_task_pool_await_shutdown(loomc_task_pool_t* pool);
-
-/// Drains, awaits, and frees `pool`.
+/// Releases the pool's worker-executor reference and frees `pool`.
 ///
 /// @param pool Pool to free. Passing NULL is allowed.
 ///
-/// The calling thread must not be a task executing on `pool`, and no owner may
-/// retain or submit through the pool sink after this call begins.
+/// Attached task queues and native processes retain the worker executor until
+/// their own teardown completes. Freeing the final executor owner joins the
+/// worker threads before returning.
 LOOMC_API_EXPORT void loomc_task_pool_free(loomc_task_pool_t* pool);
 
 #ifdef __cplusplus

--- a/loom/binding/c/include/loomc/task_pool.h
+++ b/loom/binding/c/include/loomc/task_pool.h
@@ -1,0 +1,129 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef LOOMC_TASK_POOL_H_
+#define LOOMC_TASK_POOL_H_
+
+#include "loomc/task.h"
+
+/// @file
+/// Optional standard worker pool for generic LoomC tasks.
+///
+/// The pool implements `loomc_task_sink_t` and can run arbitrary application
+/// and compiler work in one persistent worker population. It owns scheduling
+/// policy only: caches, compilers, workspaces, requests, products, and
+/// application state remain separately composed by the caller. Applications
+/// with an existing scheduler use the same task sink protocol without linking
+/// this package or the IREE task runtime.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Opaque standard task pool.
+typedef struct loomc_task_pool_t loomc_task_pool_t;
+
+/// Task-pool creation options.
+///
+/// Callers zero-initialize this descriptor, set `type` to
+/// `LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS`, set `structure_size` to
+/// `sizeof(loomc_task_pool_options_t)`, and fill the requested fields.
+typedef struct loomc_task_pool_options_t {
+  /// Structure type. Must be `LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS` when
+  /// nonzero.
+  loomc_structure_type_t type;
+
+  /// Size of this structure in bytes.
+  loomc_host_size_t structure_size;
+
+  /// Extension chain for future task-pool options.
+  const void* next;
+
+  /// Maximum physical-core workers to create, or zero for the default.
+  ///
+  /// The default is four workers. The actual count may be lower when processor
+  /// affinity, a container CPU set, or the host topology exposes fewer
+  /// physical cores. Workers scatter across cache domains so independent
+  /// compiler jobs use the available memory bandwidth. Latency-oriented hosts
+  /// commonly request eight; autotuning and compile-report search may benefit
+  /// from wider pools.
+  loomc_host_size_t max_worker_count;
+
+  /// Minimum stack size in bytes for each worker, or zero for the default.
+  ///
+  /// The 2 MiB default is sized for recursive compiler analysis and sanitizer
+  /// instrumentation rather than only short runtime callbacks. Stack storage
+  /// is virtual address space reserved by the host threading implementation;
+  /// physical pages are committed as workers use them.
+  loomc_host_size_t worker_stack_size;
+} loomc_task_pool_options_t;
+
+/// Allocates a standard task pool and starts its worker population.
+///
+/// @param options Pool configuration, or NULL for defaults.
+/// @param allocator Host allocator used for pool and executor storage.
+/// @param out_pool Receives the allocated pool on success.
+/// @return OK when the pool and all worker threads were created.
+///
+/// @ownership
+/// The caller owns `out_pool` and frees it with `loomc_task_pool_free` after
+/// every object that may submit through its sink has completed.
+LOOMC_API_EXPORT loomc_status_t loomc_task_pool_allocate(
+    const loomc_task_pool_options_t* options, loomc_allocator_t allocator,
+    loomc_task_pool_t** out_pool);
+
+/// Returns the number of worker threads owned by `pool`.
+///
+/// @param pool Pool to inspect, or NULL.
+/// @return Worker count, or zero for a NULL pool.
+LOOMC_API_EXPORT loomc_host_size_t
+loomc_task_pool_worker_count(const loomc_task_pool_t* pool);
+
+/// Returns a borrowed generic task sink backed by `pool`.
+///
+/// @param pool Pool accepting submitted work, or NULL.
+/// @return Borrowed sink, or an empty sink for a NULL pool.
+///
+/// The sink remains valid until shutdown begins. Rejected submission leaves
+/// task ownership with the caller according to the generic sink contract.
+LOOMC_API_EXPORT loomc_task_sink_t
+loomc_task_pool_sink(loomc_task_pool_t* pool);
+
+/// Stops accepting new tasks and begins draining accepted work.
+///
+/// @param pool Pool to shut down.
+/// @return OK after shutdown begins.
+///
+/// This operation is thread safe and idempotent. Tasks already executing
+/// finish normally. Their attempts to submit additional work are rejected, so
+/// owners of recursively expanding work await that work before shutting down
+/// its sink.
+LOOMC_API_EXPORT loomc_status_t
+loomc_task_pool_shutdown(loomc_task_pool_t* pool);
+
+/// Waits until every accepted task and every pool worker has released `pool`.
+///
+/// @param pool Pool whose shutdown has already begun.
+/// @return OK after every worker releases the pool.
+///
+/// Shutdown must have begun before this call. The calling thread must not be a
+/// task executing on `pool`, because a worker cannot wait for its own release.
+LOOMC_API_EXPORT loomc_status_t
+loomc_task_pool_await_shutdown(loomc_task_pool_t* pool);
+
+/// Drains, awaits, and frees `pool`.
+///
+/// @param pool Pool to free. Passing NULL is allowed.
+///
+/// The calling thread must not be a task executing on `pool`, and no owner may
+/// retain or submit through the pool sink after this call begins.
+LOOMC_API_EXPORT void loomc_task_pool_free(loomc_task_pool_t* pool);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOMC_TASK_POOL_H_

--- a/loom/binding/c/include/loomc/task_queue.h
+++ b/loom/binding/c/include/loomc/task_queue.h
@@ -1,0 +1,89 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef LOOMC_TASK_QUEUE_H_
+#define LOOMC_TASK_QUEUE_H_
+
+#include "loomc/task.h"
+#include "loomc/task_pool.h"
+
+/// @file
+/// Generic Loom task queue attached to a standard task pool.
+///
+/// A queue is one scheduling and ownership domain backed by one cooperative
+/// process on the pool's shared worker executor. Multiple queues attached to
+/// one pool can make progress independently at process drain boundaries. This
+/// permits compiler, materialization, and application work to overlap while
+/// retaining one worker population.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Opaque generic task queue.
+typedef struct loomc_task_queue_t loomc_task_queue_t;
+
+/// Allocates a task queue attached to `pool`.
+///
+/// @param pool Pool whose worker executor will drain the queue.
+/// @param allocator Host allocator used for queue storage.
+/// @param out_queue Receives the allocated queue on success.
+/// @return OK after the queue is ready to accept tasks.
+///
+/// @ownership
+/// The queue retains the pool's worker executor and may outlive the pool
+/// handle. The caller owns `out_queue` and frees it with
+/// `loomc_task_queue_free` after every object that may submit through its sink
+/// has completed.
+LOOMC_API_EXPORT loomc_status_t loomc_task_queue_allocate(
+    const loomc_task_pool_t* pool, loomc_allocator_t allocator,
+    loomc_task_queue_t** out_queue);
+
+/// Returns a borrowed generic task sink backed by `queue`.
+///
+/// @param queue Queue accepting submitted work, or NULL.
+/// @return Borrowed sink, or an empty sink for a NULL queue.
+///
+/// The sink remains valid until shutdown begins. Rejected submission leaves
+/// task ownership with the caller according to the generic sink contract.
+LOOMC_API_EXPORT loomc_task_sink_t
+loomc_task_queue_sink(loomc_task_queue_t* queue);
+
+/// Stops accepting new tasks and begins draining accepted work.
+///
+/// @param queue Queue to shut down.
+/// @return OK after shutdown begins.
+///
+/// This operation is thread safe and idempotent. Tasks already executing
+/// finish normally. Their attempts to submit additional work are rejected, so
+/// owners of recursively expanding work await that work before shutting down
+/// its sink.
+LOOMC_API_EXPORT loomc_status_t
+loomc_task_queue_shutdown(loomc_task_queue_t* queue);
+
+/// Waits until every accepted task has drained and the queue process releases.
+///
+/// @param queue Queue whose shutdown has already begun.
+/// @return OK after the queue process has released its executor state.
+///
+/// Shutdown must have begun before this call. The calling thread must not be a
+/// task executing on `queue`, because a worker cannot wait for its own release.
+LOOMC_API_EXPORT loomc_status_t
+loomc_task_queue_await_shutdown(loomc_task_queue_t* queue);
+
+/// Drains, awaits, and frees `queue`.
+///
+/// @param queue Queue to free. Passing NULL is allowed.
+///
+/// The calling thread must not be a task executing on `queue`, and no owner may
+/// retain or submit through the queue sink after this call begins.
+LOOMC_API_EXPORT void loomc_task_queue_free(loomc_task_queue_t* queue);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOMC_TASK_QUEUE_H_

--- a/loom/binding/c/src/task.c
+++ b/loom/binding/c/src/task.c
@@ -1,0 +1,32 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loomc/task.h"
+
+void loomc_task_initialize(const loomc_task_vtable_t* vtable,
+                           loomc_task_t* out_task) {
+  out_task->vtable = vtable;
+  out_task->next = NULL;
+}
+
+void loomc_task_execute(loomc_task_t* task, loomc_host_size_t worker_ordinal) {
+  const loomc_task_vtable_t* vtable = task->vtable;
+  vtable->execute(task, worker_ordinal);
+  vtable->destroy(task);
+}
+
+void loomc_task_destroy(loomc_task_t* task) { task->vtable->destroy(task); }
+
+loomc_status_t loomc_task_sink_submit(loomc_task_sink_t sink,
+                                      loomc_task_t* task) {
+  if (sink.submit == NULL || task == NULL || task->vtable == NULL ||
+      task->vtable->execute == NULL || task->vtable->destroy == NULL ||
+      task->next != NULL) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "task sink and initialized task are required");
+  }
+  return sink.submit(sink.user_data, task);
+}

--- a/loom/binding/c/src/task_pool.c
+++ b/loom/binding/c/src/task_pool.c
@@ -1,0 +1,318 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loomc/task_pool.h"
+
+#include <string.h>
+
+#include "iree/base/api.h"
+#include "iree/base/threading/notification.h"
+#include "iree/task/executor.h"
+#include "iree/task/topology.h"
+#include "loomc/iree.h"
+
+#define LOOMC_TASK_POOL_DEFAULT_WORKER_COUNT 4
+#define LOOMC_TASK_POOL_DEFAULT_WORKER_STACK_SIZE (2 * 1024 * 1024)
+
+typedef enum loomc_task_pool_state_e {
+  // Accepts new work and keeps the process reusable for later submissions.
+  LOOMC_TASK_POOL_STATE_ACCEPTING = 0,
+
+  // Rejects new work and releases the process after the shared queue drains.
+  LOOMC_TASK_POOL_STATE_DRAINING = 1,
+} loomc_task_pool_state_t;
+
+struct loomc_task_pool_t {
+  // Host allocator used for pool and executor storage.
+  iree_allocator_t allocator;
+
+  // Worker executor owned by the pool.
+  iree_task_executor_t* executor;
+
+  // Number of worker threads in the executor.
+  loomc_host_size_t worker_count;
+
+  // Persistent cooperative process draining the shared ready queue.
+  iree_task_process_t process;
+
+  // Ready-queue state serialized across submitters and workers.
+  struct {
+    // Serializes queue pointers and shutdown state.
+    iree_slim_mutex_t mutex;
+
+    // First task awaiting execution.
+    loomc_task_t* head;
+
+    // Last task awaiting execution.
+    loomc_task_t* tail;
+
+    // Number of tasks linked from |head| through |tail|.
+    loomc_host_size_t count;
+
+    // Worker capacity published for the current non-empty queue wave.
+    int32_t scheduled_capacity;
+
+    // Current task acceptance and shutdown state.
+    loomc_task_pool_state_t state;
+  } ready;
+
+  // Process-release synchronization used only during shutdown.
+  struct {
+    // Posted after the executor has made its final process access.
+    iree_notification_t notification;
+
+    // Whether the executor has made its final process access.
+    iree_atomic_int32_t released;
+  } shutdown;
+};
+
+static loomc_task_t* loomc_task_pool_pop_ready_locked(loomc_task_pool_t* pool) {
+  loomc_task_t* task = pool->ready.head;
+  if (task == NULL) return NULL;
+  pool->ready.head = task->next;
+  task->next = NULL;
+  if (pool->ready.head == NULL) pool->ready.tail = NULL;
+  if (--pool->ready.count == 0) pool->ready.scheduled_capacity = 0;
+  return task;
+}
+
+static iree_status_t loomc_task_pool_process_drain(
+    iree_task_process_t* process,
+    const iree_task_worker_context_t* worker_context,
+    iree_task_process_drain_result_t* out_result) {
+  loomc_task_pool_t* pool = (loomc_task_pool_t*)process->user_data;
+
+  iree_slim_mutex_lock(&pool->ready.mutex);
+  loomc_task_t* task = loomc_task_pool_pop_ready_locked(pool);
+  const bool completed =
+      task == NULL && pool->ready.state == LOOMC_TASK_POOL_STATE_DRAINING;
+  iree_slim_mutex_unlock(&pool->ready.mutex);
+
+  if (task != NULL) {
+    loomc_task_execute(task, (loomc_host_size_t)worker_context->worker_index);
+    *out_result = (iree_task_process_drain_result_t){
+        .completed = false,
+        .did_work = true,
+    };
+  } else {
+    *out_result = (iree_task_process_drain_result_t){
+        .completed = completed,
+        .did_work = false,
+    };
+  }
+  return iree_ok_status();
+}
+
+static void loomc_task_pool_process_release(iree_task_process_t* process) {
+  loomc_task_pool_t* pool = (loomc_task_pool_t*)process->user_data;
+  iree_slim_mutex_lock(&pool->ready.mutex);
+  iree_atomic_store(&pool->shutdown.released, 1, iree_memory_order_release);
+  iree_notification_post(&pool->shutdown.notification, IREE_ALL_WAITERS);
+  iree_slim_mutex_unlock(&pool->ready.mutex);
+}
+
+static loomc_status_t loomc_task_pool_submit(void* user_data,
+                                             loomc_task_t* task) {
+  loomc_task_pool_t* pool = (loomc_task_pool_t*)user_data;
+  bool schedule_process = false;
+  iree_slim_mutex_lock(&pool->ready.mutex);
+  if (pool->ready.state != LOOMC_TASK_POOL_STATE_ACCEPTING) {
+    iree_slim_mutex_unlock(&pool->ready.mutex);
+    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                             "task pool is shutting down");
+  }
+  if (pool->ready.tail != NULL) {
+    pool->ready.tail->next = task;
+  } else {
+    pool->ready.head = task;
+  }
+  pool->ready.tail = task;
+  ++pool->ready.count;
+  const int32_t desired_capacity =
+      (int32_t)iree_min(pool->ready.count, pool->worker_count);
+  if (desired_capacity > pool->ready.scheduled_capacity) {
+    pool->ready.scheduled_capacity = desired_capacity;
+    iree_atomic_store(&pool->process.wake_budget, desired_capacity,
+                      iree_memory_order_relaxed);
+    schedule_process = true;
+  }
+  iree_slim_mutex_unlock(&pool->ready.mutex);
+  if (schedule_process) {
+    iree_task_executor_schedule_process(pool->executor, &pool->process);
+  }
+  return loomc_ok_status();
+}
+
+static bool loomc_task_pool_released_condition(void* user_data) {
+  const loomc_task_pool_t* pool = (const loomc_task_pool_t*)user_data;
+  return iree_atomic_load(&pool->shutdown.released,
+                          iree_memory_order_acquire) != 0;
+}
+
+static void loomc_task_pool_await_release(loomc_task_pool_t* pool) {
+  iree_notification_await(&pool->shutdown.notification,
+                          loomc_task_pool_released_condition, pool,
+                          iree_infinite_timeout());
+
+  // The condition may become true before the release callback finishes
+  // posting. Crossing its mutex keeps notification storage alive until the
+  // callback has made its final access.
+  iree_slim_mutex_lock(&pool->ready.mutex);
+  iree_slim_mutex_unlock(&pool->ready.mutex);
+}
+
+static void loomc_task_pool_request_shutdown(loomc_task_pool_t* pool) {
+  bool schedule_process = false;
+  int32_t wake_budget = 1;
+  iree_slim_mutex_lock(&pool->ready.mutex);
+  if (pool->ready.state == LOOMC_TASK_POOL_STATE_ACCEPTING) {
+    pool->ready.state = LOOMC_TASK_POOL_STATE_DRAINING;
+    wake_budget =
+        (int32_t)iree_min(iree_max(pool->ready.count, 1), pool->worker_count);
+    schedule_process = true;
+  }
+  iree_slim_mutex_unlock(&pool->ready.mutex);
+  if (schedule_process) {
+    iree_atomic_store(&pool->process.wake_budget, wake_budget,
+                      iree_memory_order_relaxed);
+    iree_task_executor_schedule_process(pool->executor, &pool->process);
+  }
+}
+
+loomc_status_t loomc_task_pool_allocate(
+    const loomc_task_pool_options_t* options, loomc_allocator_t allocator,
+    loomc_task_pool_t** out_pool) {
+  if (out_pool == NULL || !loomc_allocator_is_valid(allocator)) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "allocator and out_pool are required");
+  }
+  *out_pool = NULL;
+  if (options != NULL) {
+    if (options->type != LOOMC_STRUCTURE_TYPE_NONE &&
+        options->type != LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS) {
+      return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                               "task pool options have an unknown type");
+    }
+    if (options->structure_size != 0 &&
+        options->structure_size < sizeof(*options)) {
+      return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                               "task pool options structure_size is too small");
+    }
+    if (options->next != NULL) {
+      return loomc_make_status(LOOMC_STATUS_UNIMPLEMENTED,
+                               "task pool option extensions are not supported");
+    }
+    if (options->max_worker_count > IREE_TASK_EXECUTOR_MAX_WORKER_COUNT) {
+      return loomc_make_status(
+          LOOMC_STATUS_OUT_OF_RANGE,
+          "task pool worker count exceeds executor limits");
+    }
+  }
+
+  const loomc_host_size_t max_worker_count =
+      options != NULL && options->max_worker_count != 0
+          ? options->max_worker_count
+          : LOOMC_TASK_POOL_DEFAULT_WORKER_COUNT;
+  iree_allocator_t iree_allocator = iree_allocator_from_loomc(allocator);
+  loomc_task_pool_t* pool = NULL;
+  iree_status_t status = iree_allocator_malloc_aligned(
+      iree_allocator, sizeof(*pool), iree_alignof(loomc_task_pool_t),
+      /*offset=*/0, (void**)&pool);
+  if (!iree_status_is_ok(status)) return loomc_status_from_iree(status);
+  memset(pool, 0, sizeof(*pool));
+  pool->allocator = iree_allocator;
+  pool->ready.state = LOOMC_TASK_POOL_STATE_ACCEPTING;
+  iree_slim_mutex_initialize(&pool->ready.mutex);
+  iree_notification_initialize(&pool->shutdown.notification);
+  iree_atomic_store(&pool->shutdown.released, 0, iree_memory_order_relaxed);
+
+  iree_task_topology_t topology;
+  status = iree_task_topology_initialize_from_physical_cores(
+      IREE_TASK_TOPOLOGY_NODE_ID_ANY, IREE_TASK_TOPOLOGY_PERFORMANCE_LEVEL_ANY,
+      IREE_TASK_TOPOLOGY_DISTRIBUTION_SCATTER, max_worker_count, &topology);
+  if (iree_status_is_ok(status)) {
+    if (iree_task_topology_group_count(&topology) == 0) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "host topology contains no available cores");
+    } else {
+      iree_task_executor_options_t executor_options;
+      iree_task_executor_options_initialize(&executor_options);
+      executor_options.worker_stack_size =
+          options != NULL && options->worker_stack_size != 0
+              ? options->worker_stack_size
+              : LOOMC_TASK_POOL_DEFAULT_WORKER_STACK_SIZE;
+      status = iree_task_executor_create(executor_options, &topology,
+                                         iree_allocator, &pool->executor);
+    }
+    iree_task_topology_deinitialize(&topology);
+  }
+  if (!iree_status_is_ok(status)) {
+    iree_notification_deinitialize(&pool->shutdown.notification);
+    iree_slim_mutex_deinitialize(&pool->ready.mutex);
+    iree_allocator_free_aligned(iree_allocator, pool);
+    return loomc_status_from_iree(status);
+  }
+
+  pool->worker_count = iree_task_executor_worker_count(pool->executor);
+  iree_task_process_initialize(loomc_task_pool_process_drain,
+                               /*suspend_count=*/0,
+                               /*wake_budget=*/(int32_t)pool->worker_count,
+                               &pool->process);
+  iree_task_process_set_flags(&pool->process,
+                              IREE_TASK_PROCESS_FLAG_COMPUTE_SLOT);
+  pool->process.release_fn = loomc_task_pool_process_release;
+  pool->process.user_data = pool;
+  *out_pool = pool;
+  return loomc_ok_status();
+}
+
+loomc_host_size_t loomc_task_pool_worker_count(const loomc_task_pool_t* pool) {
+  return pool != NULL ? pool->worker_count : 0;
+}
+
+loomc_task_sink_t loomc_task_pool_sink(loomc_task_pool_t* pool) {
+  return pool != NULL ? (loomc_task_sink_t){
+                            .submit = loomc_task_pool_submit,
+                            .user_data = pool,
+                        }
+                      : (loomc_task_sink_t){0};
+}
+
+loomc_status_t loomc_task_pool_shutdown(loomc_task_pool_t* pool) {
+  if (pool == NULL) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "task pool is required");
+  }
+  loomc_task_pool_request_shutdown(pool);
+  return loomc_ok_status();
+}
+
+loomc_status_t loomc_task_pool_await_shutdown(loomc_task_pool_t* pool) {
+  if (pool == NULL) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "task pool is required");
+  }
+  iree_slim_mutex_lock(&pool->ready.mutex);
+  const bool shutdown_started =
+      pool->ready.state != LOOMC_TASK_POOL_STATE_ACCEPTING;
+  iree_slim_mutex_unlock(&pool->ready.mutex);
+  if (!shutdown_started) {
+    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                             "task pool shutdown has not begun");
+  }
+  loomc_task_pool_await_release(pool);
+  return loomc_ok_status();
+}
+
+void loomc_task_pool_free(loomc_task_pool_t* pool) {
+  if (pool == NULL) return;
+  loomc_task_pool_request_shutdown(pool);
+  loomc_task_pool_await_release(pool);
+  iree_task_executor_release(pool->executor);
+  iree_notification_deinitialize(&pool->shutdown.notification);
+  iree_slim_mutex_deinitialize(&pool->ready.mutex);
+  iree_allocator_free_aligned(pool->allocator, pool);
+}

--- a/loom/binding/c/src/task_pool.c
+++ b/loom/binding/c/src/task_pool.c
@@ -9,177 +9,41 @@
 #include <string.h>
 
 #include "iree/base/api.h"
-#include "iree/base/threading/notification.h"
 #include "iree/task/executor.h"
 #include "iree/task/topology.h"
 #include "loomc/iree.h"
+#include "loomc/iree/task_pool.h"
 
 #define LOOMC_TASK_POOL_DEFAULT_WORKER_COUNT 4
 #define LOOMC_TASK_POOL_DEFAULT_WORKER_STACK_SIZE (2 * 1024 * 1024)
 
-typedef enum loomc_task_pool_state_e {
-  // Accepts new work and keeps the process reusable for later submissions.
-  LOOMC_TASK_POOL_STATE_ACCEPTING = 0,
-
-  // Rejects new work and releases the process after the shared queue drains.
-  LOOMC_TASK_POOL_STATE_DRAINING = 1,
-} loomc_task_pool_state_t;
-
 struct loomc_task_pool_t {
-  // Host allocator used for pool and executor storage.
+  // Host allocator used for pool storage.
   iree_allocator_t allocator;
 
-  // Worker executor owned by the pool.
+  // Shared worker executor retained for the pool lifetime.
   iree_task_executor_t* executor;
-
-  // Number of worker threads in the executor.
-  loomc_host_size_t worker_count;
-
-  // Persistent cooperative process draining the shared ready queue.
-  iree_task_process_t process;
-
-  // Ready-queue state serialized across submitters and workers.
-  struct {
-    // Serializes queue pointers and shutdown state.
-    iree_slim_mutex_t mutex;
-
-    // First task awaiting execution.
-    loomc_task_t* head;
-
-    // Last task awaiting execution.
-    loomc_task_t* tail;
-
-    // Number of tasks linked from |head| through |tail|.
-    loomc_host_size_t count;
-
-    // Worker capacity published for the current non-empty queue wave.
-    int32_t scheduled_capacity;
-
-    // Current task acceptance and shutdown state.
-    loomc_task_pool_state_t state;
-  } ready;
-
-  // Process-release synchronization used only during shutdown.
-  struct {
-    // Posted after the executor has made its final process access.
-    iree_notification_t notification;
-
-    // Whether the executor has made its final process access.
-    iree_atomic_int32_t released;
-  } shutdown;
 };
 
-static loomc_task_t* loomc_task_pool_pop_ready_locked(loomc_task_pool_t* pool) {
-  loomc_task_t* task = pool->ready.head;
-  if (task == NULL) return NULL;
-  pool->ready.head = task->next;
-  task->next = NULL;
-  if (pool->ready.head == NULL) pool->ready.tail = NULL;
-  if (--pool->ready.count == 0) pool->ready.scheduled_capacity = 0;
-  return task;
-}
-
-static iree_status_t loomc_task_pool_process_drain(
-    iree_task_process_t* process,
-    const iree_task_worker_context_t* worker_context,
-    iree_task_process_drain_result_t* out_result) {
-  loomc_task_pool_t* pool = (loomc_task_pool_t*)process->user_data;
-
-  iree_slim_mutex_lock(&pool->ready.mutex);
-  loomc_task_t* task = loomc_task_pool_pop_ready_locked(pool);
-  const bool completed =
-      task == NULL && pool->ready.state == LOOMC_TASK_POOL_STATE_DRAINING;
-  iree_slim_mutex_unlock(&pool->ready.mutex);
-
-  if (task != NULL) {
-    loomc_task_execute(task, (loomc_host_size_t)worker_context->worker_index);
-    *out_result = (iree_task_process_drain_result_t){
-        .completed = false,
-        .did_work = true,
-    };
-  } else {
-    *out_result = (iree_task_process_drain_result_t){
-        .completed = completed,
-        .did_work = false,
-    };
+static loomc_status_t loomc_task_pool_allocate_with_executor(
+    iree_task_executor_t* executor, loomc_allocator_t allocator,
+    loomc_task_pool_t** out_pool) {
+  if (iree_task_executor_worker_count(executor) == 0) {
+    return loomc_make_status(LOOMC_STATUS_RESOURCE_EXHAUSTED,
+                             "task executor contains no workers");
   }
-  return iree_ok_status();
-}
-
-static void loomc_task_pool_process_release(iree_task_process_t* process) {
-  loomc_task_pool_t* pool = (loomc_task_pool_t*)process->user_data;
-  iree_slim_mutex_lock(&pool->ready.mutex);
-  iree_atomic_store(&pool->shutdown.released, 1, iree_memory_order_release);
-  iree_notification_post(&pool->shutdown.notification, IREE_ALL_WAITERS);
-  iree_slim_mutex_unlock(&pool->ready.mutex);
-}
-
-static loomc_status_t loomc_task_pool_submit(void* user_data,
-                                             loomc_task_t* task) {
-  loomc_task_pool_t* pool = (loomc_task_pool_t*)user_data;
-  bool schedule_process = false;
-  iree_slim_mutex_lock(&pool->ready.mutex);
-  if (pool->ready.state != LOOMC_TASK_POOL_STATE_ACCEPTING) {
-    iree_slim_mutex_unlock(&pool->ready.mutex);
-    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
-                             "task pool is shutting down");
-  }
-  if (pool->ready.tail != NULL) {
-    pool->ready.tail->next = task;
-  } else {
-    pool->ready.head = task;
-  }
-  pool->ready.tail = task;
-  ++pool->ready.count;
-  const int32_t desired_capacity =
-      (int32_t)iree_min(pool->ready.count, pool->worker_count);
-  if (desired_capacity > pool->ready.scheduled_capacity) {
-    pool->ready.scheduled_capacity = desired_capacity;
-    iree_atomic_store(&pool->process.wake_budget, desired_capacity,
-                      iree_memory_order_relaxed);
-    schedule_process = true;
-  }
-  iree_slim_mutex_unlock(&pool->ready.mutex);
-  if (schedule_process) {
-    iree_task_executor_schedule_process(pool->executor, &pool->process);
-  }
+  iree_allocator_t iree_allocator = iree_allocator_from_loomc(allocator);
+  loomc_task_pool_t* pool = NULL;
+  iree_status_t status = iree_allocator_malloc_aligned(
+      iree_allocator, sizeof(*pool), iree_alignof(loomc_task_pool_t),
+      /*offset=*/0, (void**)&pool);
+  if (!iree_status_is_ok(status)) return loomc_status_from_iree(status);
+  memset(pool, 0, sizeof(*pool));
+  pool->allocator = iree_allocator;
+  iree_task_executor_retain(executor);
+  pool->executor = executor;
+  *out_pool = pool;
   return loomc_ok_status();
-}
-
-static bool loomc_task_pool_released_condition(void* user_data) {
-  const loomc_task_pool_t* pool = (const loomc_task_pool_t*)user_data;
-  return iree_atomic_load(&pool->shutdown.released,
-                          iree_memory_order_acquire) != 0;
-}
-
-static void loomc_task_pool_await_release(loomc_task_pool_t* pool) {
-  iree_notification_await(&pool->shutdown.notification,
-                          loomc_task_pool_released_condition, pool,
-                          iree_infinite_timeout());
-
-  // The condition may become true before the release callback finishes
-  // posting. Crossing its mutex keeps notification storage alive until the
-  // callback has made its final access.
-  iree_slim_mutex_lock(&pool->ready.mutex);
-  iree_slim_mutex_unlock(&pool->ready.mutex);
-}
-
-static void loomc_task_pool_request_shutdown(loomc_task_pool_t* pool) {
-  bool schedule_process = false;
-  int32_t wake_budget = 1;
-  iree_slim_mutex_lock(&pool->ready.mutex);
-  if (pool->ready.state == LOOMC_TASK_POOL_STATE_ACCEPTING) {
-    pool->ready.state = LOOMC_TASK_POOL_STATE_DRAINING;
-    wake_budget =
-        (int32_t)iree_min(iree_max(pool->ready.count, 1), pool->worker_count);
-    schedule_process = true;
-  }
-  iree_slim_mutex_unlock(&pool->ready.mutex);
-  if (schedule_process) {
-    iree_atomic_store(&pool->process.wake_budget, wake_budget,
-                      iree_memory_order_relaxed);
-    iree_task_executor_schedule_process(pool->executor, &pool->process);
-  }
 }
 
 loomc_status_t loomc_task_pool_allocate(
@@ -216,23 +80,12 @@ loomc_status_t loomc_task_pool_allocate(
       options != NULL && options->max_worker_count != 0
           ? options->max_worker_count
           : LOOMC_TASK_POOL_DEFAULT_WORKER_COUNT;
-  iree_allocator_t iree_allocator = iree_allocator_from_loomc(allocator);
-  loomc_task_pool_t* pool = NULL;
-  iree_status_t status = iree_allocator_malloc_aligned(
-      iree_allocator, sizeof(*pool), iree_alignof(loomc_task_pool_t),
-      /*offset=*/0, (void**)&pool);
-  if (!iree_status_is_ok(status)) return loomc_status_from_iree(status);
-  memset(pool, 0, sizeof(*pool));
-  pool->allocator = iree_allocator;
-  pool->ready.state = LOOMC_TASK_POOL_STATE_ACCEPTING;
-  iree_slim_mutex_initialize(&pool->ready.mutex);
-  iree_notification_initialize(&pool->shutdown.notification);
-  iree_atomic_store(&pool->shutdown.released, 0, iree_memory_order_relaxed);
-
   iree_task_topology_t topology;
-  status = iree_task_topology_initialize_from_physical_cores(
+  iree_status_t status = iree_task_topology_initialize_from_physical_cores(
       IREE_TASK_TOPOLOGY_NODE_ID_ANY, IREE_TASK_TOPOLOGY_PERFORMANCE_LEVEL_ANY,
       IREE_TASK_TOPOLOGY_DISTRIBUTION_SCATTER, max_worker_count, &topology);
+
+  iree_task_executor_t* executor = NULL;
   if (iree_status_is_ok(status)) {
     if (iree_task_topology_group_count(&topology) == 0) {
       status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
@@ -245,74 +98,44 @@ loomc_status_t loomc_task_pool_allocate(
               ? options->worker_stack_size
               : LOOMC_TASK_POOL_DEFAULT_WORKER_STACK_SIZE;
       status = iree_task_executor_create(executor_options, &topology,
-                                         iree_allocator, &pool->executor);
+                                         iree_allocator_from_loomc(allocator),
+                                         &executor);
     }
     iree_task_topology_deinitialize(&topology);
   }
-  if (!iree_status_is_ok(status)) {
-    iree_notification_deinitialize(&pool->shutdown.notification);
-    iree_slim_mutex_deinitialize(&pool->ready.mutex);
-    iree_allocator_free_aligned(iree_allocator, pool);
-    return loomc_status_from_iree(status);
-  }
+  if (!iree_status_is_ok(status)) return loomc_status_from_iree(status);
 
-  pool->worker_count = iree_task_executor_worker_count(pool->executor);
-  iree_task_process_initialize(loomc_task_pool_process_drain,
-                               /*suspend_count=*/0,
-                               /*wake_budget=*/(int32_t)pool->worker_count,
-                               &pool->process);
-  iree_task_process_set_flags(&pool->process,
-                              IREE_TASK_PROCESS_FLAG_COMPUTE_SLOT);
-  pool->process.release_fn = loomc_task_pool_process_release;
-  pool->process.user_data = pool;
-  *out_pool = pool;
-  return loomc_ok_status();
+  loomc_status_t public_status =
+      loomc_task_pool_allocate_with_executor(executor, allocator, out_pool);
+  iree_task_executor_release(executor);
+  return public_status;
 }
 
 loomc_host_size_t loomc_task_pool_worker_count(const loomc_task_pool_t* pool) {
-  return pool != NULL ? pool->worker_count : 0;
-}
-
-loomc_task_sink_t loomc_task_pool_sink(loomc_task_pool_t* pool) {
-  return pool != NULL ? (loomc_task_sink_t){
-                            .submit = loomc_task_pool_submit,
-                            .user_data = pool,
-                        }
-                      : (loomc_task_sink_t){0};
-}
-
-loomc_status_t loomc_task_pool_shutdown(loomc_task_pool_t* pool) {
-  if (pool == NULL) {
-    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
-                             "task pool is required");
-  }
-  loomc_task_pool_request_shutdown(pool);
-  return loomc_ok_status();
-}
-
-loomc_status_t loomc_task_pool_await_shutdown(loomc_task_pool_t* pool) {
-  if (pool == NULL) {
-    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
-                             "task pool is required");
-  }
-  iree_slim_mutex_lock(&pool->ready.mutex);
-  const bool shutdown_started =
-      pool->ready.state != LOOMC_TASK_POOL_STATE_ACCEPTING;
-  iree_slim_mutex_unlock(&pool->ready.mutex);
-  if (!shutdown_started) {
-    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
-                             "task pool shutdown has not begun");
-  }
-  loomc_task_pool_await_release(pool);
-  return loomc_ok_status();
+  return pool != NULL ? iree_task_executor_worker_count(
+                            iree_task_executor_from_loomc_task_pool(pool))
+                      : 0;
 }
 
 void loomc_task_pool_free(loomc_task_pool_t* pool) {
   if (pool == NULL) return;
-  loomc_task_pool_request_shutdown(pool);
-  loomc_task_pool_await_release(pool);
   iree_task_executor_release(pool->executor);
-  iree_notification_deinitialize(&pool->shutdown.notification);
-  iree_slim_mutex_deinitialize(&pool->ready.mutex);
   iree_allocator_free_aligned(pool->allocator, pool);
+}
+
+loomc_status_t loomc_task_pool_allocate_from_iree_executor(
+    iree_task_executor_t* executor, loomc_allocator_t allocator,
+    loomc_task_pool_t** out_pool) {
+  if (executor == NULL || out_pool == NULL ||
+      !loomc_allocator_is_valid(allocator)) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "executor, allocator, and out_pool are required");
+  }
+  *out_pool = NULL;
+  return loomc_task_pool_allocate_with_executor(executor, allocator, out_pool);
+}
+
+iree_task_executor_t* iree_task_executor_from_loomc_task_pool(
+    const loomc_task_pool_t* pool) {
+  return pool != NULL ? pool->executor : NULL;
 }

--- a/loom/binding/c/src/task_queue.c
+++ b/loom/binding/c/src/task_queue.c
@@ -1,0 +1,265 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loomc/task_queue.h"
+
+#include <string.h>
+
+#include "iree/base/api.h"
+#include "iree/base/threading/notification.h"
+#include "iree/task/executor.h"
+#include "loomc/iree.h"
+#include "loomc/iree/task_pool.h"
+
+typedef enum loomc_task_queue_state_e {
+  // Accepts new work and keeps the process reusable for later submissions.
+  LOOMC_TASK_QUEUE_STATE_ACCEPTING = 0,
+
+  // Rejects new work and releases the process after the queue drains.
+  LOOMC_TASK_QUEUE_STATE_DRAINING = 1,
+} loomc_task_queue_state_t;
+
+struct loomc_task_queue_t {
+  // Host allocator used for queue storage.
+  iree_allocator_t allocator;
+
+  // Shared worker executor retained for the queue lifetime.
+  iree_task_executor_t* executor;
+
+  // Number of dense worker-local slots exposed to task callbacks.
+  loomc_host_size_t worker_count;
+
+  // Persistent cooperative process draining the ready queue.
+  iree_task_process_t process;
+
+  // Ready-queue state serialized across submitters and workers.
+  struct {
+    // Serializes queue pointers and shutdown state.
+    iree_slim_mutex_t mutex;
+
+    // First task awaiting execution.
+    loomc_task_t* head;
+
+    // Last task awaiting execution.
+    loomc_task_t* tail;
+
+    // Number of tasks linked from `head` through `tail`.
+    loomc_host_size_t count;
+
+    // Worker capacity published for the current non-empty queue wave.
+    int32_t scheduled_capacity;
+
+    // Current task acceptance and shutdown state.
+    loomc_task_queue_state_t state;
+  } ready;
+
+  // Process-release synchronization used only during shutdown.
+  struct {
+    // Posted after the executor has made its final process access.
+    iree_notification_t notification;
+
+    // Whether the executor has made its final process access.
+    iree_atomic_int32_t released;
+  } shutdown;
+};
+
+static loomc_task_t* loomc_task_queue_pop_ready_locked(
+    loomc_task_queue_t* queue) {
+  loomc_task_t* task = queue->ready.head;
+  if (task == NULL) return NULL;
+  queue->ready.head = task->next;
+  task->next = NULL;
+  if (queue->ready.head == NULL) queue->ready.tail = NULL;
+  if (--queue->ready.count == 0) queue->ready.scheduled_capacity = 0;
+  return task;
+}
+
+static iree_status_t loomc_task_queue_process_drain(
+    iree_task_process_t* process,
+    const iree_task_worker_context_t* worker_context,
+    iree_task_process_drain_result_t* out_result) {
+  loomc_task_queue_t* queue = (loomc_task_queue_t*)process->user_data;
+
+  iree_slim_mutex_lock(&queue->ready.mutex);
+  loomc_task_t* task = loomc_task_queue_pop_ready_locked(queue);
+  const bool completed =
+      task == NULL && queue->ready.state == LOOMC_TASK_QUEUE_STATE_DRAINING;
+  iree_slim_mutex_unlock(&queue->ready.mutex);
+
+  if (task != NULL) {
+    const loomc_host_size_t worker_ordinal =
+        (loomc_host_size_t)worker_context->worker_index % queue->worker_count;
+    loomc_task_execute(task, worker_ordinal);
+    *out_result = (iree_task_process_drain_result_t){
+        .completed = false,
+        .did_work = true,
+    };
+  } else {
+    *out_result = (iree_task_process_drain_result_t){
+        .completed = completed,
+        .did_work = false,
+    };
+  }
+  return iree_ok_status();
+}
+
+static void loomc_task_queue_process_release(iree_task_process_t* process) {
+  loomc_task_queue_t* queue = (loomc_task_queue_t*)process->user_data;
+  iree_slim_mutex_lock(&queue->ready.mutex);
+  iree_atomic_store(&queue->shutdown.released, 1, iree_memory_order_release);
+  iree_notification_post(&queue->shutdown.notification, IREE_ALL_WAITERS);
+  iree_slim_mutex_unlock(&queue->ready.mutex);
+}
+
+static loomc_status_t loomc_task_queue_submit(void* user_data,
+                                              loomc_task_t* task) {
+  loomc_task_queue_t* queue = (loomc_task_queue_t*)user_data;
+  bool schedule_process = false;
+  iree_slim_mutex_lock(&queue->ready.mutex);
+  if (queue->ready.state != LOOMC_TASK_QUEUE_STATE_ACCEPTING) {
+    iree_slim_mutex_unlock(&queue->ready.mutex);
+    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                             "task queue is shutting down");
+  }
+  if (queue->ready.tail != NULL) {
+    queue->ready.tail->next = task;
+  } else {
+    queue->ready.head = task;
+  }
+  queue->ready.tail = task;
+  ++queue->ready.count;
+  const int32_t desired_capacity =
+      (int32_t)iree_min(queue->ready.count, queue->worker_count);
+  if (desired_capacity > queue->ready.scheduled_capacity) {
+    queue->ready.scheduled_capacity = desired_capacity;
+    iree_atomic_store(&queue->process.wake_budget, desired_capacity,
+                      iree_memory_order_relaxed);
+    schedule_process = true;
+  }
+  iree_slim_mutex_unlock(&queue->ready.mutex);
+  if (schedule_process) {
+    iree_task_executor_schedule_process(queue->executor, &queue->process);
+  }
+  return loomc_ok_status();
+}
+
+static bool loomc_task_queue_released_condition(void* user_data) {
+  const loomc_task_queue_t* queue = (const loomc_task_queue_t*)user_data;
+  return iree_atomic_load(&queue->shutdown.released,
+                          iree_memory_order_acquire) != 0;
+}
+
+static void loomc_task_queue_await_release(loomc_task_queue_t* queue) {
+  iree_notification_await(&queue->shutdown.notification,
+                          loomc_task_queue_released_condition, queue,
+                          iree_infinite_timeout());
+
+  // The condition may become true before the release callback finishes
+  // posting. Crossing its mutex keeps notification storage alive until the
+  // callback has made its final access.
+  iree_slim_mutex_lock(&queue->ready.mutex);
+  iree_slim_mutex_unlock(&queue->ready.mutex);
+}
+
+static void loomc_task_queue_request_shutdown(loomc_task_queue_t* queue) {
+  bool schedule_process = false;
+  int32_t wake_budget = 1;
+  iree_slim_mutex_lock(&queue->ready.mutex);
+  if (queue->ready.state == LOOMC_TASK_QUEUE_STATE_ACCEPTING) {
+    queue->ready.state = LOOMC_TASK_QUEUE_STATE_DRAINING;
+    wake_budget =
+        (int32_t)iree_min(iree_max(queue->ready.count, 1), queue->worker_count);
+    schedule_process = true;
+  }
+  iree_slim_mutex_unlock(&queue->ready.mutex);
+  if (schedule_process) {
+    iree_atomic_store(&queue->process.wake_budget, wake_budget,
+                      iree_memory_order_relaxed);
+    iree_task_executor_schedule_process(queue->executor, &queue->process);
+  }
+}
+
+loomc_status_t loomc_task_queue_allocate(const loomc_task_pool_t* pool,
+                                         loomc_allocator_t allocator,
+                                         loomc_task_queue_t** out_queue) {
+  if (pool == NULL || out_queue == NULL ||
+      !loomc_allocator_is_valid(allocator)) {
+    return loomc_make_status(
+        LOOMC_STATUS_INVALID_ARGUMENT,
+        "task pool, allocator, and out_queue are required");
+  }
+  *out_queue = NULL;
+  iree_allocator_t iree_allocator = iree_allocator_from_loomc(allocator);
+  loomc_task_queue_t* queue = NULL;
+  iree_status_t status = iree_allocator_malloc_aligned(
+      iree_allocator, sizeof(*queue), iree_alignof(loomc_task_queue_t),
+      /*offset=*/0, (void**)&queue);
+  if (!iree_status_is_ok(status)) return loomc_status_from_iree(status);
+  memset(queue, 0, sizeof(*queue));
+  queue->allocator = iree_allocator;
+  queue->executor = iree_task_executor_from_loomc_task_pool(pool);
+  iree_task_executor_retain(queue->executor);
+  queue->worker_count = iree_task_executor_worker_count(queue->executor);
+  queue->ready.state = LOOMC_TASK_QUEUE_STATE_ACCEPTING;
+  iree_slim_mutex_initialize(&queue->ready.mutex);
+  iree_notification_initialize(&queue->shutdown.notification);
+  iree_atomic_store(&queue->shutdown.released, 0, iree_memory_order_relaxed);
+
+  iree_task_process_initialize(loomc_task_queue_process_drain,
+                               /*suspend_count=*/0,
+                               /*wake_budget=*/(int32_t)queue->worker_count,
+                               &queue->process);
+  iree_task_process_set_flags(&queue->process,
+                              IREE_TASK_PROCESS_FLAG_COMPUTE_SLOT);
+  queue->process.release_fn = loomc_task_queue_process_release;
+  queue->process.user_data = queue;
+  *out_queue = queue;
+  return loomc_ok_status();
+}
+
+loomc_task_sink_t loomc_task_queue_sink(loomc_task_queue_t* queue) {
+  return queue != NULL ? (loomc_task_sink_t){
+                             .submit = loomc_task_queue_submit,
+                             .user_data = queue,
+                         }
+                       : (loomc_task_sink_t){0};
+}
+
+loomc_status_t loomc_task_queue_shutdown(loomc_task_queue_t* queue) {
+  if (queue == NULL) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "task queue is required");
+  }
+  loomc_task_queue_request_shutdown(queue);
+  return loomc_ok_status();
+}
+
+loomc_status_t loomc_task_queue_await_shutdown(loomc_task_queue_t* queue) {
+  if (queue == NULL) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "task queue is required");
+  }
+  iree_slim_mutex_lock(&queue->ready.mutex);
+  const bool shutdown_started =
+      queue->ready.state != LOOMC_TASK_QUEUE_STATE_ACCEPTING;
+  iree_slim_mutex_unlock(&queue->ready.mutex);
+  if (!shutdown_started) {
+    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                             "task queue shutdown has not begun");
+  }
+  loomc_task_queue_await_release(queue);
+  return loomc_ok_status();
+}
+
+void loomc_task_queue_free(loomc_task_queue_t* queue) {
+  if (queue == NULL) return;
+  loomc_task_queue_request_shutdown(queue);
+  loomc_task_queue_await_release(queue);
+  iree_task_executor_release(queue->executor);
+  iree_notification_deinitialize(&queue->shutdown.notification);
+  iree_slim_mutex_deinitialize(&queue->ready.mutex);
+  iree_allocator_free_aligned(queue->allocator, queue);
+}

--- a/loom/binding/c/test/BUILD.bazel
+++ b/loom/binding/c/test/BUILD.bazel
@@ -6,6 +6,7 @@
 
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
+    "iree_cmake_extra_content",
     "loom_cc_library",
     "loom_cc_test",
     "loom_config_compatible_with",
@@ -299,6 +300,31 @@ loom_cc_test(
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],
+)
+
+iree_cmake_extra_content(
+    content = """
+if(IREE_TARGET_HAS_THREADS)
+""",
+    inline = True,
+)
+
+loom_cc_test(
+    name = "task_pool_test",
+    srcs = ["task_pool_test.cc"],
+    deps = [
+        ":test_util",
+        "//loom/binding/c:task_pool",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_cmake_extra_content(
+    content = """
+endif()
+""",
+    inline = True,
 )
 
 loom_cc_test(

--- a/loom/binding/c/test/BUILD.bazel
+++ b/loom/binding/c/test/BUILD.bazel
@@ -291,6 +291,17 @@ loom_cc_test(
 )
 
 loom_cc_test(
+    name = "task_test",
+    srcs = ["task_test.cc"],
+    deps = [
+        ":test_util",
+        "//loom/binding/c:loomc",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_test(
     name = "workspace_test",
     srcs = ["workspace_test.cc"],
     deps = [

--- a/loom/binding/c/test/BUILD.bazel
+++ b/loom/binding/c/test/BUILD.bazel
@@ -320,6 +320,18 @@ loom_cc_test(
     ],
 )
 
+loom_cc_test(
+    name = "task_queue_test",
+    srcs = ["task_queue_test.cc"],
+    deps = [
+        ":test_util",
+        "//loom/binding/c:task_pool",
+        "//loom/binding/c:task_queue",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
 iree_cmake_extra_content(
     content = """
 endif()

--- a/loom/binding/c/test/CMakeLists.txt
+++ b/loom/binding/c/test/CMakeLists.txt
@@ -309,6 +309,22 @@ loom_cc_test(
     loom::binding::c::loomc
 )
 
+if(IREE_TARGET_HAS_THREADS)
+
+loom_cc_test(
+  NAME
+    task_pool_test
+  SRCS
+    "task_pool_test.cc"
+  DEPS
+    ::test_util
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::binding::c::task_pool
+)
+
+endif()
+
 loom_cc_test(
   NAME
     workspace_test

--- a/loom/binding/c/test/CMakeLists.txt
+++ b/loom/binding/c/test/CMakeLists.txt
@@ -299,6 +299,18 @@ loom_cc_test(
 
 loom_cc_test(
   NAME
+    task_test
+  SRCS
+    "task_test.cc"
+  DEPS
+    ::test_util
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::binding::c::loomc
+)
+
+loom_cc_test(
+  NAME
     workspace_test
   SRCS
     "workspace_test.cc"

--- a/loom/binding/c/test/CMakeLists.txt
+++ b/loom/binding/c/test/CMakeLists.txt
@@ -323,6 +323,19 @@ loom_cc_test(
     loom::binding::c::task_pool
 )
 
+loom_cc_test(
+  NAME
+    task_queue_test
+  SRCS
+    "task_queue_test.cc"
+  DEPS
+    ::test_util
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::binding::c::task_pool
+    loom::binding::c::task_queue
+)
+
 endif()
 
 loom_cc_test(

--- a/loom/binding/c/test/target/amdgpu/amdgpu_test.cc
+++ b/loom/binding/c/test/target/amdgpu/amdgpu_test.cc
@@ -37,7 +37,7 @@ using loomc::testing::HandlePtr;
 
 using CompilerPtr = HandlePtr<loomc_compiler_t, loomc_compiler_release>;
 using ContextPtr = HandlePtr<loomc_context_t, loomc_context_release>;
-using CmdProgramProductPtr = HandlePtr<loomc_product_t, loomc_product_release>;
+using ProductPtr = HandlePtr<loomc_product_t, loomc_product_release>;
 using LaunchConfigProgramPtr = HandlePtr<loomc_launch_config_program_t,
                                          loomc_launch_config_program_release>;
 using LinkIndexBuilderPtr =
@@ -952,6 +952,99 @@ config.def @test.workgroup_size_x = 64 : index
 }
 
 TEST(AmdgpuTargetTest,
+     CommandProductTargetBindingPreservesLaunchConfigurationProjection) {
+  TargetEnvironmentPtr target_environment = CreateAmdgpuTargetEnvironment();
+  ContextPtr context = CreateAmdgpuContext(target_environment.get());
+  WorkspacePtr workspace = CreateWorkspace();
+  TargetProfilePtr profile =
+      CreateTargetProfile(target_environment.get(), "gfx1151");
+  SourcePtr source = CreateTextSource("specialized_command_request.loom", R"(
+target.decl @device
+
+kernel.def target(@device) @record_subgroup_size() {
+  %one = index.constant 1 : index
+  %size = target.subgroup.size : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%size, %one, %one) : index
+} launch() {
+  kernel.return
+}
+
+command.program.def public target(@device) @dispatch() launch() {
+  kernel.launch @record_subgroup_size() : ()
+  command.return
+}
+)");
+  LinkIndexPtr index = CreateLinkIndex(context.get(), source.get());
+
+  const loomc_target_binding_t target_binding = {
+      /*.target_symbol=*/loomc_make_cstring_view("device"),
+      /*.target_profile=*/profile.get(),
+  };
+  const loomc_target_specialization_options_t target_options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_TARGET_SPECIALIZATION_OPTIONS,
+      /*.structure_size=*/sizeof(target_options),
+      /*.next=*/nullptr,
+      /*.specializations=*/nullptr,
+      /*.specialization_count=*/0,
+      /*.target_bindings=*/&target_binding,
+      /*.target_binding_count=*/1,
+  };
+  KernelRequestCapture request_capture;
+  const loomc_cmd_program_product_options_t product_options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_CMD_PROGRAM_PRODUCT_OPTIONS,
+      /*.structure_size=*/sizeof(product_options),
+      /*.next=*/&target_options,
+      /*.link_index=*/index.get(),
+      /*.root_symbol_ordinals=*/nullptr,
+      /*.root_symbol_count=*/0,
+      /*.flags=*/LOOMC_CMD_PROGRAM_PRODUCT_FLAG_INCLUDE_INPUT_EXPORTS,
+      /*.config=*/{},
+      /*.request_sink=*/
+      {
+          /*.publish=*/CaptureKernelRequest,
+          /*.user_data=*/&request_capture,
+      },
+  };
+  loomc_product_t* product = nullptr;
+  loomc_result_t* product_result = nullptr;
+  LOOMC_ASSERT_OK(loomc_cmd_program_product_build(
+      workspace.get(), &product_options, loomc_allocator_system(), &product,
+      &product_result));
+  ProductPtr product_ptr(product);
+  ResultPtr product_result_ptr(product_result);
+  ExpectSucceededResult(product_result_ptr.get());
+  ASSERT_EQ(loomc_cmd_program_product_program_count(product_ptr.get()), 1u);
+  ASSERT_EQ(request_capture.requests.size(), 1u);
+
+  CompilerPtr compiler = CreateCompiler(context.get());
+  PassProgramPtr pass_program = CreatePreparedLowPassProgram(context.get());
+  const loomc_compile_options_t compile_options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
+      /*.structure_size=*/sizeof(compile_options),
+      /*.next=*/nullptr,
+      /*.module_name=*/loomc_make_cstring_view("specialized_command_request"),
+      /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_TEXT,
+  };
+  loomc_product_t* kernel_product = nullptr;
+  loomc_result_t* compile_result = nullptr;
+  LOOMC_ASSERT_OK(loomc_compile_request(
+      compiler.get(), workspace.get(), pass_program.get(),
+      request_capture.requests[0].get(), &compile_options,
+      loomc_allocator_system(), &kernel_product, &compile_result));
+  ProductPtr kernel_product_ptr(kernel_product);
+  ResultPtr compile_result_ptr(compile_result);
+  ExpectSucceededResult(compile_result_ptr.get());
+  const loomc_artifact_t* text_artifact =
+      loomc_product_artifact_at(kernel_product_ptr.get(), 0);
+  ASSERT_NE(text_artifact, nullptr);
+  const std::string module_text = ToString(text_artifact->contents);
+  EXPECT_NE(module_text.find("target<amdgpu.rdna3_5.core>"), std::string::npos)
+      << module_text;
+  EXPECT_NE(module_text.find("workgroup_size(32, 1, 1)"), std::string::npos)
+      << module_text;
+}
+
+TEST(AmdgpuTargetTest,
      CommandKernelRequestCompilesForIndependentTargetProfiles) {
   TargetEnvironmentPtr target_environment = CreateAmdgpuTargetEnvironment();
   ContextPtr context = CreateAmdgpuContext(target_environment.get());
@@ -999,7 +1092,7 @@ command.program.def public @dispatch() launch() {
   LOOMC_ASSERT_OK(loomc_cmd_program_product_build(
       workspace.get(), &product_options, loomc_allocator_system(), &product,
       &product_result));
-  CmdProgramProductPtr product_ptr(product);
+  ProductPtr product_ptr(product);
   ResultPtr product_result_ptr(product_result);
   ExpectSucceededResult(product_result_ptr.get());
   ASSERT_EQ(loomc_cmd_program_product_program_count(product_ptr.get()), 1u);

--- a/loom/binding/c/test/task_pool_test.cc
+++ b/loom/binding/c/test/task_pool_test.cc
@@ -6,297 +6,14 @@
 
 #include "loomc/task_pool.h"
 
-#include <condition_variable>
-#include <mutex>
-#include <thread>
-#include <vector>
-
 #include "iree/testing/gtest.h"
+#include "loomc/iree/task_pool.h"
 #include "test/util.h"
 
 namespace {
 
 using loomc::testing::HandlePtr;
 using TaskPoolPtr = HandlePtr<loomc_task_pool_t, loomc_task_pool_free>;
-
-class TaskTracker {
- public:
-  explicit TaskTracker(loomc_host_size_t worker_count)
-      : active_by_worker_(worker_count, 0) {}
-
-  void BeginExecution(loomc_host_size_t worker_ordinal) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (worker_ordinal >= active_by_worker_.size()) {
-      invalid_worker_ordinal_ = true;
-    } else if (active_by_worker_[worker_ordinal]++ != 0) {
-      concurrent_worker_ordinal_ = true;
-    }
-    ++execution_count_;
-    condition_.notify_all();
-  }
-
-  void EndExecution(loomc_host_size_t worker_ordinal) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (worker_ordinal < active_by_worker_.size()) {
-      --active_by_worker_[worker_ordinal];
-    }
-  }
-
-  void RecordDestruction() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    ++destruction_count_;
-    condition_.notify_all();
-  }
-
-  void RecordSubmissionFailure(loomc_status_t status) {
-    const loomc_status_code_t code = loomc_status_consume_code(status);
-    std::lock_guard<std::mutex> lock(mutex_);
-    submission_status_code_ = code;
-    condition_.notify_all();
-  }
-
-  void WaitForExecutions(int expected_count) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    condition_.wait(lock, [&] { return execution_count_ >= expected_count; });
-  }
-
-  void WaitForDestructions(int expected_count) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    condition_.wait(lock, [&] { return destruction_count_ >= expected_count; });
-  }
-
-  int execution_count() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return execution_count_;
-  }
-
-  int destruction_count() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return destruction_count_;
-  }
-
-  loomc_status_code_t submission_status_code() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return submission_status_code_;
-  }
-
-  bool has_invalid_worker_ordinal() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return invalid_worker_ordinal_;
-  }
-
-  bool has_concurrent_worker_ordinal() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return concurrent_worker_ordinal_;
-  }
-
- private:
-  // Serializes all tracked outcome state.
-  mutable std::mutex mutex_;
-
-  // Notifies waiters when task execution or destruction advances.
-  std::condition_variable condition_;
-
-  // Active callback count indexed by dense worker ordinal.
-  std::vector<int> active_by_worker_;
-
-  // Number of task callbacks that began execution.
-  int execution_count_ = 0;
-
-  // Number of task objects destroyed.
-  int destruction_count_ = 0;
-
-  // First observed recursive submission failure.
-  loomc_status_code_t submission_status_code_ = LOOMC_STATUS_OK;
-
-  // Whether a callback observed an out-of-range worker ordinal.
-  bool invalid_worker_ordinal_ = false;
-
-  // Whether two callbacks ran concurrently with one worker ordinal.
-  bool concurrent_worker_ordinal_ = false;
-};
-
-typedef struct tracked_task_t {
-  // Generic task base.
-  loomc_task_t base;
-
-  // External outcome tracker that outlives the task.
-  TaskTracker* tracker;
-} tracked_task_t;
-
-static void ExecuteTrackedTask(loomc_task_t* base_task,
-                               loomc_host_size_t worker_ordinal) {
-  tracked_task_t* task = reinterpret_cast<tracked_task_t*>(base_task);
-  task->tracker->BeginExecution(worker_ordinal);
-  task->tracker->EndExecution(worker_ordinal);
-}
-
-static void DestroyTrackedTask(loomc_task_t* base_task) {
-  tracked_task_t* task = reinterpret_cast<tracked_task_t*>(base_task);
-  task->tracker->RecordDestruction();
-  delete task;
-}
-
-static const loomc_task_vtable_t kTrackedTaskVtable = {
-    /*.execute=*/ExecuteTrackedTask,
-    /*.destroy=*/DestroyTrackedTask,
-};
-
-static loomc_task_t* AllocateTrackedTask(TaskTracker* tracker) {
-  tracked_task_t* task = new tracked_task_t;
-  loomc_task_initialize(&kTrackedTaskVtable, &task->base);
-  task->tracker = tracker;
-  return &task->base;
-}
-
-class ExecutionGate {
- public:
-  explicit ExecutionGate(int expected_count)
-      : expected_count_(expected_count) {}
-
-  void EnterAndWait() {
-    std::unique_lock<std::mutex> lock(mutex_);
-    ++entered_count_;
-    condition_.notify_all();
-    condition_.wait(lock, [&] { return released_; });
-  }
-
-  void WaitUntilEntered() {
-    std::unique_lock<std::mutex> lock(mutex_);
-    condition_.wait(lock, [&] { return entered_count_ >= expected_count_; });
-  }
-
-  void Release() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    released_ = true;
-    condition_.notify_all();
-  }
-
- private:
-  // Serializes entry and release state.
-  std::mutex mutex_;
-
-  // Notifies waiters when entrants arrive or the gate releases.
-  std::condition_variable condition_;
-
-  // Number of concurrent entrants required before the observer proceeds.
-  int expected_count_ = 0;
-
-  // Number of tasks that have entered the gate.
-  int entered_count_ = 0;
-
-  // Whether every task waiting at the gate may proceed.
-  bool released_ = false;
-};
-
-typedef struct gated_task_t {
-  // Generic task base.
-  loomc_task_t base;
-
-  // External execution gate that outlives the task.
-  ExecutionGate* gate;
-
-  // External outcome tracker that outlives the task.
-  TaskTracker* tracker;
-} gated_task_t;
-
-static void ExecuteGatedTask(loomc_task_t* base_task,
-                             loomc_host_size_t worker_ordinal) {
-  gated_task_t* task = reinterpret_cast<gated_task_t*>(base_task);
-  task->tracker->BeginExecution(worker_ordinal);
-  task->gate->EnterAndWait();
-  task->tracker->EndExecution(worker_ordinal);
-}
-
-static void DestroyGatedTask(loomc_task_t* base_task) {
-  gated_task_t* task = reinterpret_cast<gated_task_t*>(base_task);
-  task->tracker->RecordDestruction();
-  delete task;
-}
-
-static const loomc_task_vtable_t kGatedTaskVtable = {
-    /*.execute=*/ExecuteGatedTask,
-    /*.destroy=*/DestroyGatedTask,
-};
-
-static loomc_task_t* AllocateGatedTask(ExecutionGate* gate,
-                                       TaskTracker* tracker) {
-  gated_task_t* task = new gated_task_t;
-  loomc_task_initialize(&kGatedTaskVtable, &task->base);
-  task->gate = gate;
-  task->tracker = tracker;
-  return &task->base;
-}
-
-typedef struct recursive_task_t {
-  // Generic task base.
-  loomc_task_t base;
-
-  // Borrowed sink used to publish child tasks.
-  loomc_task_sink_t sink;
-
-  // External child execution gate that outlives the task.
-  ExecutionGate* child_gate;
-
-  // External outcome tracker that outlives the task.
-  TaskTracker* tracker;
-
-  // Number of child tasks to publish.
-  int child_count;
-} recursive_task_t;
-
-static void ExecuteRecursiveTask(loomc_task_t* base_task,
-                                 loomc_host_size_t worker_ordinal) {
-  recursive_task_t* task = reinterpret_cast<recursive_task_t*>(base_task);
-  task->tracker->BeginExecution(worker_ordinal);
-  for (int i = 0; i < task->child_count; ++i) {
-    loomc_task_t* child = AllocateGatedTask(task->child_gate, task->tracker);
-    loomc_status_t status = loomc_task_sink_submit(task->sink, child);
-    if (!loomc_status_is_ok(status)) {
-      task->tracker->RecordSubmissionFailure(status);
-      loomc_task_destroy(child);
-    }
-  }
-  task->tracker->EndExecution(worker_ordinal);
-}
-
-static void DestroyRecursiveTask(loomc_task_t* base_task) {
-  recursive_task_t* task = reinterpret_cast<recursive_task_t*>(base_task);
-  task->tracker->RecordDestruction();
-  delete task;
-}
-
-static const loomc_task_vtable_t kRecursiveTaskVtable = {
-    /*.execute=*/ExecuteRecursiveTask,
-    /*.destroy=*/DestroyRecursiveTask,
-};
-
-static loomc_task_t* AllocateRecursiveTask(loomc_task_sink_t sink,
-                                           ExecutionGate* child_gate,
-                                           int child_count,
-                                           TaskTracker* tracker) {
-  recursive_task_t* task = new recursive_task_t;
-  loomc_task_initialize(&kRecursiveTaskVtable, &task->base);
-  task->sink = sink;
-  task->child_gate = child_gate;
-  task->tracker = tracker;
-  task->child_count = child_count;
-  return &task->base;
-}
-
-static TaskPoolPtr AllocateTaskPool(loomc_host_size_t max_worker_count) {
-  loomc_task_pool_options_t options = {
-      /*.type=*/LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS,
-      /*.structure_size=*/sizeof(loomc_task_pool_options_t),
-      /*.next=*/nullptr,
-      /*.max_worker_count=*/max_worker_count,
-      /*.worker_stack_size=*/0,
-  };
-  loomc_task_pool_t* pool = nullptr;
-  IREE_CHECK_OK(iree_status_from_loomc(
-      loomc_task_pool_allocate(&options, loomc_allocator_system(), &pool)));
-  return TaskPoolPtr(pool);
-}
 
 TEST(TaskPoolTest, DefaultUsesFourWorkerLimit) {
   loomc_task_pool_t* raw_pool = nullptr;
@@ -307,154 +24,38 @@ TEST(TaskPoolTest, DefaultUsesFourWorkerLimit) {
   EXPECT_LE(loomc_task_pool_worker_count(pool.get()), 4u);
 }
 
-TEST(TaskPoolTest, DrainsAcceptedTasksWithExclusiveWorkerOrdinals) {
-  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
-  const loomc_host_size_t worker_count =
-      loomc_task_pool_worker_count(pool.get());
-  TaskTracker tracker(worker_count);
-  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
-
-  constexpr int kTaskCount = 256;
-  for (int i = 0; i < kTaskCount; ++i) {
-    LOOMC_ASSERT_OK(
-        loomc_task_sink_submit(sink, AllocateTrackedTask(&tracker)));
-  }
-  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
-  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
-
-  EXPECT_EQ(tracker.execution_count(), kTaskCount);
-  EXPECT_EQ(tracker.destruction_count(), kTaskCount);
-  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
-  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
-}
-
-TEST(TaskPoolTest, ConcurrentSubmittersShareOneWorkerPopulation) {
-  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
-  TaskTracker tracker(loomc_task_pool_worker_count(pool.get()));
-  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
-
-  constexpr int kSubmitterCount = 8;
-  constexpr int kTasksPerSubmitter = 128;
-  std::vector<std::thread> submitters;
-  submitters.reserve(kSubmitterCount);
-  for (int i = 0; i < kSubmitterCount; ++i) {
-    submitters.emplace_back([&] {
-      for (int j = 0; j < kTasksPerSubmitter; ++j) {
-        loomc_task_t* task = AllocateTrackedTask(&tracker);
-        loomc_status_t status = loomc_task_sink_submit(sink, task);
-        if (!loomc_status_is_ok(status)) {
-          tracker.RecordSubmissionFailure(status);
-          loomc_task_destroy(task);
-        }
-      }
-    });
-  }
-  for (std::thread& submitter : submitters) submitter.join();
-
-  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
-  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
-  EXPECT_EQ(tracker.submission_status_code(), LOOMC_STATUS_OK);
-  EXPECT_EQ(tracker.execution_count(), kSubmitterCount * kTasksPerSubmitter);
-  EXPECT_EQ(tracker.destruction_count(), kSubmitterCount * kTasksPerSubmitter);
-  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
-  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
-}
-
-TEST(TaskPoolTest, ReusesWorkersAcrossSubmissionWaves) {
-  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
-  const loomc_host_size_t worker_count =
-      loomc_task_pool_worker_count(pool.get());
-  TaskTracker tracker(worker_count);
-  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
-
-  constexpr int kWaveCount = 256;
-  int expected_task_count = 0;
-  for (int wave = 0; wave < kWaveCount; ++wave) {
-    const int wave_task_count = 1 + wave % static_cast<int>(worker_count);
-    for (int i = 0; i < wave_task_count; ++i) {
-      LOOMC_ASSERT_OK(
-          loomc_task_sink_submit(sink, AllocateTrackedTask(&tracker)));
-    }
-    expected_task_count += wave_task_count;
-    tracker.WaitForDestructions(expected_task_count);
-  }
-
-  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
-  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
-  EXPECT_EQ(tracker.execution_count(), expected_task_count);
-  EXPECT_EQ(tracker.destruction_count(), expected_task_count);
-  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
-  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
-}
-
-TEST(TaskPoolTest, RecursiveSubmissionUsesMultipleWorkers) {
-  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
-  const int worker_count =
-      static_cast<int>(loomc_task_pool_worker_count(pool.get()));
-  if (worker_count < 2) GTEST_SKIP() << "host exposes only one worker";
-
-  ExecutionGate child_gate(/*expected_count=*/2);
-  TaskTracker tracker(worker_count);
-  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
-  const int child_count = worker_count * 2;
-  LOOMC_ASSERT_OK(loomc_task_sink_submit(
-      sink, AllocateRecursiveTask(sink, &child_gate, child_count, &tracker)));
-
-  child_gate.WaitUntilEntered();
-  child_gate.Release();
-  tracker.WaitForExecutions(/*expected_count=*/child_count + 1);
-  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
-  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
-
-  EXPECT_EQ(tracker.submission_status_code(), LOOMC_STATUS_OK);
-  EXPECT_EQ(tracker.execution_count(), child_count + 1);
-  EXPECT_EQ(tracker.destruction_count(), child_count + 1);
-  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
-  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
-}
-
-TEST(TaskPoolTest, ShutdownDrainsAcceptedWorkAndRejectsNewWork) {
-  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/1);
-  TaskTracker tracker(loomc_task_pool_worker_count(pool.get()));
-  ExecutionGate gate(/*expected_count=*/1);
-  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
-
+TEST(TaskPoolTest, WrapperRetainsExistingExecutor) {
+  loomc_task_pool_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS,
+      /*.structure_size=*/sizeof(loomc_task_pool_options_t),
+      /*.next=*/nullptr,
+      /*.max_worker_count=*/2,
+      /*.worker_stack_size=*/0,
+  };
+  loomc_task_pool_t* raw_owner = nullptr;
   LOOMC_ASSERT_OK(
-      loomc_task_sink_submit(sink, AllocateGatedTask(&gate, &tracker)));
-  gate.WaitUntilEntered();
-  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
+      loomc_task_pool_allocate(&options, loomc_allocator_system(), &raw_owner));
+  TaskPoolPtr owner(raw_owner);
 
-  loomc_task_t* rejected_task = AllocateTrackedTask(&tracker);
-  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_FAILED_PRECONDITION,
-                         loomc_task_sink_submit(sink, rejected_task));
-  loomc_task_destroy(rejected_task);
+  iree_task_executor_t* executor =
+      iree_task_executor_from_loomc_task_pool(owner.get());
+  ASSERT_NE(executor, nullptr);
+  const loomc_host_size_t worker_count =
+      loomc_task_pool_worker_count(owner.get());
 
-  gate.Release();
-  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
-  EXPECT_EQ(tracker.execution_count(), 1);
-  EXPECT_EQ(tracker.destruction_count(), 2);
+  loomc_task_pool_t* raw_wrapper = nullptr;
+  LOOMC_ASSERT_OK(loomc_task_pool_allocate_from_iree_executor(
+      executor, loomc_allocator_system(), &raw_wrapper));
+  TaskPoolPtr wrapper(raw_wrapper);
+  owner.reset();
+
+  EXPECT_EQ(iree_task_executor_from_loomc_task_pool(wrapper.get()), executor);
+  EXPECT_EQ(loomc_task_pool_worker_count(wrapper.get()), worker_count);
 }
 
-TEST(TaskPoolTest, FreeDrainsAcceptedWork) {
-  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
-  TaskTracker tracker(loomc_task_pool_worker_count(pool.get()));
-  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
-
-  constexpr int kTaskCount = 256;
-  for (int i = 0; i < kTaskCount; ++i) {
-    LOOMC_ASSERT_OK(
-        loomc_task_sink_submit(sink, AllocateTrackedTask(&tracker)));
-  }
-  pool.reset();
-
-  EXPECT_EQ(tracker.execution_count(), kTaskCount);
-  EXPECT_EQ(tracker.destruction_count(), kTaskCount);
-}
-
-TEST(TaskPoolTest, AwaitRequiresShutdown) {
-  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/1);
-  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_FAILED_PRECONDITION,
-                         loomc_task_pool_await_shutdown(pool.get()));
+TEST(TaskPoolTest, NullQueriesReturnEmptyValues) {
+  EXPECT_EQ(loomc_task_pool_worker_count(nullptr), 0u);
+  EXPECT_EQ(iree_task_executor_from_loomc_task_pool(nullptr), nullptr);
 }
 
 }  // namespace

--- a/loom/binding/c/test/task_pool_test.cc
+++ b/loom/binding/c/test/task_pool_test.cc
@@ -1,0 +1,460 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loomc/task_pool.h"
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "iree/testing/gtest.h"
+#include "test/util.h"
+
+namespace {
+
+using loomc::testing::HandlePtr;
+using TaskPoolPtr = HandlePtr<loomc_task_pool_t, loomc_task_pool_free>;
+
+class TaskTracker {
+ public:
+  explicit TaskTracker(loomc_host_size_t worker_count)
+      : active_by_worker_(worker_count, 0) {}
+
+  void BeginExecution(loomc_host_size_t worker_ordinal) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (worker_ordinal >= active_by_worker_.size()) {
+      invalid_worker_ordinal_ = true;
+    } else if (active_by_worker_[worker_ordinal]++ != 0) {
+      concurrent_worker_ordinal_ = true;
+    }
+    ++execution_count_;
+    condition_.notify_all();
+  }
+
+  void EndExecution(loomc_host_size_t worker_ordinal) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (worker_ordinal < active_by_worker_.size()) {
+      --active_by_worker_[worker_ordinal];
+    }
+  }
+
+  void RecordDestruction() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++destruction_count_;
+    condition_.notify_all();
+  }
+
+  void RecordSubmissionFailure(loomc_status_t status) {
+    const loomc_status_code_t code = loomc_status_consume_code(status);
+    std::lock_guard<std::mutex> lock(mutex_);
+    submission_status_code_ = code;
+    condition_.notify_all();
+  }
+
+  void WaitForExecutions(int expected_count) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait(lock, [&] { return execution_count_ >= expected_count; });
+  }
+
+  void WaitForDestructions(int expected_count) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait(lock, [&] { return destruction_count_ >= expected_count; });
+  }
+
+  int execution_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return execution_count_;
+  }
+
+  int destruction_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return destruction_count_;
+  }
+
+  loomc_status_code_t submission_status_code() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return submission_status_code_;
+  }
+
+  bool has_invalid_worker_ordinal() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return invalid_worker_ordinal_;
+  }
+
+  bool has_concurrent_worker_ordinal() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return concurrent_worker_ordinal_;
+  }
+
+ private:
+  // Serializes all tracked outcome state.
+  mutable std::mutex mutex_;
+
+  // Notifies waiters when task execution or destruction advances.
+  std::condition_variable condition_;
+
+  // Active callback count indexed by dense worker ordinal.
+  std::vector<int> active_by_worker_;
+
+  // Number of task callbacks that began execution.
+  int execution_count_ = 0;
+
+  // Number of task objects destroyed.
+  int destruction_count_ = 0;
+
+  // First observed recursive submission failure.
+  loomc_status_code_t submission_status_code_ = LOOMC_STATUS_OK;
+
+  // Whether a callback observed an out-of-range worker ordinal.
+  bool invalid_worker_ordinal_ = false;
+
+  // Whether two callbacks ran concurrently with one worker ordinal.
+  bool concurrent_worker_ordinal_ = false;
+};
+
+typedef struct tracked_task_t {
+  // Generic task base.
+  loomc_task_t base;
+
+  // External outcome tracker that outlives the task.
+  TaskTracker* tracker;
+} tracked_task_t;
+
+static void ExecuteTrackedTask(loomc_task_t* base_task,
+                               loomc_host_size_t worker_ordinal) {
+  tracked_task_t* task = reinterpret_cast<tracked_task_t*>(base_task);
+  task->tracker->BeginExecution(worker_ordinal);
+  task->tracker->EndExecution(worker_ordinal);
+}
+
+static void DestroyTrackedTask(loomc_task_t* base_task) {
+  tracked_task_t* task = reinterpret_cast<tracked_task_t*>(base_task);
+  task->tracker->RecordDestruction();
+  delete task;
+}
+
+static const loomc_task_vtable_t kTrackedTaskVtable = {
+    /*.execute=*/ExecuteTrackedTask,
+    /*.destroy=*/DestroyTrackedTask,
+};
+
+static loomc_task_t* AllocateTrackedTask(TaskTracker* tracker) {
+  tracked_task_t* task = new tracked_task_t;
+  loomc_task_initialize(&kTrackedTaskVtable, &task->base);
+  task->tracker = tracker;
+  return &task->base;
+}
+
+class ExecutionGate {
+ public:
+  explicit ExecutionGate(int expected_count)
+      : expected_count_(expected_count) {}
+
+  void EnterAndWait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    ++entered_count_;
+    condition_.notify_all();
+    condition_.wait(lock, [&] { return released_; });
+  }
+
+  void WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait(lock, [&] { return entered_count_ >= expected_count_; });
+  }
+
+  void Release() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    released_ = true;
+    condition_.notify_all();
+  }
+
+ private:
+  // Serializes entry and release state.
+  std::mutex mutex_;
+
+  // Notifies waiters when entrants arrive or the gate releases.
+  std::condition_variable condition_;
+
+  // Number of concurrent entrants required before the observer proceeds.
+  int expected_count_ = 0;
+
+  // Number of tasks that have entered the gate.
+  int entered_count_ = 0;
+
+  // Whether every task waiting at the gate may proceed.
+  bool released_ = false;
+};
+
+typedef struct gated_task_t {
+  // Generic task base.
+  loomc_task_t base;
+
+  // External execution gate that outlives the task.
+  ExecutionGate* gate;
+
+  // External outcome tracker that outlives the task.
+  TaskTracker* tracker;
+} gated_task_t;
+
+static void ExecuteGatedTask(loomc_task_t* base_task,
+                             loomc_host_size_t worker_ordinal) {
+  gated_task_t* task = reinterpret_cast<gated_task_t*>(base_task);
+  task->tracker->BeginExecution(worker_ordinal);
+  task->gate->EnterAndWait();
+  task->tracker->EndExecution(worker_ordinal);
+}
+
+static void DestroyGatedTask(loomc_task_t* base_task) {
+  gated_task_t* task = reinterpret_cast<gated_task_t*>(base_task);
+  task->tracker->RecordDestruction();
+  delete task;
+}
+
+static const loomc_task_vtable_t kGatedTaskVtable = {
+    /*.execute=*/ExecuteGatedTask,
+    /*.destroy=*/DestroyGatedTask,
+};
+
+static loomc_task_t* AllocateGatedTask(ExecutionGate* gate,
+                                       TaskTracker* tracker) {
+  gated_task_t* task = new gated_task_t;
+  loomc_task_initialize(&kGatedTaskVtable, &task->base);
+  task->gate = gate;
+  task->tracker = tracker;
+  return &task->base;
+}
+
+typedef struct recursive_task_t {
+  // Generic task base.
+  loomc_task_t base;
+
+  // Borrowed sink used to publish child tasks.
+  loomc_task_sink_t sink;
+
+  // External child execution gate that outlives the task.
+  ExecutionGate* child_gate;
+
+  // External outcome tracker that outlives the task.
+  TaskTracker* tracker;
+
+  // Number of child tasks to publish.
+  int child_count;
+} recursive_task_t;
+
+static void ExecuteRecursiveTask(loomc_task_t* base_task,
+                                 loomc_host_size_t worker_ordinal) {
+  recursive_task_t* task = reinterpret_cast<recursive_task_t*>(base_task);
+  task->tracker->BeginExecution(worker_ordinal);
+  for (int i = 0; i < task->child_count; ++i) {
+    loomc_task_t* child = AllocateGatedTask(task->child_gate, task->tracker);
+    loomc_status_t status = loomc_task_sink_submit(task->sink, child);
+    if (!loomc_status_is_ok(status)) {
+      task->tracker->RecordSubmissionFailure(status);
+      loomc_task_destroy(child);
+    }
+  }
+  task->tracker->EndExecution(worker_ordinal);
+}
+
+static void DestroyRecursiveTask(loomc_task_t* base_task) {
+  recursive_task_t* task = reinterpret_cast<recursive_task_t*>(base_task);
+  task->tracker->RecordDestruction();
+  delete task;
+}
+
+static const loomc_task_vtable_t kRecursiveTaskVtable = {
+    /*.execute=*/ExecuteRecursiveTask,
+    /*.destroy=*/DestroyRecursiveTask,
+};
+
+static loomc_task_t* AllocateRecursiveTask(loomc_task_sink_t sink,
+                                           ExecutionGate* child_gate,
+                                           int child_count,
+                                           TaskTracker* tracker) {
+  recursive_task_t* task = new recursive_task_t;
+  loomc_task_initialize(&kRecursiveTaskVtable, &task->base);
+  task->sink = sink;
+  task->child_gate = child_gate;
+  task->tracker = tracker;
+  task->child_count = child_count;
+  return &task->base;
+}
+
+static TaskPoolPtr AllocateTaskPool(loomc_host_size_t max_worker_count) {
+  loomc_task_pool_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS,
+      /*.structure_size=*/sizeof(loomc_task_pool_options_t),
+      /*.next=*/nullptr,
+      /*.max_worker_count=*/max_worker_count,
+      /*.worker_stack_size=*/0,
+  };
+  loomc_task_pool_t* pool = nullptr;
+  IREE_CHECK_OK(iree_status_from_loomc(
+      loomc_task_pool_allocate(&options, loomc_allocator_system(), &pool)));
+  return TaskPoolPtr(pool);
+}
+
+TEST(TaskPoolTest, DefaultUsesFourWorkerLimit) {
+  loomc_task_pool_t* raw_pool = nullptr;
+  LOOMC_ASSERT_OK(loomc_task_pool_allocate(
+      /*options=*/nullptr, loomc_allocator_system(), &raw_pool));
+  TaskPoolPtr pool(raw_pool);
+  EXPECT_GE(loomc_task_pool_worker_count(pool.get()), 1u);
+  EXPECT_LE(loomc_task_pool_worker_count(pool.get()), 4u);
+}
+
+TEST(TaskPoolTest, DrainsAcceptedTasksWithExclusiveWorkerOrdinals) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  const loomc_host_size_t worker_count =
+      loomc_task_pool_worker_count(pool.get());
+  TaskTracker tracker(worker_count);
+  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
+
+  constexpr int kTaskCount = 256;
+  for (int i = 0; i < kTaskCount; ++i) {
+    LOOMC_ASSERT_OK(
+        loomc_task_sink_submit(sink, AllocateTrackedTask(&tracker)));
+  }
+  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
+  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
+
+  EXPECT_EQ(tracker.execution_count(), kTaskCount);
+  EXPECT_EQ(tracker.destruction_count(), kTaskCount);
+  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
+  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
+}
+
+TEST(TaskPoolTest, ConcurrentSubmittersShareOneWorkerPopulation) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  TaskTracker tracker(loomc_task_pool_worker_count(pool.get()));
+  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
+
+  constexpr int kSubmitterCount = 8;
+  constexpr int kTasksPerSubmitter = 128;
+  std::vector<std::thread> submitters;
+  submitters.reserve(kSubmitterCount);
+  for (int i = 0; i < kSubmitterCount; ++i) {
+    submitters.emplace_back([&] {
+      for (int j = 0; j < kTasksPerSubmitter; ++j) {
+        loomc_task_t* task = AllocateTrackedTask(&tracker);
+        loomc_status_t status = loomc_task_sink_submit(sink, task);
+        if (!loomc_status_is_ok(status)) {
+          tracker.RecordSubmissionFailure(status);
+          loomc_task_destroy(task);
+        }
+      }
+    });
+  }
+  for (std::thread& submitter : submitters) submitter.join();
+
+  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
+  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
+  EXPECT_EQ(tracker.submission_status_code(), LOOMC_STATUS_OK);
+  EXPECT_EQ(tracker.execution_count(), kSubmitterCount * kTasksPerSubmitter);
+  EXPECT_EQ(tracker.destruction_count(), kSubmitterCount * kTasksPerSubmitter);
+  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
+  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
+}
+
+TEST(TaskPoolTest, ReusesWorkersAcrossSubmissionWaves) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  const loomc_host_size_t worker_count =
+      loomc_task_pool_worker_count(pool.get());
+  TaskTracker tracker(worker_count);
+  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
+
+  constexpr int kWaveCount = 256;
+  int expected_task_count = 0;
+  for (int wave = 0; wave < kWaveCount; ++wave) {
+    const int wave_task_count = 1 + wave % static_cast<int>(worker_count);
+    for (int i = 0; i < wave_task_count; ++i) {
+      LOOMC_ASSERT_OK(
+          loomc_task_sink_submit(sink, AllocateTrackedTask(&tracker)));
+    }
+    expected_task_count += wave_task_count;
+    tracker.WaitForDestructions(expected_task_count);
+  }
+
+  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
+  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
+  EXPECT_EQ(tracker.execution_count(), expected_task_count);
+  EXPECT_EQ(tracker.destruction_count(), expected_task_count);
+  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
+  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
+}
+
+TEST(TaskPoolTest, RecursiveSubmissionUsesMultipleWorkers) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  const int worker_count =
+      static_cast<int>(loomc_task_pool_worker_count(pool.get()));
+  if (worker_count < 2) GTEST_SKIP() << "host exposes only one worker";
+
+  ExecutionGate child_gate(/*expected_count=*/2);
+  TaskTracker tracker(worker_count);
+  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
+  const int child_count = worker_count * 2;
+  LOOMC_ASSERT_OK(loomc_task_sink_submit(
+      sink, AllocateRecursiveTask(sink, &child_gate, child_count, &tracker)));
+
+  child_gate.WaitUntilEntered();
+  child_gate.Release();
+  tracker.WaitForExecutions(/*expected_count=*/child_count + 1);
+  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
+  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
+
+  EXPECT_EQ(tracker.submission_status_code(), LOOMC_STATUS_OK);
+  EXPECT_EQ(tracker.execution_count(), child_count + 1);
+  EXPECT_EQ(tracker.destruction_count(), child_count + 1);
+  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
+  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
+}
+
+TEST(TaskPoolTest, ShutdownDrainsAcceptedWorkAndRejectsNewWork) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/1);
+  TaskTracker tracker(loomc_task_pool_worker_count(pool.get()));
+  ExecutionGate gate(/*expected_count=*/1);
+  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
+
+  LOOMC_ASSERT_OK(
+      loomc_task_sink_submit(sink, AllocateGatedTask(&gate, &tracker)));
+  gate.WaitUntilEntered();
+  LOOMC_ASSERT_OK(loomc_task_pool_shutdown(pool.get()));
+
+  loomc_task_t* rejected_task = AllocateTrackedTask(&tracker);
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_FAILED_PRECONDITION,
+                         loomc_task_sink_submit(sink, rejected_task));
+  loomc_task_destroy(rejected_task);
+
+  gate.Release();
+  LOOMC_ASSERT_OK(loomc_task_pool_await_shutdown(pool.get()));
+  EXPECT_EQ(tracker.execution_count(), 1);
+  EXPECT_EQ(tracker.destruction_count(), 2);
+}
+
+TEST(TaskPoolTest, FreeDrainsAcceptedWork) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  TaskTracker tracker(loomc_task_pool_worker_count(pool.get()));
+  loomc_task_sink_t sink = loomc_task_pool_sink(pool.get());
+
+  constexpr int kTaskCount = 256;
+  for (int i = 0; i < kTaskCount; ++i) {
+    LOOMC_ASSERT_OK(
+        loomc_task_sink_submit(sink, AllocateTrackedTask(&tracker)));
+  }
+  pool.reset();
+
+  EXPECT_EQ(tracker.execution_count(), kTaskCount);
+  EXPECT_EQ(tracker.destruction_count(), kTaskCount);
+}
+
+TEST(TaskPoolTest, AwaitRequiresShutdown) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/1);
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_FAILED_PRECONDITION,
+                         loomc_task_pool_await_shutdown(pool.get()));
+}
+
+}  // namespace

--- a/loom/binding/c/test/task_queue_test.cc
+++ b/loom/binding/c/test/task_queue_test.cc
@@ -1,0 +1,635 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loomc/task_queue.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "iree/testing/gtest.h"
+#include "loomc/task_pool.h"
+#include "test/util.h"
+
+namespace {
+
+using loomc::testing::HandlePtr;
+using TaskPoolPtr = HandlePtr<loomc_task_pool_t, loomc_task_pool_free>;
+using TaskQueuePtr = HandlePtr<loomc_task_queue_t, loomc_task_queue_free>;
+
+class TaskTracker {
+ public:
+  explicit TaskTracker(loomc_host_size_t worker_count)
+      : active_by_worker_(worker_count, 0) {}
+
+  void BeginExecution(loomc_host_size_t worker_ordinal) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (worker_ordinal >= active_by_worker_.size()) {
+      invalid_worker_ordinal_ = true;
+    } else if (active_by_worker_[worker_ordinal]++ != 0) {
+      concurrent_worker_ordinal_ = true;
+    }
+    ++execution_count_;
+    condition_.notify_all();
+  }
+
+  void EndExecution(loomc_host_size_t worker_ordinal) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (worker_ordinal < active_by_worker_.size()) {
+      --active_by_worker_[worker_ordinal];
+    }
+  }
+
+  void RecordDestruction() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ++destruction_count_;
+    condition_.notify_all();
+  }
+
+  void RecordSubmissionFailure(loomc_status_t status) {
+    const loomc_status_code_t code = loomc_status_consume_code(status);
+    std::lock_guard<std::mutex> lock(mutex_);
+    submission_status_code_ = code;
+    condition_.notify_all();
+  }
+
+  void WaitForExecutions(int expected_count) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait(lock, [&] { return execution_count_ >= expected_count; });
+  }
+
+  void WaitForDestructions(int expected_count) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait(lock, [&] { return destruction_count_ >= expected_count; });
+  }
+
+  int execution_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return execution_count_;
+  }
+
+  int destruction_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return destruction_count_;
+  }
+
+  loomc_status_code_t submission_status_code() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return submission_status_code_;
+  }
+
+  bool has_invalid_worker_ordinal() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return invalid_worker_ordinal_;
+  }
+
+  bool has_concurrent_worker_ordinal() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return concurrent_worker_ordinal_;
+  }
+
+ private:
+  // Serializes all tracked outcome state.
+  mutable std::mutex mutex_;
+
+  // Notifies waiters when task execution or destruction advances.
+  std::condition_variable condition_;
+
+  // Active callback count indexed by dense worker ordinal.
+  std::vector<int> active_by_worker_;
+
+  // Number of task callbacks that began execution.
+  int execution_count_ = 0;
+
+  // Number of task objects destroyed.
+  int destruction_count_ = 0;
+
+  // First observed recursive submission failure.
+  loomc_status_code_t submission_status_code_ = LOOMC_STATUS_OK;
+
+  // Whether a callback observed an out-of-range worker ordinal.
+  bool invalid_worker_ordinal_ = false;
+
+  // Whether two callbacks ran concurrently with one worker ordinal.
+  bool concurrent_worker_ordinal_ = false;
+};
+
+typedef struct tracked_task_t {
+  // Generic task base.
+  loomc_task_t base;
+
+  // External outcome tracker that outlives the task.
+  TaskTracker* tracker;
+} tracked_task_t;
+
+static void ExecuteTrackedTask(loomc_task_t* base_task,
+                               loomc_host_size_t worker_ordinal) {
+  tracked_task_t* task = reinterpret_cast<tracked_task_t*>(base_task);
+  task->tracker->BeginExecution(worker_ordinal);
+  task->tracker->EndExecution(worker_ordinal);
+}
+
+static void DestroyTrackedTask(loomc_task_t* base_task) {
+  tracked_task_t* task = reinterpret_cast<tracked_task_t*>(base_task);
+  task->tracker->RecordDestruction();
+  delete task;
+}
+
+static const loomc_task_vtable_t kTrackedTaskVtable = {
+    /*.execute=*/ExecuteTrackedTask,
+    /*.destroy=*/DestroyTrackedTask,
+};
+
+static loomc_task_t* AllocateTrackedTask(TaskTracker* tracker) {
+  tracked_task_t* task = new tracked_task_t;
+  loomc_task_initialize(&kTrackedTaskVtable, &task->base);
+  task->tracker = tracker;
+  return &task->base;
+}
+
+class ExecutionGate {
+ public:
+  explicit ExecutionGate(int expected_count)
+      : expected_count_(expected_count) {}
+
+  void EnterAndWait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    ++entered_count_;
+    condition_.notify_all();
+    condition_.wait(lock, [&] { return released_; });
+  }
+
+  void WaitUntilEntered() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait(lock, [&] { return entered_count_ >= expected_count_; });
+  }
+
+  void Release() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    released_ = true;
+    condition_.notify_all();
+  }
+
+ private:
+  // Serializes entry and release state.
+  std::mutex mutex_;
+
+  // Notifies waiters when entrants arrive or the gate releases.
+  std::condition_variable condition_;
+
+  // Number of concurrent entrants required before the observer proceeds.
+  int expected_count_ = 0;
+
+  // Number of tasks that have entered the gate.
+  int entered_count_ = 0;
+
+  // Whether every task waiting at the gate may proceed.
+  bool released_ = false;
+};
+
+typedef struct gated_task_t {
+  // Generic task base.
+  loomc_task_t base;
+
+  // External execution gate that outlives the task.
+  ExecutionGate* gate;
+
+  // External outcome tracker that outlives the task.
+  TaskTracker* tracker;
+} gated_task_t;
+
+static void ExecuteGatedTask(loomc_task_t* base_task,
+                             loomc_host_size_t worker_ordinal) {
+  gated_task_t* task = reinterpret_cast<gated_task_t*>(base_task);
+  task->tracker->BeginExecution(worker_ordinal);
+  task->gate->EnterAndWait();
+  task->tracker->EndExecution(worker_ordinal);
+}
+
+static void DestroyGatedTask(loomc_task_t* base_task) {
+  gated_task_t* task = reinterpret_cast<gated_task_t*>(base_task);
+  task->tracker->RecordDestruction();
+  delete task;
+}
+
+static const loomc_task_vtable_t kGatedTaskVtable = {
+    /*.execute=*/ExecuteGatedTask,
+    /*.destroy=*/DestroyGatedTask,
+};
+
+static loomc_task_t* AllocateGatedTask(ExecutionGate* gate,
+                                       TaskTracker* tracker) {
+  gated_task_t* task = new gated_task_t;
+  loomc_task_initialize(&kGatedTaskVtable, &task->base);
+  task->gate = gate;
+  task->tracker = tracker;
+  return &task->base;
+}
+
+typedef struct recursive_task_t {
+  // Generic task base.
+  loomc_task_t base;
+
+  // Borrowed sink used to publish child tasks.
+  loomc_task_sink_t sink;
+
+  // External child execution gate that outlives the task.
+  ExecutionGate* child_gate;
+
+  // External outcome tracker that outlives the task.
+  TaskTracker* tracker;
+
+  // Number of child tasks to publish.
+  int child_count;
+} recursive_task_t;
+
+static void ExecuteRecursiveTask(loomc_task_t* base_task,
+                                 loomc_host_size_t worker_ordinal) {
+  recursive_task_t* task = reinterpret_cast<recursive_task_t*>(base_task);
+  task->tracker->BeginExecution(worker_ordinal);
+  for (int i = 0; i < task->child_count; ++i) {
+    loomc_task_t* child = AllocateGatedTask(task->child_gate, task->tracker);
+    loomc_status_t status = loomc_task_sink_submit(task->sink, child);
+    if (!loomc_status_is_ok(status)) {
+      task->tracker->RecordSubmissionFailure(status);
+      loomc_task_destroy(child);
+    }
+  }
+  task->tracker->EndExecution(worker_ordinal);
+}
+
+static void DestroyRecursiveTask(loomc_task_t* base_task) {
+  recursive_task_t* task = reinterpret_cast<recursive_task_t*>(base_task);
+  task->tracker->RecordDestruction();
+  delete task;
+}
+
+static const loomc_task_vtable_t kRecursiveTaskVtable = {
+    /*.execute=*/ExecuteRecursiveTask,
+    /*.destroy=*/DestroyRecursiveTask,
+};
+
+static loomc_task_t* AllocateRecursiveTask(loomc_task_sink_t sink,
+                                           ExecutionGate* child_gate,
+                                           int child_count,
+                                           TaskTracker* tracker) {
+  recursive_task_t* task = new recursive_task_t;
+  loomc_task_initialize(&kRecursiveTaskVtable, &task->base);
+  task->sink = sink;
+  task->child_gate = child_gate;
+  task->tracker = tracker;
+  task->child_count = child_count;
+  return &task->base;
+}
+
+typedef enum pipeline_task_role_e {
+  PIPELINE_TASK_ROLE_COMPILE = 0,
+  PIPELINE_TASK_ROLE_MATERIALIZE = 1,
+} pipeline_task_role_t;
+
+typedef struct pipeline_tracker_t {
+  // Number of compile tasks that have executed.
+  std::atomic<int> compile_count{0};
+
+  // Compile count observed when the materialization task executed.
+  std::atomic<int> compile_count_at_materialization{0};
+
+  // Status from publishing the materialization task.
+  std::atomic<loomc_status_code_t> publication_status{LOOMC_STATUS_OK};
+} pipeline_tracker_t;
+
+typedef struct pipeline_task_t {
+  // Generic task base.
+  loomc_task_t base;
+
+  // Scheduling role performed by this task.
+  pipeline_task_role_t role;
+
+  // External outcome tracker that outlives the task.
+  pipeline_tracker_t* tracker;
+
+  // Borrowed sink receiving `downstream_task` during execution.
+  loomc_task_sink_t downstream_sink;
+
+  // Owned downstream task awaiting publication, or NULL.
+  loomc_task_t* downstream_task;
+} pipeline_task_t;
+
+static void ExecutePipelineTask(loomc_task_t* base_task,
+                                loomc_host_size_t worker_ordinal) {
+  (void)worker_ordinal;
+  pipeline_task_t* task = reinterpret_cast<pipeline_task_t*>(base_task);
+  switch (task->role) {
+    case PIPELINE_TASK_ROLE_COMPILE:
+      task->tracker->compile_count.fetch_add(1, std::memory_order_release);
+      if (task->downstream_task != nullptr) {
+        loomc_task_t* downstream_task = task->downstream_task;
+        task->downstream_task = nullptr;
+        loomc_status_t status =
+            loomc_task_sink_submit(task->downstream_sink, downstream_task);
+        if (!loomc_status_is_ok(status)) {
+          task->tracker->publication_status.store(
+              loomc_status_consume_code(status), std::memory_order_release);
+          loomc_task_destroy(downstream_task);
+        }
+      }
+      break;
+    case PIPELINE_TASK_ROLE_MATERIALIZE:
+      task->tracker->compile_count_at_materialization.store(
+          task->tracker->compile_count.load(std::memory_order_acquire),
+          std::memory_order_release);
+      break;
+  }
+}
+
+static void DestroyPipelineTask(loomc_task_t* base_task) {
+  pipeline_task_t* task = reinterpret_cast<pipeline_task_t*>(base_task);
+  if (task->downstream_task != nullptr) {
+    loomc_task_destroy(task->downstream_task);
+  }
+  delete task;
+}
+
+static const loomc_task_vtable_t kPipelineTaskVtable = {
+    /*.execute=*/ExecutePipelineTask,
+    /*.destroy=*/DestroyPipelineTask,
+};
+
+static loomc_task_t* AllocatePipelineTask(pipeline_task_role_t role,
+                                          pipeline_tracker_t* tracker) {
+  pipeline_task_t* task = new pipeline_task_t;
+  loomc_task_initialize(&kPipelineTaskVtable, &task->base);
+  task->role = role;
+  task->tracker = tracker;
+  task->downstream_sink = {};
+  task->downstream_task = nullptr;
+  return &task->base;
+}
+
+static TaskPoolPtr AllocateTaskPool(loomc_host_size_t max_worker_count) {
+  loomc_task_pool_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS,
+      /*.structure_size=*/sizeof(loomc_task_pool_options_t),
+      /*.next=*/nullptr,
+      /*.max_worker_count=*/max_worker_count,
+      /*.worker_stack_size=*/0,
+  };
+  loomc_task_pool_t* pool = nullptr;
+  IREE_CHECK_OK(iree_status_from_loomc(
+      loomc_task_pool_allocate(&options, loomc_allocator_system(), &pool)));
+  return TaskPoolPtr(pool);
+}
+
+static TaskQueuePtr AllocateTaskQueue(loomc_task_pool_t* pool) {
+  loomc_task_queue_t* queue = nullptr;
+  IREE_CHECK_OK(iree_status_from_loomc(
+      loomc_task_queue_allocate(pool, loomc_allocator_system(), &queue)));
+  return TaskQueuePtr(queue);
+}
+
+TEST(TaskQueueTest, DrainsAcceptedTasksWithExclusiveWorkerOrdinals) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  TaskQueuePtr queue = AllocateTaskQueue(pool.get());
+  const loomc_host_size_t worker_count =
+      loomc_task_pool_worker_count(pool.get());
+  TaskTracker tracker(worker_count);
+  loomc_task_sink_t sink = loomc_task_queue_sink(queue.get());
+
+  constexpr int kTaskCount = 256;
+  for (int i = 0; i < kTaskCount; ++i) {
+    LOOMC_ASSERT_OK(
+        loomc_task_sink_submit(sink, AllocateTrackedTask(&tracker)));
+  }
+  LOOMC_ASSERT_OK(loomc_task_queue_shutdown(queue.get()));
+  LOOMC_ASSERT_OK(loomc_task_queue_await_shutdown(queue.get()));
+
+  EXPECT_EQ(tracker.execution_count(), kTaskCount);
+  EXPECT_EQ(tracker.destruction_count(), kTaskCount);
+  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
+  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
+}
+
+TEST(TaskQueueTest, ConcurrentSubmittersShareOneQueue) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  TaskQueuePtr queue = AllocateTaskQueue(pool.get());
+  TaskTracker tracker(loomc_task_pool_worker_count(pool.get()));
+  loomc_task_sink_t sink = loomc_task_queue_sink(queue.get());
+
+  constexpr int kSubmitterCount = 8;
+  constexpr int kTasksPerSubmitter = 128;
+  std::vector<std::thread> submitters;
+  submitters.reserve(kSubmitterCount);
+  for (int i = 0; i < kSubmitterCount; ++i) {
+    submitters.emplace_back([&] {
+      for (int j = 0; j < kTasksPerSubmitter; ++j) {
+        loomc_task_t* task = AllocateTrackedTask(&tracker);
+        loomc_status_t status = loomc_task_sink_submit(sink, task);
+        if (!loomc_status_is_ok(status)) {
+          tracker.RecordSubmissionFailure(status);
+          loomc_task_destroy(task);
+        }
+      }
+    });
+  }
+  for (std::thread& submitter : submitters) submitter.join();
+
+  LOOMC_ASSERT_OK(loomc_task_queue_shutdown(queue.get()));
+  LOOMC_ASSERT_OK(loomc_task_queue_await_shutdown(queue.get()));
+  EXPECT_EQ(tracker.submission_status_code(), LOOMC_STATUS_OK);
+  EXPECT_EQ(tracker.execution_count(), kSubmitterCount * kTasksPerSubmitter);
+  EXPECT_EQ(tracker.destruction_count(), kSubmitterCount * kTasksPerSubmitter);
+  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
+  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
+}
+
+TEST(TaskQueueTest, ReusesWorkersAcrossSubmissionWaves) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  TaskQueuePtr queue = AllocateTaskQueue(pool.get());
+  const loomc_host_size_t worker_count =
+      loomc_task_pool_worker_count(pool.get());
+  TaskTracker tracker(worker_count);
+  loomc_task_sink_t sink = loomc_task_queue_sink(queue.get());
+
+  constexpr int kWaveCount = 256;
+  int expected_task_count = 0;
+  for (int wave = 0; wave < kWaveCount; ++wave) {
+    const int wave_task_count = 1 + wave % static_cast<int>(worker_count);
+    for (int i = 0; i < wave_task_count; ++i) {
+      LOOMC_ASSERT_OK(
+          loomc_task_sink_submit(sink, AllocateTrackedTask(&tracker)));
+    }
+    expected_task_count += wave_task_count;
+    tracker.WaitForDestructions(expected_task_count);
+  }
+
+  LOOMC_ASSERT_OK(loomc_task_queue_shutdown(queue.get()));
+  LOOMC_ASSERT_OK(loomc_task_queue_await_shutdown(queue.get()));
+  EXPECT_EQ(tracker.execution_count(), expected_task_count);
+  EXPECT_EQ(tracker.destruction_count(), expected_task_count);
+  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
+  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
+}
+
+TEST(TaskQueueTest, RecursiveSubmissionUsesMultipleWorkers) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  TaskQueuePtr queue = AllocateTaskQueue(pool.get());
+  const int worker_count =
+      static_cast<int>(loomc_task_pool_worker_count(pool.get()));
+  if (worker_count < 2) GTEST_SKIP() << "host exposes only one worker";
+
+  ExecutionGate child_gate(/*expected_count=*/2);
+  TaskTracker tracker(worker_count);
+  loomc_task_sink_t sink = loomc_task_queue_sink(queue.get());
+  const int child_count = worker_count * 2;
+  LOOMC_ASSERT_OK(loomc_task_sink_submit(
+      sink, AllocateRecursiveTask(sink, &child_gate, child_count, &tracker)));
+
+  child_gate.WaitUntilEntered();
+  child_gate.Release();
+  tracker.WaitForExecutions(/*expected_count=*/child_count + 1);
+  LOOMC_ASSERT_OK(loomc_task_queue_shutdown(queue.get()));
+  LOOMC_ASSERT_OK(loomc_task_queue_await_shutdown(queue.get()));
+
+  EXPECT_EQ(tracker.submission_status_code(), LOOMC_STATUS_OK);
+  EXPECT_EQ(tracker.execution_count(), child_count + 1);
+  EXPECT_EQ(tracker.destruction_count(), child_count + 1);
+  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
+  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
+}
+
+TEST(TaskQueueTest, ShutdownDrainsAcceptedWorkAndRejectsNewWork) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/1);
+  TaskQueuePtr queue = AllocateTaskQueue(pool.get());
+  TaskTracker tracker(loomc_task_pool_worker_count(pool.get()));
+  ExecutionGate gate(/*expected_count=*/1);
+  loomc_task_sink_t sink = loomc_task_queue_sink(queue.get());
+
+  LOOMC_ASSERT_OK(
+      loomc_task_sink_submit(sink, AllocateGatedTask(&gate, &tracker)));
+  gate.WaitUntilEntered();
+  LOOMC_ASSERT_OK(loomc_task_queue_shutdown(queue.get()));
+
+  loomc_task_t* rejected_task = AllocateTrackedTask(&tracker);
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_FAILED_PRECONDITION,
+                         loomc_task_sink_submit(sink, rejected_task));
+  loomc_task_destroy(rejected_task);
+
+  gate.Release();
+  LOOMC_ASSERT_OK(loomc_task_queue_await_shutdown(queue.get()));
+  EXPECT_EQ(tracker.execution_count(), 1);
+  EXPECT_EQ(tracker.destruction_count(), 2);
+}
+
+TEST(TaskQueueTest, FreeDrainsAcceptedWork) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  TaskQueuePtr queue = AllocateTaskQueue(pool.get());
+  TaskTracker tracker(loomc_task_pool_worker_count(pool.get()));
+  loomc_task_sink_t sink = loomc_task_queue_sink(queue.get());
+
+  constexpr int kTaskCount = 256;
+  for (int i = 0; i < kTaskCount; ++i) {
+    LOOMC_ASSERT_OK(
+        loomc_task_sink_submit(sink, AllocateTrackedTask(&tracker)));
+  }
+  queue.reset();
+
+  EXPECT_EQ(tracker.execution_count(), kTaskCount);
+  EXPECT_EQ(tracker.destruction_count(), kTaskCount);
+}
+
+TEST(TaskQueueTest, AwaitRequiresShutdown) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/1);
+  TaskQueuePtr queue = AllocateTaskQueue(pool.get());
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_FAILED_PRECONDITION,
+                         loomc_task_queue_await_shutdown(queue.get()));
+}
+
+TEST(TaskQueueTest, QueuesRetainAndIndependentlyUseSharedWorkers) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/4);
+  const loomc_host_size_t worker_count =
+      loomc_task_pool_worker_count(pool.get());
+  TaskQueuePtr compile_queue = AllocateTaskQueue(pool.get());
+  TaskQueuePtr materialize_queue = AllocateTaskQueue(pool.get());
+  TaskTracker tracker(worker_count);
+  loomc_task_sink_t compile_sink = loomc_task_queue_sink(compile_queue.get());
+  loomc_task_sink_t materialize_sink =
+      loomc_task_queue_sink(materialize_queue.get());
+
+  // Queue ownership keeps the shared executor alive independently from the
+  // convenience pool handle.
+  pool.reset();
+
+  constexpr int kTaskCountPerQueue = 256;
+  for (int i = 0; i < kTaskCountPerQueue; ++i) {
+    LOOMC_ASSERT_OK(
+        loomc_task_sink_submit(compile_sink, AllocateTrackedTask(&tracker)));
+    LOOMC_ASSERT_OK(loomc_task_sink_submit(materialize_sink,
+                                           AllocateTrackedTask(&tracker)));
+  }
+
+  LOOMC_ASSERT_OK(loomc_task_queue_shutdown(compile_queue.get()));
+  LOOMC_ASSERT_OK(loomc_task_queue_await_shutdown(compile_queue.get()));
+
+  // Shutting one scheduling domain down does not stop another domain sharing
+  // the same workers.
+  LOOMC_ASSERT_OK(
+      loomc_task_sink_submit(materialize_sink, AllocateTrackedTask(&tracker)));
+  LOOMC_ASSERT_OK(loomc_task_queue_shutdown(materialize_queue.get()));
+  LOOMC_ASSERT_OK(loomc_task_queue_await_shutdown(materialize_queue.get()));
+
+  EXPECT_EQ(tracker.execution_count(), kTaskCountPerQueue * 2 + 1);
+  EXPECT_EQ(tracker.destruction_count(), kTaskCountPerQueue * 2 + 1);
+  EXPECT_FALSE(tracker.has_invalid_worker_ordinal());
+  EXPECT_FALSE(tracker.has_concurrent_worker_ordinal());
+}
+
+TEST(TaskQueueTest, PipelinesDependentWorkAcrossIndependentQueues) {
+  TaskPoolPtr pool = AllocateTaskPool(/*max_worker_count=*/1);
+  TaskQueuePtr compile_queue = AllocateTaskQueue(pool.get());
+  TaskQueuePtr materialize_queue = AllocateTaskQueue(pool.get());
+  const loomc_task_sink_t compile_sink =
+      loomc_task_queue_sink(compile_queue.get());
+  const loomc_task_sink_t materialize_sink =
+      loomc_task_queue_sink(materialize_queue.get());
+  pipeline_tracker_t tracker;
+
+  loomc_task_t* materialize_task =
+      AllocatePipelineTask(PIPELINE_TASK_ROLE_MATERIALIZE, &tracker);
+  loomc_task_t* first_compile_task =
+      AllocatePipelineTask(PIPELINE_TASK_ROLE_COMPILE, &tracker);
+  pipeline_task_t* first_compile =
+      reinterpret_cast<pipeline_task_t*>(first_compile_task);
+  first_compile->downstream_sink = materialize_sink;
+  first_compile->downstream_task = materialize_task;
+  LOOMC_ASSERT_OK(loomc_task_sink_submit(compile_sink, first_compile_task));
+
+  constexpr int kCompileTaskCount = 256;
+  for (int i = 1; i < kCompileTaskCount; ++i) {
+    LOOMC_ASSERT_OK(loomc_task_sink_submit(
+        compile_sink,
+        AllocatePipelineTask(PIPELINE_TASK_ROLE_COMPILE, &tracker)));
+  }
+
+  LOOMC_ASSERT_OK(loomc_task_queue_shutdown(compile_queue.get()));
+  LOOMC_ASSERT_OK(loomc_task_queue_await_shutdown(compile_queue.get()));
+  LOOMC_ASSERT_OK(loomc_task_queue_shutdown(materialize_queue.get()));
+  LOOMC_ASSERT_OK(loomc_task_queue_await_shutdown(materialize_queue.get()));
+
+  EXPECT_EQ(tracker.publication_status.load(std::memory_order_acquire),
+            LOOMC_STATUS_OK);
+  EXPECT_EQ(tracker.compile_count.load(std::memory_order_acquire),
+            kCompileTaskCount);
+  EXPECT_GT(
+      tracker.compile_count_at_materialization.load(std::memory_order_acquire),
+      0);
+  EXPECT_LT(
+      tracker.compile_count_at_materialization.load(std::memory_order_acquire),
+      kCompileTaskCount);
+}
+
+}  // namespace

--- a/loom/binding/c/test/task_test.cc
+++ b/loom/binding/c/test/task_test.cc
@@ -1,0 +1,192 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loomc/task.h"
+
+#include "iree/testing/gtest.h"
+#include "test/util.h"
+
+namespace {
+
+typedef struct test_task_t {
+  // Generic task base.
+  loomc_task_t base;
+
+  // External execution count that outlives this task.
+  int* execution_count;
+
+  // External destruction count that outlives this task.
+  int* destruction_count;
+
+  // External worker ordinal record that outlives this task.
+  loomc_host_size_t* worker_ordinal;
+} test_task_t;
+
+static void ExecuteTestTask(loomc_task_t* base_task,
+                            loomc_host_size_t worker_ordinal) {
+  test_task_t* task = reinterpret_cast<test_task_t*>(base_task);
+  ++*task->execution_count;
+  *task->worker_ordinal = worker_ordinal;
+}
+
+static void DestroyTestTask(loomc_task_t* base_task) {
+  test_task_t* task = reinterpret_cast<test_task_t*>(base_task);
+  ++*task->destruction_count;
+  delete task;
+}
+
+static const loomc_task_vtable_t kTestTaskVtable = {
+    /*.execute=*/ExecuteTestTask,
+    /*.destroy=*/DestroyTestTask,
+};
+
+static loomc_task_t* AllocateTestTask(int* execution_count,
+                                      int* destruction_count,
+                                      loomc_host_size_t* worker_ordinal) {
+  test_task_t* task = new test_task_t;
+  loomc_task_initialize(&kTestTaskVtable, &task->base);
+  task->execution_count = execution_count;
+  task->destruction_count = destruction_count;
+  task->worker_ordinal = worker_ordinal;
+  return &task->base;
+}
+
+typedef struct test_sink_t {
+  // Whether submissions are accepted.
+  bool accepts_tasks;
+
+  // Whether accepted tasks execute before submission returns.
+  bool executes_inline;
+
+  // Worker ordinal supplied to executed tasks.
+  loomc_host_size_t worker_ordinal;
+
+  // Accepted task waiting for explicit execution.
+  loomc_task_t* pending_task;
+} test_sink_t;
+
+static loomc_status_t SubmitTestTask(void* user_data, loomc_task_t* task) {
+  test_sink_t* sink = static_cast<test_sink_t*>(user_data);
+  if (!sink->accepts_tasks) {
+    return loomc_make_status(LOOMC_STATUS_UNAVAILABLE, "queue stopped");
+  }
+  if (sink->executes_inline) {
+    loomc_task_execute(task, sink->worker_ordinal);
+  } else {
+    sink->pending_task = task;
+  }
+  return loomc_ok_status();
+}
+
+static loomc_task_sink_t TestTaskSink(test_sink_t* sink) {
+  return (loomc_task_sink_t){
+      /*.submit=*/SubmitTestTask,
+      /*.user_data=*/sink,
+  };
+}
+
+TEST(TaskTest, AcceptedSubmissionTransfersExecutionAndDestruction) {
+  int execution_count = 0;
+  int destruction_count = 0;
+  loomc_host_size_t worker_ordinal = 0;
+  test_sink_t sink = {
+      /*.accepts_tasks=*/true,
+      /*.executes_inline=*/false,
+      /*.worker_ordinal=*/7,
+      /*.pending_task=*/nullptr,
+  };
+  loomc_task_t* task =
+      AllocateTestTask(&execution_count, &destruction_count, &worker_ordinal);
+
+  LOOMC_ASSERT_OK(loomc_task_sink_submit(TestTaskSink(&sink), task));
+  EXPECT_EQ(execution_count, 0);
+  EXPECT_EQ(destruction_count, 0);
+  ASSERT_NE(sink.pending_task, nullptr);
+
+  loomc_task_execute(sink.pending_task, sink.worker_ordinal);
+  sink.pending_task = nullptr;
+  EXPECT_EQ(execution_count, 1);
+  EXPECT_EQ(destruction_count, 1);
+  EXPECT_EQ(worker_ordinal, 7u);
+}
+
+TEST(TaskTest, RejectedSubmissionLeavesOwnershipWithCaller) {
+  int execution_count = 0;
+  int destruction_count = 0;
+  loomc_host_size_t worker_ordinal = 0;
+  test_sink_t sink = {
+      /*.accepts_tasks=*/false,
+      /*.executes_inline=*/false,
+      /*.worker_ordinal=*/0,
+      /*.pending_task=*/nullptr,
+  };
+  loomc_task_t* task =
+      AllocateTestTask(&execution_count, &destruction_count, &worker_ordinal);
+
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_UNAVAILABLE,
+                         loomc_task_sink_submit(TestTaskSink(&sink), task));
+  EXPECT_EQ(execution_count, 0);
+  EXPECT_EQ(destruction_count, 0);
+  EXPECT_EQ(sink.pending_task, nullptr);
+
+  loomc_task_destroy(task);
+  EXPECT_EQ(execution_count, 0);
+  EXPECT_EQ(destruction_count, 1);
+}
+
+TEST(TaskTest, InlineSubmissionMayDestroyTaskBeforeReturning) {
+  int execution_count = 0;
+  int destruction_count = 0;
+  loomc_host_size_t worker_ordinal = 0;
+  test_sink_t sink = {
+      /*.accepts_tasks=*/true,
+      /*.executes_inline=*/true,
+      /*.worker_ordinal=*/3,
+      /*.pending_task=*/nullptr,
+  };
+
+  LOOMC_ASSERT_OK(loomc_task_sink_submit(
+      TestTaskSink(&sink),
+      AllocateTestTask(&execution_count, &destruction_count, &worker_ordinal)));
+  EXPECT_EQ(execution_count, 1);
+  EXPECT_EQ(destruction_count, 1);
+  EXPECT_EQ(worker_ordinal, 3u);
+  EXPECT_EQ(sink.pending_task, nullptr);
+}
+
+TEST(TaskTest, InvalidProtocolIsRejectedBeforeEnteringSink) {
+  int execution_count = 0;
+  int destruction_count = 0;
+  loomc_host_size_t worker_ordinal = 0;
+  test_sink_t sink = {
+      /*.accepts_tasks=*/true,
+      /*.executes_inline=*/false,
+      /*.worker_ordinal=*/0,
+      /*.pending_task=*/nullptr,
+  };
+  loomc_task_t invalid_task = {};
+
+  LOOMC_EXPECT_STATUS_IS(
+      LOOMC_STATUS_INVALID_ARGUMENT,
+      loomc_task_sink_submit(TestTaskSink(&sink), &invalid_task));
+  EXPECT_EQ(sink.pending_task, nullptr);
+  loomc_task_t* rejected_task =
+      AllocateTestTask(&execution_count, &destruction_count, &worker_ordinal);
+  LOOMC_EXPECT_STATUS_IS(
+      LOOMC_STATUS_INVALID_ARGUMENT,
+      loomc_task_sink_submit((loomc_task_sink_t){0}, rejected_task));
+  rejected_task->next = rejected_task;
+  LOOMC_EXPECT_STATUS_IS(
+      LOOMC_STATUS_INVALID_ARGUMENT,
+      loomc_task_sink_submit(TestTaskSink(&sink), rejected_task));
+  rejected_task->next = nullptr;
+  EXPECT_EQ(execution_count, 0);
+  EXPECT_EQ(destruction_count, 0);
+  loomc_task_destroy(rejected_task);
+  EXPECT_EQ(destruction_count, 1);
+}
+
+}  // namespace

--- a/loom/docs/examples/integration/jit-task-pool/.doc-generate.sh
+++ b/loom/docs/examples/integration/jit-task-pool/.doc-generate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Runs the public JIT task-pool example and stages its source and checked output
+# for MkDocs.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
+if [[ "$#" -gt 1 ]]; then
+  printf 'usage: %s [output-directory]\n' "$0" >&2
+  exit 64
+fi
+
+if [[ -n "${RUNFILES_DIR:-}" ]]; then
+  workspace="${TEST_WORKSPACE:-_main}"
+  repo_root="${RUNFILES_DIR}/${workspace}"
+  jit_task_pool="${repo_root}/loom/binding/c/example/jit_task_pool"
+else
+  repo_root="$(cd -- "${script_dir}/../../../../.." && pwd -P)"
+  "${repo_root}/build_tools/bin/iree-bazel-build" \
+    --config=asan \
+    //loom/binding/c/example:jit_task_pool
+  jit_task_pool="${repo_root}/bazel-bin/loom/binding/c/example/jit_task_pool"
+fi
+
+source_file="${repo_root}/loom/binding/c/example/jit_task_pool.c"
+for required_path in "${jit_task_pool}" "${source_file}"; do
+  if [[ ! -e "${required_path}" ]]; then
+    printf 'required JIT task-pool input not found: %s\n' "${required_path}" >&2
+    exit 127
+  fi
+done
+
+output_dir="${1:-${TEST_UNDECLARED_OUTPUTS_DIR:-${repo_root}/build/loom-docs/examples/integration/jit-task-pool}}"
+mkdir -p -- "${output_dir}"
+output_dir="$(cd -- "${output_dir}" && pwd -P)"
+
+summary_output="${output_dir}/summary.txt"
+"${jit_task_pool}" >"${summary_output}"
+expected_summary='compiled=8'
+actual_summary="$(<"${summary_output}")"
+if [[ "${actual_summary}" != "${expected_summary}" ]]; then
+  printf 'unexpected JIT task-pool summary:\n%s\n' "${actual_summary}" >&2
+  exit 1
+fi
+
+cp -- "${source_file}" "${output_dir}/jit_task_pool.c"
+
+printf 'Generated documentation snippets:\n'
+printf '  %s\n' \
+  "${output_dir}/jit_task_pool.c" \
+  "${output_dir}/summary.txt"

--- a/loom/docs/mkdocs.yml
+++ b/loom/docs/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - Integration map: integration/index.md
       - Compose modules in memory: integration/module-composition.md
       - Embed product frontiers: integration/product-frontier.md
+      - Schedule concurrent JIT work: integration/jit-task-pool.md
       - Embed kernel JIT compilation: integration/jit-kernel.md
   - Reference:
       - Reference map: reference/index.md

--- a/loom/docs/src/integration/index.md
+++ b/loom/docs/src/integration/index.md
@@ -45,8 +45,9 @@ created them only after the application loads or copies them.
   portable command product publishes independently compilable kernel requests
   while preserving external executable requirements.
 - [Schedule concurrent JIT work](jit-task-pool.md) shows how generic tasks,
-  cache-before-submit policy, worker-local workspaces, and an optional standard
-  pool compose without making scheduling part of the compiler API.
+  cache-before-submit policy, worker-local workspaces, and independent queues
+  on one optional shared pool compose without making scheduling part of the
+  compiler API.
 - [Embed kernel JIT compilation](jit-kernel.md) follows source through target
   specialization, launch evaluation, native artifact emission, and the runtime
   handoff using the public `loomc` API.

--- a/loom/docs/src/integration/index.md
+++ b/loom/docs/src/integration/index.md
@@ -44,6 +44,9 @@ created them only after the application loads or copies them.
 - [Embed command and kernel product frontiers](product-frontier.md) shows how a
   portable command product publishes independently compilable kernel requests
   while preserving external executable requirements.
+- [Schedule concurrent JIT work](jit-task-pool.md) shows how generic tasks,
+  cache-before-submit policy, worker-local workspaces, and an optional standard
+  pool compose without making scheduling part of the compiler API.
 - [Embed kernel JIT compilation](jit-kernel.md) follows source through target
   specialization, launch evaluation, native artifact emission, and the runtime
   handoff using the public `loomc` API.

--- a/loom/docs/src/integration/jit-task-pool.md
+++ b/loom/docs/src/integration/jit-task-pool.md
@@ -4,9 +4,11 @@
 
 LoomC separates a queueable unit of work from the scheduler that executes it.
 An embedding can submit the same `loomc_task_t` records to its own event loop,
-deterministic executor, or the optional standard `loomc_task_pool_t`. The core
-compiler API does not link the task runtime, and the standard pool does not own
-compiler policy, caches, workspaces, requests, products, or completion state.
+deterministic executor, or an optional standard `loomc_task_queue_t`. The core
+compiler API does not link the task runtime. The standard implementation splits
+its shared worker population (`loomc_task_pool_t`) from each independent
+task domain (`loomc_task_queue_t`), and neither object owns compiler policy,
+caches, workspaces, requests, products, or completion state.
 
 This separation keeps cache hits on the shortest path. A host first derives the
 identity of the requested product and checks its process-local cache. Only a
@@ -24,6 +26,35 @@ borrows its prepared configuration module for the compile invocation. The
 example is intentionally target-independent; a native JIT uses the same task
 shape with its prepared target pipeline and emitter.
 
+## Pipeline independent work domains
+
+One process-wide pool can drive compiler queues, HAL materializers, and
+application processes without forcing their work through one FIFO:
+
+```text
+                             +-> compile queue --------+
+request -> cache miss -------+                         +-> publish product
+                             +-> command queue --------+
+                                                       |
+shared worker pool <------ HAL executable loader <-----+
+                   <------ command-buffer recorder <---+
+                   <------ application processes
+```
+
+A queue owns readiness and scheduling only within its domain; callbacks from
+one queue may execute concurrently and complete in any order. A compile
+callback that publishes an executable-load task therefore makes that task
+immediately eligible on the shared workers instead of placing it behind the
+remaining compilation roots. The worker population remains bounded while
+compilation, executable loading, and command-buffer recording pipeline
+naturally.
+
+Applications using the IREE task runtime include `loomc/iree/task_pool.h` to
+allocate a pool from an existing `iree_task_executor_t` or borrow the executor
+created by a LoomC pool. HAL integrations attach their own cooperative
+processes to that executor and do not depend on LoomC task queues. Applications
+using another scheduler continue to implement `loomc_task_sink_t` directly.
+
 ## Split process, worker, and request state
 
 The scheduler exposes a dense, mutually exclusive worker ordinal on every task
@@ -32,12 +63,13 @@ workspace lease, hash lookup, or lock:
 
 | Lifetime | Example state |
 | --- | --- |
-| Process | Context, source catalog, frozen link indexes, compiler, pass programs, cache, and task pool. |
+| Process | Context, source catalog, frozen link indexes, compiler, pass programs, cache, shared task pool, and independent queues. |
 | Worker | One `loomc_workspace_t` and any target-specific scratch indexed by worker ordinal. |
 | Request | Immutable request/configuration, task record, terminal result, and application completion state. |
 
 The example prepares the shared compiler state, requests a four-worker pool,
-and allocates exactly one workspace per actual worker:
+attaches one compilation queue, and allocates exactly one workspace per actual
+worker:
 
 ```c
 --8<-- "generated/examples/integration/jit-task-pool/jit_task_pool.c:configure"
@@ -78,24 +110,28 @@ poisoning unrelated tasks or turning the scheduler into a second compiler API.
 
 ## Compose completion separately from scheduling
 
-The compact example submits one finite batch and uses pool shutdown as its
+The compact example submits one finite batch and uses queue shutdown as its
 join:
 
 ```c
 --8<-- "generated/examples/integration/jit-task-pool/jit_task_pool.c:submit"
 ```
 
-A long-lived compiler service instead allocates one pool for the service
-lifetime and uses its own request completion objects, callbacks, futures, or
-event-loop messages. The pool intentionally has no global idle wait: another
-producer may publish work at any time, and observing a transiently empty queue
-does not mean an application request is complete. The request owner knows its
-actual frontier and terminalizes it when every required product has resolved.
+A long-lived compiler service instead allocates one pool and its attached queues
+for the service lifetime, then uses request completion objects, callbacks,
+futures, or event-loop messages. Neither a queue nor the pool exposes a global
+idle wait: another producer may publish work at any time, and observing a
+transiently empty domain does not mean an application request is complete. The
+request owner knows its actual frontier and terminalizes it when every required
+product has resolved.
 
-Shutdown is drain-only. It stops accepting work, executes every accepted task,
-and releases the worker population. Work that recursively publishes child tasks
-therefore completes its application frontier before service teardown begins;
-publication attempted after shutdown is correctly rejected.
+Queue shutdown is drain-only. It stops that domain from accepting work, executes
+every accepted task, and releases its cooperative process without affecting
+other domains attached to the pool. Work that recursively publishes child tasks
+therefore completes its application frontier before its queue begins teardown;
+publication attempted after shutdown is correctly rejected. Attached queues
+retain the shared executor, so they may outlive the convenience pool handle and
+the final owner joins the worker threads.
 
 ## Run the checked example
 
@@ -111,6 +147,7 @@ bytecode artifact:
 ```
 
 Applications that already own a scheduler include `loomc/task.h` and implement
-`loomc_task_sink_t::submit`. Applications wanting the standard pool additionally
-link `//loom/binding/c:task_pool` and include `loomc/task_pool.h`. Both paths use
-the same concrete task records and preserve the same ownership contract.
+`loomc_task_sink_t::submit`. Applications wanting the standard implementation
+link `//loom/binding/c:task_pool` and `//loom/binding/c:task_queue`, then include
+`loomc/task_pool.h` and `loomc/task_queue.h`. Both paths use the same concrete
+task records and preserve the same ownership contract.

--- a/loom/docs/src/integration/jit-task-pool.md
+++ b/loom/docs/src/integration/jit-task-pool.md
@@ -1,0 +1,116 @@
+# Schedule concurrent JIT work
+
+**Example source:** [`loom/binding/c/example/jit_task_pool.c`](https://github.com/ROCm/hrx-system/blob/main/loom/binding/c/example/jit_task_pool.c)
+
+LoomC separates a queueable unit of work from the scheduler that executes it.
+An embedding can submit the same `loomc_task_t` records to its own event loop,
+deterministic executor, or the optional standard `loomc_task_pool_t`. The core
+compiler API does not link the task runtime, and the standard pool does not own
+compiler policy, caches, workspaces, requests, products, or completion state.
+
+This separation keeps cache hits on the shortest path. A host first derives the
+identity of the requested product and checks its process-local cache. Only a
+miss allocates a task and crosses a scheduler boundary:
+
+```text
+request -> classify -> cache lookup -> hit  -> reuse product
+                                    -> miss -> submit task -> compile -> publish
+```
+
+The checked example loads eight immutable typed configuration modules, then
+compiles eight independently configured program modules through the public
+LoomC API. Configuration parsing stays outside the worker callback; each task
+borrows its prepared configuration module for the compile invocation. The
+example is intentionally target-independent; a native JIT uses the same task
+shape with its prepared target pipeline and emitter.
+
+## Split process, worker, and request state
+
+The scheduler exposes a dense, mutually exclusive worker ordinal on every task
+callback. That ordinal indexes caller-owned mutable scratch directly, without a
+workspace lease, hash lookup, or lock:
+
+| Lifetime | Example state |
+| --- | --- |
+| Process | Context, source catalog, frozen link indexes, compiler, pass programs, cache, and task pool. |
+| Worker | One `loomc_workspace_t` and any target-specific scratch indexed by worker ordinal. |
+| Request | Immutable request/configuration, task record, terminal result, and application completion state. |
+
+The example prepares the shared compiler state, requests a four-worker pool,
+and allocates exactly one workspace per actual worker:
+
+```c
+--8<-- "generated/examples/integration/jit-task-pool/jit_task_pool.c:configure"
+```
+
+Four workers are the default and suit common latency-oriented JIT workloads.
+Eight is another normal application choice when independent compilations have
+enough work to amortize scheduling. Search and autotuning services can request
+wider pools when many parameter variants produce independent reports. The
+actual worker count may be lower when the process affinity or container CPU set
+exposes fewer physical cores.
+
+## Keep the task record application-owned
+
+A concrete task embeds `loomc_task_t` at offset zero and carries only the state
+needed to terminalize that operation:
+
+```c
+--8<-- "generated/examples/integration/jit-task-pool/jit_task_pool.c:task-record"
+```
+
+Successful submission transfers the task reference to the sink. The sink runs
+the callback exactly once and then invokes its destructor exactly once. A
+rejected submission leaves ownership with the caller, which may retry another
+sink or destroy the task immediately.
+
+The callback selects worker-local scratch by ordinal and otherwise uses shared
+immutable compiler state:
+
+```c
+--8<-- "generated/examples/integration/jit-task-pool/jit_task_pool.c:execute"
+```
+
+Task execution has no scheduler-facing status return. The concrete task writes
+its compiler result or infrastructure status into caller-owned completion state
+before returning. This prevents an application compilation failure from
+poisoning unrelated tasks or turning the scheduler into a second compiler API.
+
+## Compose completion separately from scheduling
+
+The compact example submits one finite batch and uses pool shutdown as its
+join:
+
+```c
+--8<-- "generated/examples/integration/jit-task-pool/jit_task_pool.c:submit"
+```
+
+A long-lived compiler service instead allocates one pool for the service
+lifetime and uses its own request completion objects, callbacks, futures, or
+event-loop messages. The pool intentionally has no global idle wait: another
+producer may publish work at any time, and observing a transiently empty queue
+does not mean an application request is complete. The request owner knows its
+actual frontier and terminalizes it when every required product has resolved.
+
+Shutdown is drain-only. It stops accepting work, executes every accepted task,
+and releases the worker population. Work that recursively publishes child tasks
+therefore completes its application frontier before service teardown begins;
+publication attempted after shutdown is correctly rejected.
+
+## Run the checked example
+
+```shell
+python dev.py bazel run //loom/binding/c/example:jit_task_pool
+```
+
+The output confirms that every scheduled variant produced its requested
+bytecode artifact:
+
+```text
+--8<-- "generated/examples/integration/jit-task-pool/summary.txt"
+```
+
+Applications that already own a scheduler include `loomc/task.h` and implement
+`loomc_task_sink_t::submit`. Applications wanting the standard pool additionally
+link `//loom/binding/c:task_pool` and include `loomc/task_pool.h`. Both paths use
+the same concrete task records and preserve the same ownership contract.

--- a/loom/docs/src/integration/product-frontier.md
+++ b/loom/docs/src/integration/product-frontier.md
@@ -118,4 +118,6 @@ single-threaded application can run the example literally. A concurrent host
 retains each request, checks its cache before leasing a workspace, and schedules
 only misses. Product artifacts are immutable byte sequences, so successful
 results can pass directly to executable loaders or packaging code without a
-filesystem round trip.
+filesystem round trip. [Schedule concurrent JIT work](jit-task-pool.md) shows
+that composition with caller-owned completion and the optional standard task
+pool.

--- a/loom/src/loom/link/plan_materializer.h
+++ b/loom/src/loom/link/plan_materializer.h
@@ -31,14 +31,16 @@ typedef struct loom_link_plan_materialization_t {
     iree_host_size_t count;
   } target_symbols;
   // Dense concrete source-definition ordinals indexed by target module symbol
-  // ID. A target assembled from a declaration and definition names the
-  // definition selected by the plan. Declarations without an indexed provider
-  // and synthetic symbols contain LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL.
-  // Storage belongs to the caller's arena.
+  // ID at the end of linking. A target assembled from a declaration and
+  // definition names the definition selected by the plan. Declarations
+  // without an indexed provider and synthetic symbols contain
+  // LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL. Caller-owned preparation may
+  // append symbols while preserving this stable linked prefix. Storage belongs
+  // to the caller's arena.
   struct {
     // Arena-owned target-to-source definition projection.
     iree_host_size_t* values;
-    // Number of target module symbol slots.
+    // Number of target module symbol slots present before caller preparation.
     iree_host_size_t count;
   } target_source_definitions;
   // Dense target refs indexed by template-family ordinal. Each demanded family
@@ -50,15 +52,16 @@ typedef struct loom_link_plan_materialization_t {
     // Number of index-wide template-family slots.
     iree_host_size_t count;
   } target_template_families;
-  // Dense configuration-function refs indexed by target module symbol ID.
-  // Only partially projected logical kernels contain valid refs. This direct
-  // target-domain projection lets downstream consumers resolve a linked
-  // kernel callee without rebuilding an inverse source-symbol map. Storage
-  // belongs to the caller's arena.
+  // Dense configuration-function refs indexed by target module symbol ID at
+  // the end of linking. Only partially projected logical kernels contain valid
+  // refs. Caller-owned preparation may append symbols while preserving this
+  // stable linked prefix. This direct target-domain projection lets downstream
+  // consumers resolve a linked kernel callee without rebuilding an inverse
+  // source-symbol map. Storage belongs to the caller's arena.
   struct {
     // Arena-owned target-kernel-to-configuration-function projection.
     loom_symbol_ref_t* values;
-    // Number of target module symbol slots.
+    // Number of target module symbol slots present before caller preparation.
     iree_host_size_t count;
   } target_kernel_configurations;
 } loom_link_plan_materialization_t;

--- a/loom/src/loom/target/arch/cmd/lower/program_plan.c
+++ b/loom/src/loom/target/arch/cmd/lower/program_plan.c
@@ -703,9 +703,10 @@ iree_status_t loom_cmd_program_plan_prepare_materialization(
       for (iree_host_size_t i = 0; i < preparation_module->symbols.count; ++i) {
         prepared_source_definitions[i] = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
       }
-      IREE_ASSERT_EQ(kernel_entry_table.count,
-                     kernel_source->source_definitions.count);
-      const iree_host_size_t source_symbol_count = kernel_entry_table.count;
+      IREE_ASSERT_LE(kernel_source->source_definitions.count,
+                     kernel_entry_table.count);
+      const iree_host_size_t source_symbol_count =
+          kernel_source->source_definitions.count;
       for (iree_host_size_t source_symbol_id = 0;
            source_symbol_id < source_symbol_count; ++source_symbol_id) {
         loom_op_t* entry_op = kernel_entry_table.values[source_symbol_id];

--- a/loom/src/loom/target/arch/cmd/lower/program_plan.h
+++ b/loom/src/loom/target/arch/cmd/lower/program_plan.h
@@ -69,12 +69,13 @@ typedef struct loom_cmd_program_kernel_source_t {
   // Invocation environment providing diagnostics and specialization.
   const loom_link_plan_materialization_environment_t* environment;
 
-  // Exact indexed source-definition ordinal by preparation-module symbol ID.
+  // Exact indexed source-definition ordinal by linked-module symbol ID.
+  // Caller preparation may append symbols while preserving this stable prefix.
   struct {
     // Borrowed dense projection storage.
     const iree_host_size_t* values;
 
-    // Number of preparation-module symbol slots.
+    // Number of linked-module symbol slots before caller preparation.
     iree_host_size_t count;
   } source_definitions;
 

--- a/loom/src/loom/transforms/kernel/resolve_launches.c
+++ b/loom/src/loom/transforms/kernel/resolve_launches.c
@@ -245,8 +245,7 @@ iree_status_t loom_kernel_resolve_launches(
   IREE_ASSERT(references->module == module);
   IREE_ASSERT_EQ(references->symbol_count, module->symbols.count);
   IREE_ASSERT(configuration_function_count == 0 || configuration_functions);
-  IREE_ASSERT(configuration_function_count == 0 ||
-              configuration_function_count == module->symbols.count);
+  IREE_ASSERT_LE(configuration_function_count, module->symbols.count);
   IREE_ASSERT_ARGUMENT(scratch_arena);
   IREE_ASSERT_ARGUMENT(out_entry_table);
   IREE_ASSERT_ARGUMENT(out_valid);

--- a/loom/src/loom/transforms/kernel/resolve_launches.h
+++ b/loom/src/loom/transforms/kernel/resolve_launches.h
@@ -35,12 +35,15 @@ typedef struct loom_kernel_launch_entry_table_t {
 
 // Resolves every logical kernel launch recorded in |references|.
 //
-// |configuration_functions| is a dense projection indexed by module-local
-// logical-kernel symbol ID. Each valid entry names a private pure function
-// accepting the kernel workload signature and returning exact XYZ workgroup
-// counts. The transform inserts ordinary pure calls at their caller-owned CFG
-// sites, derives one executable-entry declaration per logical kernel, and
-// replaces each kernel.launch with a kernel.dispatch targeting that entry.
+// |configuration_functions| is a dense prefix projection indexed by the
+// module-local logical-kernel symbol IDs present when linking completed. Each
+// valid entry names a private pure function accepting the kernel workload
+// signature and returning exact XYZ workgroup counts. Caller-owned target
+// specialization may append symbols while preserving every linked symbol ID;
+// those appended symbols intentionally lie outside the projection. The
+// transform inserts ordinary pure calls at their caller-owned CFG sites,
+// derives one executable-entry declaration per logical kernel, and replaces
+// each kernel.launch with a kernel.dispatch targeting that entry.
 //
 // Calls for launches nested only in kernel launch-schedule regions are placed
 // immediately before the outermost schedule. Schedule regions describe command

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -290,8 +290,12 @@ bool iree_task_executor_try_place_in_compute_slot(
     if (iree_atomic_compare_exchange_strong(
             &slot->process, &expected, IREE_TASK_COMPUTE_SLOT_RESERVED,
             iree_memory_order_acq_rel, iree_memory_order_relaxed)) {
+      iree_task_process_acquire_compute_placement(process);
       int32_t placement_epoch =
           iree_task_process_advance_placement_epoch(process);
+      iree_atomic_store(&slot->wake_budget,
+                        iree_task_process_wake_budget(process),
+                        iree_memory_order_release);
       iree_atomic_store(&slot->placement_epoch, placement_epoch,
                         iree_memory_order_release);
       iree_atomic_store(&slot->process, (intptr_t)process,

--- a/runtime/src/iree/task/executor_impl.h
+++ b/runtime/src/iree/task/executor_impl.h
@@ -34,8 +34,8 @@ extern "C" {
 // other.
 //
 // Active-drainer claims and their handoff to warm-retainer or release-sentinel
-// ownership prevent the release callback (which frees the processor context)
-// from firing while another worker may access it. The completion_claimed flag
+// ownership prevent the release callback (which may free the process) from
+// firing while another worker may access it. The completion_claimed flag
 // ensures exactly one worker runs the eager completion callback (semaphore
 // signaling, dependent activation).
 typedef struct iree_alignas(iree_hardware_destructive_interference_size)
@@ -48,6 +48,11 @@ typedef struct iree_alignas(iree_hardware_destructive_interference_size)
   // snapshot this before clearing the slot so they can detect if the same
   // persistent process was republished before the old release callback runs.
   iree_atomic_int32_t placement_epoch;
+
+  // Wake demand captured before the process pointer is published. Releasing
+  // workers use this slot-owned copy to re-wake a replacement placement
+  // without dereferencing process storage they do not own.
+  iree_atomic_int32_t wake_budget;
 
   // Tagged drainer counter: {generation(32) | count(32)}.
   //

--- a/runtime/src/iree/task/executor_test.cc
+++ b/runtime/src/iree/task/executor_test.cc
@@ -546,6 +546,7 @@ struct ComputeProcessContext : public TestWaiter {
   std::atomic<int32_t> tiles_completed{0};
   std::atomic<int32_t> active_drainers{0};
   std::atomic<bool> completed{false};
+  std::atomic<bool> released{false};
   iree_status_code_t completion_status_code = IREE_STATUS_OK;
   // Track which workers participated. Atomic because the completion callback
   // fires eagerly (first worker to observe terminal state) — other workers
@@ -600,6 +601,13 @@ static void compute_completion(iree_task_process_t* process,
   context->Notify();
 }
 
+static void compute_release_and_free_process(iree_task_process_t* process) {
+  auto* context = reinterpret_cast<ComputeProcessContext*>(process->user_data);
+  context->released.store(true, std::memory_order_release);
+  context->Notify();
+  delete process;
+}
+
 // Context for repeatedly reusing process storage as soon as release_fn
 // publishes that all scheduler access has ended.
 struct ComputeReleaseContext : public TestWaiter {
@@ -643,10 +651,11 @@ static void compute_release_completion(iree_task_process_t* process,
   IREE_EXPECT_OK(status);
 }
 
-static void compute_release_release(iree_task_process_t* process) {
+static void compute_release_and_free(iree_task_process_t* process) {
   auto* context = reinterpret_cast<ComputeReleaseContext*>(process->user_data);
   context->released.store(true, std::memory_order_release);
   context->Notify();
+  delete process;
 }
 
 // Context for a persistent wake_budget > 1 process that repeatedly goes idle
@@ -659,6 +668,7 @@ struct RepeatedComputeWakeContext : public TestWaiter {
   std::atomic<int32_t> active_drainers{0};
   std::atomic<bool> shutdown{false};
   std::atomic<bool> completed{false};
+  std::atomic<bool> released{false};
 };
 
 static iree_status_t repeated_compute_wake_drain(
@@ -702,6 +712,15 @@ static void repeated_compute_wake_completion(iree_task_process_t* process,
   iree_status_free(status);
   context->completed.store(true, std::memory_order_release);
   context->Notify();
+}
+
+static void repeated_compute_wake_release_and_free(
+    iree_task_process_t* process) {
+  auto* context =
+      reinterpret_cast<RepeatedComputeWakeContext*>(process->user_data);
+  context->released.store(true, std::memory_order_release);
+  context->Notify();
+  delete process;
 }
 
 // Context for a compute process that first publishes a shared keep-active
@@ -851,18 +870,18 @@ TEST(ExecutorProcessTest, ComputeSlotReleasePublishesProcessQuiescence) {
 
   ComputeReleaseContext context;
   context.job_count = kJobCount;
-  iree_task_process_t process;
   for (int batch = 0; batch < kBatchCount; ++batch) {
     context.next_job_ordinal.store(0, std::memory_order_relaxed);
     context.completed_job_count.store(0, std::memory_order_relaxed);
     context.released.store(false, std::memory_order_relaxed);
 
+    auto* process = new iree_task_process_t;
     iree_task_process_initialize(compute_release_drain, /*suspend_count=*/0,
-                                 /*wake_budget=*/kWorkerCount, &process);
-    process.completion_fn = compute_release_completion;
-    process.release_fn = compute_release_release;
-    process.user_data = &context;
-    iree_task_executor_schedule_process(executor, &process);
+                                 /*wake_budget=*/kWorkerCount, process);
+    process->completion_fn = compute_release_completion;
+    process->release_fn = compute_release_and_free;
+    process->user_data = &context;
+    iree_task_executor_schedule_process(executor, process);
 
     context.WaitUntil(
         [&] { return context.released.load(std::memory_order_acquire); });
@@ -876,24 +895,29 @@ TEST(ExecutorProcessTest, ComputeSlotReleasePublishesProcessQuiescence) {
 TEST(ExecutorProcessTest, ComputeSlotMultipleConcurrentProcesses) {
   iree_task_executor_t* executor = CreateExecutor(4);
 
-  static constexpr int kProcessCount = 8;
+  static constexpr int kProcessCount = 64;
   ComputeProcessContext contexts[kProcessCount];
-  iree_task_process_t processes[kProcessCount];
+  iree_task_process_t* processes[kProcessCount];
 
   for (int i = 0; i < kProcessCount; ++i) {
     contexts[i].tiles_remaining.store(50);
+    processes[i] = new iree_task_process_t;
     iree_task_process_initialize(compute_drain, 0, /*wake_budget=*/2,
-                                 &processes[i]);
-    processes[i].completion_fn = compute_completion;
-    processes[i].user_data = &contexts[i];
+                                 processes[i]);
+    processes[i]->completion_fn = compute_completion;
+    processes[i]->release_fn = compute_release_and_free_process;
+    processes[i]->user_data = &contexts[i];
   }
 
   for (int i = 0; i < kProcessCount; ++i) {
-    iree_task_executor_schedule_process(executor, &processes[i]);
+    iree_task_executor_schedule_process(executor, processes[i]);
   }
 
   for (int i = 0; i < kProcessCount; ++i) {
-    contexts[i].WaitUntil([&, i] { return contexts[i].completed.load(); });
+    contexts[i].WaitUntil([&, i] {
+      return contexts[i].completed.load(std::memory_order_acquire) &&
+             contexts[i].released.load(std::memory_order_acquire);
+    });
   }
 
   for (int i = 0; i < kProcessCount; ++i) {
@@ -978,25 +1002,25 @@ TEST(ExecutorProcessTest, ComputeSlotRepeatedSleepWakeCycles) {
   iree_task_executor_t* executor = CreateExecutor(4);
 
   RepeatedComputeWakeContext context;
-  iree_task_process_t process;
+  auto* process = new iree_task_process_t;
   iree_task_process_initialize(repeated_compute_wake_drain,
-                               /*suspend_count=*/0, /*wake_budget=*/4,
-                               &process);
-  process.completion_fn = repeated_compute_wake_completion;
-  process.user_data = &context;
+                               /*suspend_count=*/0, /*wake_budget=*/4, process);
+  process->completion_fn = repeated_compute_wake_completion;
+  process->release_fn = repeated_compute_wake_release_and_free;
+  process->user_data = &context;
 
-  iree_task_executor_schedule_process(executor, &process);
+  iree_task_executor_schedule_process(executor, process);
 
   static constexpr int kCycles = 500;
   for (int cycle = 0; cycle < kCycles; ++cycle) {
     SpinUntilInternalState([&] {
-      return iree_atomic_load(&process.schedule_state,
+      return iree_atomic_load(&process->schedule_state,
                               iree_memory_order_acquire) ==
              IREE_TASK_PROCESS_SCHEDULE_IDLE;
     });
 
     context.pending_work.fetch_add(1, std::memory_order_release);
-    iree_task_executor_schedule_process(executor, &process);
+    iree_task_executor_schedule_process(executor, process);
 
     context.WaitUntil([&] {
       return context.processed_work.load(std::memory_order_acquire) > cycle;
@@ -1004,16 +1028,18 @@ TEST(ExecutorProcessTest, ComputeSlotRepeatedSleepWakeCycles) {
   }
 
   SpinUntilInternalState([&] {
-    return iree_atomic_load(&process.schedule_state,
+    return iree_atomic_load(&process->schedule_state,
                             iree_memory_order_acquire) ==
            IREE_TASK_PROCESS_SCHEDULE_IDLE;
   });
 
   context.shutdown.store(true, std::memory_order_release);
-  iree_task_executor_schedule_process(executor, &process);
+  iree_task_executor_schedule_process(executor, process);
 
-  context.WaitUntil(
-      [&] { return context.completed.load(std::memory_order_acquire); });
+  context.WaitUntil([&] {
+    return context.completed.load(std::memory_order_acquire) &&
+           context.released.load(std::memory_order_acquire);
+  });
   EXPECT_EQ(context.processed_work.load(std::memory_order_acquire), kCycles);
 
   iree_task_executor_release(executor);

--- a/runtime/src/iree/task/process.c
+++ b/runtime/src/iree/task/process.c
@@ -10,6 +10,12 @@
 
 #include "iree/base/api.h"
 
+// Marks compute_placement_state as awaiting terminal release. The remaining
+// bits hold the number of slot placements that may still access process
+// storage during release.
+#define IREE_TASK_PROCESS_COMPUTE_RELEASE_PENDING INT32_MIN
+#define IREE_TASK_PROCESS_COMPUTE_PLACEMENT_COUNT_MASK INT32_MAX
+
 //===----------------------------------------------------------------------===//
 // Process lifecycle
 //===----------------------------------------------------------------------===//
@@ -49,6 +55,8 @@ void iree_task_process_initialize(iree_task_process_drain_fn_t drain_fn,
                     iree_memory_order_relaxed);
   iree_atomic_store(&out_process->placement_epoch, 0,
                     iree_memory_order_relaxed);
+  iree_atomic_store(&out_process->compute_placement_state, 0,
+                    iree_memory_order_relaxed);
   iree_atomic_store(&out_process->schedule_state, 0, iree_memory_order_relaxed);
   iree_atomic_store(&out_process->needs_drain, 0, iree_memory_order_relaxed);
   iree_atomic_store(&out_process->retain_drain, 0, iree_memory_order_relaxed);
@@ -66,6 +74,43 @@ void iree_task_process_initialize(iree_task_process_drain_fn_t drain_fn,
 void iree_task_process_set_flags(iree_task_process_t* process,
                                  iree_task_process_flags_t flags) {
   process->flags = flags;
+}
+
+void iree_task_process_acquire_compute_placement(iree_task_process_t* process) {
+  const int32_t previous = iree_atomic_fetch_add(
+      &process->compute_placement_state, 1, iree_memory_order_acq_rel);
+  IREE_ASSERT(
+      !iree_any_bit_set(previous, IREE_TASK_PROCESS_COMPUTE_RELEASE_PENDING),
+      "cannot place a process after terminal release");
+  IREE_ASSERT((previous & IREE_TASK_PROCESS_COMPUTE_PLACEMENT_COUNT_MASK) <
+                  IREE_TASK_PROCESS_COMPUTE_PLACEMENT_COUNT_MASK,
+              "compute placement count overflow");
+}
+
+void iree_task_process_release_compute_placement(iree_task_process_t* process,
+                                                 bool terminal) {
+  // Snapshot the callback before dropping the final process-storage claim.
+  // Once the CAS publishes a pending state with no placements, this function
+  // owns the only valid reference and may invoke a callback that frees it.
+  iree_task_process_release_fn_t release_fn = process->release_fn;
+  int32_t current = iree_atomic_load(&process->compute_placement_state,
+                                     iree_memory_order_acquire);
+  while (true) {
+    const int32_t placement_count =
+        current & IREE_TASK_PROCESS_COMPUTE_PLACEMENT_COUNT_MASK;
+    IREE_ASSERT(placement_count > 0, "compute placement count underflow");
+    int32_t desired = (current & IREE_TASK_PROCESS_COMPUTE_RELEASE_PENDING) |
+                      (placement_count - 1);
+    if (terminal) desired |= IREE_TASK_PROCESS_COMPUTE_RELEASE_PENDING;
+    if (iree_atomic_compare_exchange_weak(
+            &process->compute_placement_state, &current, desired,
+            iree_memory_order_acq_rel, iree_memory_order_acquire)) {
+      if (desired == IREE_TASK_PROCESS_COMPUTE_RELEASE_PENDING && release_fn) {
+        release_fn(process);
+      }
+      return;
+    }
+  }
 }
 
 bool iree_task_process_wake(iree_task_process_t* process) {

--- a/runtime/src/iree/task/process.h
+++ b/runtime/src/iree/task/process.h
@@ -141,14 +141,16 @@ typedef iree_status_t (*iree_task_process_drain_fn_t)(
 typedef void (*iree_task_process_completion_fn_t)(iree_task_process_t* process,
                                                   iree_status_t status);
 
-// Called when it is safe to free resources accessed by drain(). For
+// Called when it is safe to free the process and resources accessed by
+// drain(). For
 // wake_budget > 1 processes with cooperative multi-worker draining, this may
 // fire after completion_fn when the last active drainer exits. For
 // wake_budget == 1 processes with a single exclusive drainer, this fires
 // immediately after completion_fn.
 //
-// Typical use: freeing the processor context, issue context wrapper, and
-// other allocations that workers touch during drain().
+// This is the executor's final process access. The callback may free the
+// process itself, processor context, issue context wrapper, and other
+// allocations that workers touch during drain().
 //
 // If NULL, no deferred release is needed (the completion callback handles
 // everything, or the process's resources are externally managed).
@@ -208,7 +210,8 @@ struct iree_task_process_t {
   // completion work is needed.
   iree_task_process_completion_fn_t completion_fn;
 
-  // Called when it is safe to free drain-accessed resources. For
+  // Called on the executor's final process access, when it is safe to free the
+  // process and drain-accessed resources. For
   // wake_budget > 1 processes, this fires when the last active drainer exits
   // after completion_fn. For wake_budget == 1 processes, this fires
   // immediately after completion_fn. May be NULL if no deferred release is
@@ -273,6 +276,12 @@ struct iree_task_process_t {
   // release paths so stale releases cannot mutate process-global schedule
   // state after a newer slot lifetime has begun.
   iree_atomic_int32_t placement_epoch;
+
+  // Active compute-slot placement count with terminal release in the high bit.
+  // A placement retains process storage from publication until its complete
+  // slot-release path exits. The final placement invokes release_fn after a
+  // terminal placement has requested release.
+  iree_atomic_int32_t compute_placement_state;
 
   // Executor-managed scheduling state (iree_task_process_schedule_state_t).
   // Tracks whether this process is idle, queued on a run list, or being
@@ -368,6 +377,17 @@ void iree_task_process_initialize(iree_task_process_drain_fn_t drain_fn,
 // Sets immutable scheduler/lifecycle flags before the process is activated.
 void iree_task_process_set_flags(iree_task_process_t* process,
                                  iree_task_process_flags_t flags);
+
+// Retains process storage for one compute-slot placement. Called after a slot
+// is reserved and before its process pointer is published.
+void iree_task_process_acquire_compute_placement(iree_task_process_t* process);
+
+// Releases one compute-slot placement and optionally requests terminal
+// process release. The final placement invokes release_fn exactly once after a
+// terminal placement requests it. Callers must not access |process| after this
+// function because release_fn may free its storage.
+void iree_task_process_release_compute_placement(iree_task_process_t* process,
+                                                 bool terminal);
 
 // Decrements the process's suspend count by one. If the count reaches zero,
 // returns true — the caller is responsible for pushing the process to the

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -313,18 +313,18 @@ static void iree_task_worker_eager_complete_compute_process(
 
 // Releases a compute slot's current process ownership. Clears the slot, resets
 // the slot generation for reuse, optionally reclaims a non-terminal process if
-// new work arrived during the sleep transition, and frees drain-accessed
-// resources only for terminal processes. Called by a worker holding exclusive
-// release-sentinel ownership after transferring either the final active
-// drainer claim or the final warm-retainer claim.
+// new work arrived during the sleep transition, and requests final process
+// release for terminal processes. Called by a worker holding exclusive
+// release-sentinel ownership after transferring either the final active drainer
+// claim or the final warm-retainer claim.
 //
 // |tagged_sentinel| is the full 64-bit value (gen|SENTINEL) currently in
 // active_drainers. The generation bits are preserved and incremented when
 // the slot is reset, preventing ABA races on subsequent slot lifetimes.
 //
-// Ordering: clear process pointer, reset active_drainers, promote from
-// overflow, re-wake, then either put the process to sleep or run its terminal
-// release callback. Each phase has ordering constraints documented inline.
+// Ordering: clear slot metadata and process pointer, reset active_drainers,
+// promote from overflow, re-wake, then either put the process to sleep or drop
+// its placement claim. Each phase has ordering constraints documented inline.
 static void iree_task_worker_release_compute_process(
     iree_task_worker_t* worker, iree_task_compute_slot_t* slot,
     iree_task_process_t* process, bool process_is_terminal,
@@ -343,6 +343,11 @@ static void iree_task_worker_release_compute_process(
   // pointer in the quick check; the placement epoch lets it reject that stale
   // observation after registering in the next empty slot generation.
   iree_atomic_store(&slot->placement_epoch, 0, iree_memory_order_release);
+
+  // Clear the slot-owned wake demand before making the slot available. A new
+  // placement publishes its wake demand while the process pointer is reserved,
+  // so it cannot be overwritten by this release after the pointer becomes 0.
+  iree_atomic_store(&slot->wake_budget, 0, iree_memory_order_release);
 
   // Clear the process pointer. After this store (release), no new worker will
   // pass the quick check for this slot — except via stale reads that are
@@ -403,8 +408,8 @@ static void iree_task_worker_release_compute_process(
   intptr_t new_process =
       iree_atomic_load(&slot->process, iree_memory_order_acquire);
   if (new_process && new_process != IREE_TASK_COMPUTE_SLOT_RESERVED) {
-    iree_task_process_t* p = (iree_task_process_t*)new_process;
-    int32_t budget = iree_task_process_wake_budget(p);
+    int32_t budget =
+        iree_atomic_load(&slot->wake_budget, iree_memory_order_acquire);
     iree_task_executor_wake_workers(executor, budget);
   }
 
@@ -414,6 +419,7 @@ static void iree_task_worker_release_compute_process(
   // responsible for sleeping or releasing the process.
   if (IREE_UNLIKELY(release_placement_epoch !=
                     iree_task_process_placement_epoch(process))) {
+    iree_task_process_release_compute_placement(process, process_is_terminal);
     return;
   }
 
@@ -434,6 +440,7 @@ static void iree_task_worker_release_compute_process(
     // re-drain decision against that newer lifetime.
     if (IREE_UNLIKELY(release_placement_epoch !=
                       iree_task_process_placement_epoch(process))) {
+      iree_task_process_release_compute_placement(process, process_is_terminal);
       return;
     }
 
@@ -455,19 +462,10 @@ static void iree_task_worker_release_compute_process(
     }
   }
 
-  // Free drain-accessed resources. The slot is fully clean and may
-  // be reused by a new process placed by a concurrent schedule_process call.
-  // release_fn operates on the old process via its pointer argument, which
-  // is independent of whatever new process may now occupy the slot.
-  //
-  // Non-terminal processes are merely going idle here and must keep their
-  // process-owned state live for the next activation.
-  if (process_is_terminal) {
-    iree_task_process_release_fn_t release_fn = process->release_fn;
-    if (release_fn) {
-      release_fn(process);
-    }
-  }
+  // Drop this slot lifetime's process-storage claim. A terminal placement
+  // requests release, but release_fn waits for any overlapping stale slot
+  // releases to exit before it may reclaim process storage.
+  iree_task_process_release_compute_placement(process, process_is_terminal);
 }
 
 // Attempts to transfer an empty active-drainer generation into exclusive
@@ -750,10 +748,10 @@ static bool iree_task_worker_try_rejoin_warm_compute_process(
 //
 // Two-phase active-drainer protocol:
 //   Before accessing a slot's process, the worker increments active_drainers.
-//   This prevents the release callback (which frees the processor context)
-//   from firing while any worker is still inside drain(). The completion
-//   callback (semaphore signaling, dependent activation) fires eagerly —
-//   only the resource release is deferred until the last drainer exits.
+//   This prevents the release callback (which may free the process and its
+//   context) from firing while any worker is still inside drain(). The
+//   completion callback (semaphore signaling, dependent activation) fires
+//   eagerly — final process release waits for every placement to exit.
 //
 // Returns true if any useful work was performed or a cooperative process asked
 // this worker to remain active. The caller should loop back to check the


### PR DESCRIPTION
LoomC can now take four Qwen decode command programs containing 4,770 dispatch sites, reduce them to 34 unique kernel products, and finish all command products and final gfx1151 HSACOs in about 0.11 seconds on eight CPU workers. The same worker population can pipeline independent JIT compilation, executable loading, command-buffer recording, and application work without making a scheduler part of the compiler API.

Applications with an existing scheduler implement a two-callback task sink; applications that want a complete implementation allocate the optional task pool and attach one or more independently scheduled queues.

The important boundary is cache-before-submit. Product identity and reuse remain application policy, cache hits return without allocating or scheduling a task, and only cache misses enter the worker system. Prepared compilers, pass programs, frozen source indexes, and target state remain immutable shared process state. Each worker receives a dense stable ordinal with which compiler adapters select one reusable caller-owned workspace.

## Model-scale result

A current-syntax Qwen decode witness exercises four command programs containing 4,770 dispatch sites. Loom's semantic classification reduces those sites to 34 unique source-backed kernel products; the command products publish those kernels as soon as each becomes independently compilable, allowing compilation to overlap the remaining command work.

| Workers | 34-kernel span | Command start to all HSACOs |
| ---: | ---: | ---: |
| 4 | 75.93 ms | 115.89 ms |
| 8 | 66.42 ms | 105.66 ms |

The complete eight-worker result produces all four command products and all 34 byte-identical, valid gfx1151 HSACOs in about 0.11 seconds. Including the one-time construction of the frozen source index puts a fully cold library-and-product path at about 0.13 seconds.

This is not 4,770 independently scheduled jobs. Request publication consumes less than 0.08 ms across the entire command frontier, and cache hits bypass the scheduler entirely. The task count follows semantic products, not launch sites. A separate scheduler-floor stress test completes 64 no-op tasks in 0.10-0.12 ms; the real Qwen frontier schedules only 34 tasks whose compilation work is measured in milliseconds.

## Scheduler-independent composition

The dependency-free `loomc_task_t` protocol embeds into an application-defined task and supplies execute and destroy callbacks. Successful submission transfers one ownership reference for exactly one execution and destruction; rejected submission preserves caller ownership.

```c
loomc_task_pool_t* pool = NULL;
loomc_task_queue_t* compile_queue = NULL;

loomc_task_pool_allocate(&pool_options, allocator, &pool);
loomc_task_queue_allocate(pool, allocator, &compile_queue);

loomc_task_sink_t sink = loomc_task_queue_sink(compile_queue);
loomc_status_t status = loomc_task_sink_submit(sink, &task->base);
if (!loomc_status_is_ok(status)) {
  loomc_task_destroy(&task->base);  // Rejection retains caller ownership.
}
```

Applications with their own event loop, single-threaded work queue, or scheduler implement `loomc_task_sink_t` directly and do not link the standard task runtime. IREE-hosted applications may instead wrap an existing `iree_task_executor_t` or borrow the executor created by a LoomC pool. The compiler API therefore has one composition model rather than separate synchronous and asynchronous compiler surfaces.

## Pipeline independent stages

A task pool owns one executor and its persistent workers, but it owns no work queue. Each `loomc_task_queue_t` is an independent readiness, scheduling, and shutdown domain attached to those shared workers. Compiler tasks, executable loading, command-buffer recording, and application initialization can consequently pipeline without sitting behind one global FIFO or creating competing thread pools.

```text
                             +-> compile queue --------+
request -> cache miss -------+                         +-> publish product
                             +-> command queue --------+
                                                       |
shared worker pool <------ HAL executable loader <-----+
                   <------ command-buffer recorder <---+
                   <------ application processes
```

A controlled 256-root compile-load-record pipeline assigns 250 us of compilation, 50 us of executable loading, and 20 us of command recording to each root. Independent queues preserve the same total throughput while allowing completed upstream work to enter downstream stages immediately.

| Workers | Scheduling | First complete result | Total span |
| ---: | --- | ---: | ---: |
| 4 | One FIFO | 19.253 ms | 20.549 ms |
| 4 | Independent queues | 1.081 ms | 20.554 ms |
| 8 | One FIFO | 9.665 ms | 10.353 ms |
| 8 | Independent queues | 1.100 ms | 10.359 ms |

Independent queues improve time to the first usable result by 8.8-17.8x while changing total span by less than 0.5%. A deterministic single-worker regression proves the same scheduling property without relying on wall-clock timing: newly ready downstream work executes before a 256-task compile queue drains.

## Ownership and shutdown

Request-local tasks carry immutable inputs and write their terminal status and result into caller-owned completion state. Compiler failures terminalize one request rather than poisoning the scheduler. Queue shutdown is drain-only and independent: accepted work completes, new publication into that domain is rejected, and other queues sharing the executor remain runnable. A queue retains the executor and may outlive the convenience pool handle.

Queues intentionally expose no global idle wait. A transiently empty queue cannot prove that a recursive product frontier is complete because running work may publish more tasks. Request owners already know their actual frontier and retain completion ownership at the correct semantic boundary.

## Correctness exposed by concurrency

Target specialization may append concrete target symbols after link projections are captured. Command preparation incorrectly required the projection count to equal the later module symbol count, rejecting a valid specialized command root and preventing its child kernel request from inheriting the exact target. Projection consumers now use the captured linked-prefix bound, and public LoomC coverage specializes a command root, publishes its child request, and compiles that child with the inherited target.

Pipeline stress also exposed a task-runtime lifetime race. A persistent compute process can be republished while an older slot release is still retiring. A terminal placement previously invoked its release callback as soon as its own slot cleared, allowing an older release path to access freed process storage or a replacement process it did not own. Compute-slot placements now retain process storage through the complete release path, replacement wake demand lives in slot-owned storage, and the release callback is explicitly the executor's final process access.

The checked C embedding demonstrates eight independently configured compilations with prepared typed configuration modules, immutable shared state, worker-local workspaces, and caller-owned completion. The integration guide documents cache placement, custom schedulers, independent queue composition, IREE task-executor interop, completion ownership, and service teardown.
