### PR TITLE
[Loom] Accept typed configuration modules at compile

### DIFF
--- a/loom/binding/c/BUILD.bazel
+++ b/loom/binding/c/BUILD.bazel
@@ -129,6 +129,7 @@ loom_cc_library(
         "src/compile.c",
         "src/compile_report.c",
         "src/config.c",
+        "src/config_text.c",
         "src/context.c",
         "src/diagnostic.c",
         "src/emit.c",

--- a/loom/binding/c/CMakeLists.txt
+++ b/loom/binding/c/CMakeLists.txt
@@ -66,6 +66,7 @@ loom_cc_library(
     "src/compile.c"
     "src/compile_report.c"
     "src/config.c"
+    "src/config_text.c"
     "src/context.c"
     "src/diagnostic.c"
     "src/emit.c"

--- a/loom/binding/c/benchmark/compile_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/compile_throughput_benchmark.cc
@@ -230,6 +230,15 @@ iree_status_t DeserializeSource(loomc_context_t* context,
   return iree_ok_status();
 }
 
+iree_status_t CreateTextModule(loomc_context_t* context,
+                               loomc_workspace_t* workspace,
+                               const std::string& identifier,
+                               const std::string& text, ModulePtr* out_module) {
+  SourcePtr source;
+  IREE_RETURN_IF_ERROR(CreateTextSource(identifier, text, &source));
+  return DeserializeSource(context, workspace, source.get(), out_module);
+}
+
 iree_status_t CloneModule(const loomc_module_t* source_module,
                           loomc_workspace_t* workspace, ModulePtr* out_module) {
   out_module->reset();
@@ -445,7 +454,8 @@ iree_status_t TargetCompileScenario::SetUpTarget(
 iree_status_t TargetCompileScenario::CompileModuleToPreparedLow(
     WorkspacePtr& workspace, ModulePtr& module,
     loomc_string_view_t function_symbol, loomc_string_view_t module_name,
-    loomc_config_options_t config) {
+    const loomc_module_t* config_module,
+    loomc_config_policy_flags_t config_flags) {
   const loomc_target_specialization_t specialization = {
       /*.function_symbol=*/function_symbol,
       /*.target_profile=*/target_profile_.get(),
@@ -463,7 +473,8 @@ iree_status_t TargetCompileScenario::CompileModuleToPreparedLow(
       /*.next=*/&target_options,
       /*.module_name=*/module_name,
       /*.artifact_flags=*/0,
-      /*.config=*/config,
+      /*.config_flags=*/config_flags,
+      /*.config_module=*/config_module,
   };
 
   loomc_result_t* raw_result = nullptr;

--- a/loom/binding/c/benchmark/compile_throughput_benchmark.h
+++ b/loom/binding/c/benchmark/compile_throughput_benchmark.h
@@ -94,11 +94,11 @@ class TargetCompileScenario : public CompileScenario {
                             TargetProfilePtr target_profile,
                             loomc_string_view_t pipeline_identifier);
 
-  iree_status_t CompileModuleToPreparedLow(WorkspacePtr& workspace,
-                                           ModulePtr& module,
-                                           loomc_string_view_t function_symbol,
-                                           loomc_string_view_t module_name,
-                                           loomc_config_options_t config);
+  iree_status_t CompileModuleToPreparedLow(
+      WorkspacePtr& workspace, ModulePtr& module,
+      loomc_string_view_t function_symbol, loomc_string_view_t module_name,
+      const loomc_module_t* config_module,
+      loomc_config_policy_flags_t config_flags);
 
   loomc_target_environment_t* target_environment() const {
     return target_environment_.get();
@@ -160,6 +160,11 @@ iree_status_t DeserializeSource(loomc_context_t* context,
                                 loomc_workspace_t* workspace,
                                 const loomc_source_t* source,
                                 ModulePtr* out_module);
+
+iree_status_t CreateTextModule(loomc_context_t* context,
+                               loomc_workspace_t* workspace,
+                               const std::string& identifier,
+                               const std::string& text, ModulePtr* out_module);
 
 iree_status_t CloneModule(const loomc_module_t* source_module,
                           loomc_workspace_t* workspace, ModulePtr* out_module);

--- a/loom/binding/c/benchmark/target/amdgpu/compile_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/target/amdgpu/compile_throughput_benchmark.cc
@@ -24,6 +24,7 @@ namespace {
 using loomc::bench::CloneModule;
 using loomc::bench::CompileScenario;
 using loomc::bench::CreateBenchmarkKernelSource;
+using loomc::bench::CreateTextModule;
 using loomc::bench::CreateTextSource;
 using loomc::bench::CreateWorkspace;
 using loomc::bench::DeserializeSource;
@@ -153,8 +154,7 @@ class AmdgpuI32ChainScenario final : public AmdgpuTargetCompileScenario {
     operation_counts_.reserve(operation_counts.size());
     for (iree_host_size_t operation_count : operation_counts) {
       operation_count = std::max<iree_host_size_t>(operation_count, 1);
-      operation_counts_.push_back(
-          {operation_count, std::to_string(operation_count)});
+      operation_counts_.push_back({operation_count, {}});
     }
   }
 
@@ -164,8 +164,19 @@ class AmdgpuI32ChainScenario final : public AmdgpuTargetCompileScenario {
         loomc_make_cstring_view("i32_memory_chain.loom"), &source_));
     IREE_RETURN_IF_ERROR(
         CreateWorkspace(/*block_size=*/0, &template_workspace_));
-    return DeserializeSource(context_.get(), template_workspace_.get(),
-                             source_.get(), &template_module_);
+    IREE_RETURN_IF_ERROR(DeserializeSource(context_.get(),
+                                           template_workspace_.get(),
+                                           source_.get(), &template_module_));
+    for (OperationCount& operation_count : operation_counts_) {
+      std::ostringstream config_text;
+      config_text << "config.def @benchmark.workgroup_size = 64 : index\n"
+                  << "config.def @benchmark.operation_count = "
+                  << operation_count.value << " : index\n";
+      IREE_RETURN_IF_ERROR(CreateTextModule(
+          context_.get(), template_workspace_.get(), "i32_chain_config.loom",
+          config_text.str(), &operation_count.config_module));
+    }
+    return iree_ok_status();
   }
 
   iree_host_size_t job_count() const override { return job_count_; }
@@ -190,27 +201,11 @@ class AmdgpuI32ChainScenario final : public AmdgpuTargetCompileScenario {
     ModulePtr module;
     IREE_RETURN_IF_ERROR(
         CloneModule(template_module_.get(), workspace.get(), &module));
-    loomc_config_binding_t bindings[] = {
-        {
-            /*.key=*/loomc_make_cstring_view("@benchmark.workgroup_size"),
-            /*.value=*/loomc_make_cstring_view("64"),
-        },
-        {
-            /*.key=*/loomc_make_cstring_view("@benchmark.operation_count"),
-            /*.value=*/
-            loomc_make_string_view(operation_count.text.data(),
-                                   operation_count.text.size()),
-        },
-    };
-    const loomc_config_options_t config_options = {
-        /*.bindings=*/bindings,
-        /*.binding_count=*/IREE_ARRAYSIZE(bindings),
-        /*.json_object=*/loomc_string_view_empty(),
-        /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-    };
     IREE_RETURN_IF_ERROR(CompileModuleToPreparedLow(
         workspace, module, loomc_make_cstring_view("i32_memory_chain"),
-        loomc_make_cstring_view("amdgpu_i32_chain"), config_options));
+        loomc_make_cstring_view("amdgpu_i32_chain"),
+        operation_count.config_module.get(),
+        LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED));
     return EmitAmdgpuArtifact(
         workspace, module, loomc_make_cstring_view("i32_memory_chain.hsaco"));
   }
@@ -231,8 +226,8 @@ class AmdgpuI32ChainScenario final : public AmdgpuTargetCompileScenario {
     // Numeric operation count reported by the benchmark.
     iree_host_size_t value;
 
-    // Stable config spelling borrowed by each invocation.
-    std::string text;
+    // Immutable typed config module shared by compile invocations.
+    ModulePtr config_module;
   };
 
   // Number of kernels compiled by each benchmark iteration.
@@ -345,11 +340,10 @@ class AmdgpuClusterAsyncDisjointScenario final
     ModulePtr module;
     IREE_RETURN_IF_ERROR(
         CloneModule(template_module_.get(), workspace.get(), &module));
-    const loomc_config_options_t config_options = {};
     IREE_RETURN_IF_ERROR(CompileModuleToPreparedLow(
         workspace, module, loomc_make_cstring_view("cluster_async_disjoint"),
         loomc_make_cstring_view("amdgpu_cluster_async_disjoint"),
-        config_options));
+        /*config_module=*/nullptr, /*config_flags=*/0));
     return EmitAmdgpuArtifact(
         workspace, module,
         loomc_make_cstring_view("cluster_async_disjoint.hsaco"));

--- a/loom/binding/c/benchmark/target/spirv/compile_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/target/spirv/compile_throughput_benchmark.cc
@@ -8,11 +8,11 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <cstdio>
 #include <cstring>
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "benchmark/benchmark.h"
 #include "loomc/target/spirv.h"
@@ -22,6 +22,7 @@ namespace {
 using loomc::bench::CloneModule;
 using loomc::bench::CompileScenario;
 using loomc::bench::CreateBenchmarkKernelSource;
+using loomc::bench::CreateTextModule;
 using loomc::bench::CreateWorkspace;
 using loomc::bench::DeserializeSource;
 using loomc::bench::loom_allocator;
@@ -178,6 +179,20 @@ class SpirvTunerFlowScenario final : public SpirvScenarioBase {
     IREE_RETURN_IF_ERROR(SetUpSpirv(worker_count));
     IREE_RETURN_IF_ERROR(CreateBenchmarkKernelSource(
         loomc_make_cstring_view("i32_memory_chain.loom"), &source_));
+    IREE_RETURN_IF_ERROR(CreateWorkspace(/*block_size=*/0, &config_workspace_));
+    config_modules_.reserve(64);
+    for (iree_host_size_t workgroup_size = 1; workgroup_size <= 64;
+         ++workgroup_size) {
+      std::string config_text =
+          "config.def @benchmark.workgroup_size = " +
+          std::to_string(workgroup_size) +
+          " : index\nconfig.def @benchmark.operation_count = 1 : index\n";
+      ModulePtr config_module;
+      IREE_RETURN_IF_ERROR(
+          CreateTextModule(context_.get(), config_workspace_.get(),
+                           "tuner_config.loom", config_text, &config_module));
+      config_modules_.push_back(std::move(config_module));
+    }
     if (materialization_mode_ == ModuleMaterializationMode::kCloneTemplate) {
       IREE_RETURN_IF_ERROR(
           CreateWorkspace(/*block_size=*/0, &template_workspace_));
@@ -203,29 +218,11 @@ class SpirvTunerFlowScenario final : public SpirvScenarioBase {
                                              source_.get(), &module));
     }
 
-    char workgroup_size_value[16] = {0};
-    std::snprintf(workgroup_size_value, sizeof(workgroup_size_value), "%d",
-                  1 + (int)(job_ordinal % 64));
-    loomc_config_binding_t bindings[] = {
-        {
-            /*.key=*/loomc_make_cstring_view("@benchmark.workgroup_size"),
-            /*.value=*/loomc_make_cstring_view(workgroup_size_value),
-        },
-        {
-            /*.key=*/loomc_make_cstring_view("@benchmark.operation_count"),
-            /*.value=*/loomc_make_cstring_view("1"),
-        },
-    };
-    loomc_config_options_t config_options = {
-        /*.bindings=*/bindings,
-        /*.binding_count=*/IREE_ARRAYSIZE(bindings),
-        /*.json_object=*/loomc_string_view_empty(),
-        /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-    };
-
     IREE_RETURN_IF_ERROR(CompileModuleToPreparedLow(
         workspace, module, loomc_make_cstring_view("i32_memory_chain"),
-        loomc_make_cstring_view("spirv_tuner_kernel"), config_options));
+        loomc_make_cstring_view("spirv_tuner_kernel"),
+        config_modules_[job_ordinal % config_modules_.size()].get(),
+        LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED));
     return EmitSpirvArtifact(workspace, module,
                              loomc_make_cstring_view("i32_memory_chain.spv"));
   }
@@ -234,6 +231,8 @@ class SpirvTunerFlowScenario final : public SpirvScenarioBase {
   iree_host_size_t job_count_ = 0;
   ModuleMaterializationMode materialization_mode_;
   SourcePtr source_;
+  WorkspacePtr config_workspace_;
+  std::vector<ModulePtr> config_modules_;
   WorkspacePtr template_workspace_;
   ModulePtr template_module_;
 };
@@ -247,13 +246,20 @@ class SpirvI32ChainScenario final : public SpirvScenarioBase {
       : SpirvScenarioBase(workspace_block_size),
         job_count_(job_count),
         operation_count_(std::max<iree_host_size_t>(operation_count, 1)),
-        operation_count_value_(std::to_string(operation_count_)),
         materialization_mode_(materialization_mode) {}
 
   iree_status_t SetUp(iree_host_size_t worker_count) override {
     IREE_RETURN_IF_ERROR(SetUpSpirv(worker_count));
     IREE_RETURN_IF_ERROR(CreateBenchmarkKernelSource(
         loomc_make_cstring_view("i32_memory_chain.loom"), &source_));
+    IREE_RETURN_IF_ERROR(CreateWorkspace(/*block_size=*/0, &config_workspace_));
+    const std::string config_text =
+        "config.def @benchmark.workgroup_size = 64 : index\n"
+        "config.def @benchmark.operation_count = " +
+        std::to_string(operation_count_) + " : index\n";
+    IREE_RETURN_IF_ERROR(CreateTextModule(
+        context_.get(), config_workspace_.get(), "i32_chain_config.loom",
+        config_text, &config_module_));
     if (materialization_mode_ == ModuleMaterializationMode::kCloneTemplate) {
       IREE_RETURN_IF_ERROR(
           CreateWorkspace(/*block_size=*/0, &template_workspace_));
@@ -280,28 +286,10 @@ class SpirvI32ChainScenario final : public SpirvScenarioBase {
     }
 
     (void)job_ordinal;
-    loomc_config_binding_t bindings[] = {
-        {
-            /*.key=*/loomc_make_cstring_view("@benchmark.workgroup_size"),
-            /*.value=*/loomc_make_cstring_view("64"),
-        },
-        {
-            /*.key=*/loomc_make_cstring_view("@benchmark.operation_count"),
-            /*.value=*/
-            loomc_make_string_view(operation_count_value_.data(),
-                                   operation_count_value_.size()),
-        },
-    };
-    loomc_config_options_t config_options = {
-        /*.bindings=*/bindings,
-        /*.binding_count=*/IREE_ARRAYSIZE(bindings),
-        /*.json_object=*/loomc_string_view_empty(),
-        /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-    };
-
     IREE_RETURN_IF_ERROR(CompileModuleToPreparedLow(
         workspace, module, loomc_make_cstring_view("i32_memory_chain"),
-        loomc_make_cstring_view("spirv_i32_chain"), config_options));
+        loomc_make_cstring_view("spirv_i32_chain"), config_module_.get(),
+        LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED));
     return EmitSpirvArtifact(workspace, module,
                              loomc_make_cstring_view("i32_chain.spv"));
   }
@@ -313,9 +301,10 @@ class SpirvI32ChainScenario final : public SpirvScenarioBase {
  private:
   iree_host_size_t job_count_ = 0;
   iree_host_size_t operation_count_ = 0;
-  std::string operation_count_value_;
   ModuleMaterializationMode materialization_mode_;
   SourcePtr source_;
+  WorkspacePtr config_workspace_;
+  ModulePtr config_module_;
   WorkspacePtr template_workspace_;
   ModulePtr template_module_;
 };

--- a/loom/binding/c/benchmark/targetless_compile_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/targetless_compile_throughput_benchmark.cc
@@ -18,6 +18,7 @@ namespace {
 
 using loomc::bench::AddSourceToIndex;
 using loomc::bench::CompileScenario;
+using loomc::bench::CreateTextModule;
 using loomc::bench::CreateTextSource;
 using loomc::bench::DeserializeSource;
 using loomc::bench::LinkerPtr;
@@ -41,7 +42,28 @@ class TunerFlowScenario final : public CompileScenario {
 
   iree_status_t SetUp(iree_host_size_t worker_count) override {
     IREE_RETURN_IF_ERROR(CompileScenario::SetUp(worker_count));
-    return CreateTextSource("tuner_kernel.loom", source_text_, &source_);
+    IREE_RETURN_IF_ERROR(
+        CreateTextSource("tuner_kernel.loom", source_text_, &source_));
+    IREE_RETURN_IF_ERROR(
+        loomc::bench::CreateWorkspace(/*block_size=*/0, &config_workspace_));
+    config_modules_.reserve(256);
+    for (iree_host_size_t config_ordinal = 0; config_ordinal < 256;
+         ++config_ordinal) {
+      const int tile_m = 16 + (int)(config_ordinal % 16) * 16;
+      const int tile_n = 16 + (int)((config_ordinal / 16) % 16) * 16;
+      const int unroll = 1 + (int)(config_ordinal % 8);
+      std::ostringstream config_text;
+      config_text << "config.def @tuner.model.hidden_size = 4096 : index\n"
+                  << "config.def @tuner.tile_m = " << tile_m << " : index\n"
+                  << "config.def @tuner.tile_n = " << tile_n << " : index\n"
+                  << "config.def @tuner.unroll = " << unroll << " : index\n";
+      ModulePtr config_module;
+      IREE_RETURN_IF_ERROR(CreateTextModule(
+          context_.get(), config_workspace_.get(), "tuner_config.loom",
+          config_text.str(), &config_module));
+      config_modules_.push_back(std::move(config_module));
+    }
+    return iree_ok_status();
   }
 
   iree_host_size_t job_count() const override { return job_count_; }
@@ -54,43 +76,15 @@ class TunerFlowScenario final : public CompileScenario {
     IREE_RETURN_IF_ERROR(DeserializeSource(context_.get(), workspace.get(),
                                            source_.get(), &module));
 
-    char tile_m_value[16] = {0};
-    char tile_n_value[16] = {0};
-    char unroll_value[16] = {0};
-    std::snprintf(tile_m_value, sizeof(tile_m_value), "%d",
-                  16 + (int)(job_ordinal % 16) * 16);
-    std::snprintf(tile_n_value, sizeof(tile_n_value), "%d",
-                  16 + (int)((job_ordinal / 16) % 16) * 16);
-    std::snprintf(unroll_value, sizeof(unroll_value), "%d",
-                  1 + (int)(job_ordinal % 8));
-    loomc_config_binding_t bindings[] = {
-        {
-            /*.key=*/loomc_make_cstring_view("@tuner.tile_m"),
-            /*.value=*/loomc_make_cstring_view(tile_m_value),
-        },
-        {
-            /*.key=*/loomc_make_cstring_view("@tuner.tile_n"),
-            /*.value=*/loomc_make_cstring_view(tile_n_value),
-        },
-        {
-            /*.key=*/loomc_make_cstring_view("@tuner.unroll"),
-            /*.value=*/loomc_make_cstring_view(unroll_value),
-        },
-    };
     loomc_compile_options_t options = {
         /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
         /*.structure_size=*/sizeof(options),
         /*.next=*/nullptr,
         /*.module_name=*/loomc_make_cstring_view("tuner_kernel"),
         /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_BYTECODE,
-        /*.config=*/
-        {
-            /*.bindings=*/bindings,
-            /*.binding_count=*/IREE_ARRAYSIZE(bindings),
-            /*.json_object=*/
-            loomc_make_cstring_view("{\"@tuner.model.hidden_size\":\"4096\"}"),
-            /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-        },
+        /*.config_flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+        /*.config_module=*/
+        config_modules_[job_ordinal % config_modules_.size()].get(),
     };
 
     loomc_result_t* raw_result = nullptr;
@@ -113,6 +107,8 @@ class TunerFlowScenario final : public CompileScenario {
 
   iree_host_size_t job_count_ = 0;
   SourcePtr source_;
+  WorkspacePtr config_workspace_;
+  std::vector<ModulePtr> config_modules_;
 };
 
 const char* TunerFlowScenario::source_text_ =
@@ -223,13 +219,8 @@ class ModelFlowScenario final : public CompileScenario {
         /*.next=*/nullptr,
         /*.module_name=*/loomc_make_cstring_view("model_kernel"),
         /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_BYTECODE,
-        /*.config=*/
-        {
-            /*.bindings=*/nullptr,
-            /*.binding_count=*/0,
-            /*.json_object=*/loomc_string_view_empty(),
-            /*.flags=*/0,
-        },
+        /*.config_flags=*/0,
+        /*.config_module=*/nullptr,
     };
 
     loomc_result_t* raw_compile_result = nullptr;

--- a/loom/binding/c/example/compile_text.c
+++ b/loom/binding/c/example/compile_text.c
@@ -17,6 +17,9 @@ static const char kSourceText[] =
     "  func.return %hidden : index\n"
     "}\n";
 
+static const char kConfigText[] =
+    "config.def @model.hidden_size = 4096 : index\n";
+
 typedef struct compile_text_state_t {
   // Shared API context retained by sources, modules, and prepared tools.
   loomc_context_t* context;
@@ -27,8 +30,14 @@ typedef struct compile_text_state_t {
   // Immutable source containing the input text.
   loomc_source_t* source;
 
+  // Immutable source containing exact textual config definitions.
+  loomc_source_t* config_source;
+
   // Mutable module produced from source and consumed by compile.
   loomc_module_t* module;
+
+  // Immutable typed config module borrowed by compile.
+  loomc_module_t* config_module;
 
   // Immutable prepared compiler handle.
   loomc_compiler_t* compiler;
@@ -69,7 +78,9 @@ static void compile_text_state_deinitialize(compile_text_state_t* state) {
   loomc_result_release(state->result);
   loomc_pass_program_release(state->pass_program);
   loomc_compiler_release(state->compiler);
+  loomc_module_release(state->config_module);
   loomc_module_release(state->module);
+  loomc_source_release(state->config_source);
   loomc_source_release(state->source);
   loomc_workspace_release(state->workspace);
   loomc_context_release(state->context);
@@ -129,6 +140,18 @@ static loomc_status_t create_resources(compile_text_state_t* state) {
     status = create_source(state);
   }
   if (loomc_status_is_ok(status)) {
+    loomc_source_options_t options = {
+        .type = LOOMC_STRUCTURE_TYPE_SOURCE_OPTIONS,
+        .structure_size = sizeof(options),
+        .format = LOOMC_SOURCE_FORMAT_TEXT,
+        .identifier = loomc_make_cstring_view("config.loom"),
+        .contents = loomc_make_byte_span(kConfigText, sizeof(kConfigText) - 1),
+        .storage = LOOMC_SOURCE_STORAGE_BORROWED,
+    };
+    status = loomc_source_create(&options, loomc_allocator_system(),
+                                 &state->config_source);
+  }
+  if (loomc_status_is_ok(status)) {
     status = loomc_compiler_create(state->context, NULL,
                                    loomc_allocator_system(), &state->compiler);
   }
@@ -158,28 +181,30 @@ static loomc_status_t deserialize_source(compile_text_state_t* state) {
   if (loomc_status_is_ok(status)) {
     compile_text_state_reset_result(state);
   }
+  if (loomc_status_is_ok(status)) {
+    status = loomc_module_deserialize_text_from_source(
+        state->context, state->workspace, state->config_source, NULL,
+        loomc_allocator_system(), &state->config_module, &state->result);
+  }
+  if (loomc_status_is_ok(status)) {
+    status = require_successful_result(state->result,
+                                       "config deserialization failed");
+  }
+  if (loomc_status_is_ok(status)) {
+    compile_text_state_reset_result(state);
+  }
   return status;
 }
 
 static loomc_status_t compile_module(compile_text_state_t* state) {
-  loomc_config_binding_t bindings[] = {
-      {
-          .key = loomc_make_cstring_view("@model.hidden_size"),
-          .value = loomc_make_cstring_view("4096"),
-      },
-  };
   loomc_compile_options_t options = {
       .type = LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
       .structure_size = sizeof(options),
       .module_name = loomc_make_cstring_view("jit_kernel"),
       .artifact_flags = LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_TEXT |
                         LOOMC_COMPILE_ARTIFACT_FLAG_REPORT_JSON,
-      .config =
-          {
-              .bindings = bindings,
-              .binding_count = 1,
-              .flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-          },
+      .config_flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+      .config_module = state->config_module,
   };
   loomc_status_t status = loomc_compile_module(
       state->compiler, state->workspace, state->pass_program, state->module,

--- a/loom/binding/c/example/link_modules.c
+++ b/loom/binding/c/example/link_modules.c
@@ -236,6 +236,12 @@ static loomc_status_t link_module(link_modules_state_t* state) {
   const loomc_string_view_t roots[] = {
       loomc_make_cstring_view("@caller"),
   };
+  loomc_config_binding_t bindings[] = {
+      {
+          .key = loomc_make_cstring_view("@model.hidden_size"),
+          .value = loomc_make_cstring_view("4096"),
+      },
+  };
   loomc_link_options_t link_options = {
       .type = LOOMC_STRUCTURE_TYPE_LINK_OPTIONS,
       .structure_size = sizeof(link_options),
@@ -243,6 +249,14 @@ static loomc_status_t link_module(link_modules_state_t* state) {
       .mode = LOOMC_LINK_MODE_LINK,
       .root_symbols = roots,
       .root_symbol_count = 1,
+      .config =
+          {
+              .bindings = bindings,
+              .binding_count = 1,
+              .json_object =
+                  loomc_make_cstring_view("{\"model\":{\"hidden_size\":2048}}"),
+              .flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+          },
   };
 
   loomc_status_t status =
@@ -258,26 +272,12 @@ static loomc_status_t link_module(link_modules_state_t* state) {
 }
 
 static loomc_status_t compile_linked_module(link_modules_state_t* state) {
-  loomc_config_binding_t bindings[] = {
-      {
-          .key = loomc_make_cstring_view("@model.hidden_size"),
-          .value = loomc_make_cstring_view("4096"),
-      },
-  };
   loomc_compile_options_t compile_options = {
       .type = LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
       .structure_size = sizeof(compile_options),
       .module_name = loomc_make_cstring_view("jit_kernel"),
       .artifact_flags = LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_TEXT |
                         LOOMC_COMPILE_ARTIFACT_FLAG_REPORT_JSON,
-      .config =
-          {
-              .bindings = bindings,
-              .binding_count = 1,
-              .json_object =
-                  loomc_make_cstring_view("{\"model\":{\"hidden_size\":2048}}"),
-              .flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-          },
   };
 
   loomc_status_t status = loomc_compile_module(

--- a/loom/binding/c/include/loomc/compile.h
+++ b/loom/binding/c/include/loomc/compile.h
@@ -45,22 +45,16 @@
 ///     return;
 ///   }
 ///
-///   loomc_config_binding_t bindings[] = {
-///       {
-///           .key = loomc_make_cstring_view("tile_m"),
-///           .value = loomc_make_cstring_view("128"),
-///       },
-///   };
+///   // `config_module` is an ordinary module containing exact config.def
+///   // values. It may be deserialized from text or bytecode once and shared by
+///   // concurrent invocations.
 ///   loomc_compile_options_t compile_options = {
 ///       .type = LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
 ///       .structure_size = sizeof(loomc_compile_options_t),
 ///       .artifact_flags = LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_BYTECODE |
 ///                         LOOMC_COMPILE_ARTIFACT_FLAG_REPORT_JSON,
-///       .config =
-///           {
-///               .bindings = bindings,
-///               .binding_count = 1,
-///           },
+///       .config_flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+///       .config_module = config_module,
 ///   };
 ///
 ///   // `module` is produced by deserialization, linking, or another module
@@ -143,11 +137,12 @@ typedef struct loomc_compiler_options_t {
 /// Compile invocation options.
 ///
 /// A compile invocation borrows a mutable module and returns a result with
-/// diagnostics and artifacts. Per-kernel configuration values materialize into
-/// the module before the selected pass program runs. These values live here
-/// rather than on the prepared compiler so autotuning and JIT sweeps can vary
-/// config without constructing many compiler handles. Per-function target
-/// specializations and target-declaration bindings are supplied through
+/// diagnostics and artifacts. Exact values from an optional config module
+/// materialize into the program module before the selected pass program runs.
+/// Configuration lives here rather than on the prepared compiler so autotuning
+/// and JIT sweeps can vary config without constructing many compiler handles.
+/// Per-function target specializations and target-declaration bindings are
+/// supplied through
 /// `loomc_target_specialization_options_t` on `next`, so one invocation can
 /// compile several function versions for different exact targets.
 typedef struct loomc_compile_options_t {
@@ -170,8 +165,17 @@ typedef struct loomc_compile_options_t {
   /// the hot path focused on diagnostics and in-place module transformation.
   loomc_compile_artifact_flags_t artifact_flags;
 
-  /// Per-invocation config dialect bindings and optional JSON object.
-  loomc_config_options_t config;
+  /// Config validation and final-resolution policy.
+  loomc_config_policy_flags_t config_flags;
+
+  /// Optional module containing only exact `config.def` operations.
+  ///
+  /// The module is borrowed, remains immutable, must use the compiler context,
+  /// and must be distinct from the mutable program module. Definitions without
+  /// matching program config symbols are ignored so one config module can serve
+  /// several related programs. Load text or bytecode config modules through the
+  /// normal format-specific module deserialization APIs.
+  const loomc_module_t* config_module;
 } loomc_compile_options_t;
 
 /// Creates a prepared immutable compiler.
@@ -223,7 +227,9 @@ LOOMC_API_EXPORT loomc_status_t loomc_compiler_create(
 ///
 /// @lifetime
 /// Returned results and artifacts do not borrow from `workspace` and remain
-/// valid after `loomc_workspace_trim`.
+/// valid after `loomc_workspace_trim`. The invocation borrows
+/// `options->config_module` only for the duration of the call and does not
+/// mutate or retain it.
 ///
 /// @par Artifact Requests
 /// Artifact emission is opt-in through `loomc_compile_options_t`. Requesting

--- a/loom/binding/c/include/loomc/config.h
+++ b/loom/binding/c/include/loomc/config.h
@@ -10,13 +10,14 @@
 #include "loomc/base.h"
 
 /// @file
-/// Per-invocation configuration bindings.
+/// Text and JSON configuration bindings.
 ///
-/// Configuration is intentionally represented as plain borrowed key/value data
+/// Link and command-product operations accept plain borrowed key/value data
 /// plus one optional JSON/JSONC object string. Bindings without a matching
 /// config declaration are ignored so one stable config bag can serve modules
-/// that consume different subsets. Operation descriptors decide whether
-/// unresolved configuration may remain in the produced result.
+/// that consume different subsets. Compile operations instead accept an
+/// ordinary typed module containing `config.def` operations; callers load that
+/// module through the normal text or bytecode module APIs.
 ///
 /// @par Example
 /// Use JSON for a framework-provided configuration file and explicit bindings
@@ -64,7 +65,7 @@ typedef enum loomc_config_policy_flag_bits_e {
 /// Bitmask of `loomc_config_policy_flag_bits_t` values.
 typedef uint32_t loomc_config_policy_flags_t;
 
-/// Configuration options attached to a link or compile invocation.
+/// Text configuration options attached to a link or command-product operation.
 ///
 /// The plain binding array and optional JSON/JSONC object string normalize into
 /// the same key/value binding set. When both spellings define the same key, the

--- a/loom/binding/c/src/compile.c
+++ b/loom/binding/c/src/compile.c
@@ -130,7 +130,30 @@ static loomc_status_t loomc_compile_validate_options(
     return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
                              "compile options contain unknown artifact flags");
   }
-  return loomc_config_validate_options(&options->config);
+  return loomc_config_validate_policy_flags(options->config_flags);
+}
+
+static loomc_status_t loomc_compile_validate_config_module(
+    const loomc_compiler_t* compiler, const loomc_module_t* program_module,
+    const loomc_compile_options_t* options) {
+  const loomc_module_t* config_module = options ? options->config_module : NULL;
+  if (config_module == NULL) {
+    return loomc_ok_status();
+  }
+  if (config_module == program_module) {
+    return loomc_make_status(
+        LOOMC_STATUS_INVALID_ARGUMENT,
+        "config module must be distinct from the program module");
+  }
+  if (loomc_module_context(config_module) != compiler->context) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "config module was created with another context");
+  }
+  if (loomc_module_const_loom_module(config_module) == NULL) {
+    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                             "config module does not contain internal IR");
+  }
+  return loomc_ok_status();
 }
 
 static iree_status_t loomc_compile_capture_diagnostic_emission(
@@ -341,12 +364,16 @@ static iree_status_t loomc_compile_write_json_string_field(
 static iree_status_t loomc_compile_write_report_json(
     const loomc_compile_options_t* options, const loomc_result_t* result,
     const loomc_target_specialization_options_t* target_options,
+    const loomc_config_application_result_t* config_application,
     loomc_host_size_t artifact_count, loom_output_stream_t* stream) {
-  const loomc_config_options_t empty_config_options = {0};
-  const loomc_config_options_t* config_options =
-      options ? &options->config : &empty_config_options;
   const loomc_string_view_t module_name =
       options ? options->module_name : loomc_string_view_empty();
+  const loomc_config_policy_flags_t config_flags =
+      options ? options->config_flags : 0;
+  const loomc_host_size_t config_materialized_count =
+      config_application ? config_application->materialized_count : 0;
+  const loomc_host_size_t config_ignored_count =
+      config_application ? config_application->ignored_count : 0;
 
   IREE_RETURN_IF_ERROR(loom_output_stream_write_char(stream, '{'));
   IREE_RETURN_IF_ERROR(loomc_compile_write_json_string_field(
@@ -364,15 +391,19 @@ static iree_status_t loomc_compile_write_report_json(
   IREE_RETURN_IF_ERROR(loom_output_stream_write_cstring(stream, ","));
   IREE_RETURN_IF_ERROR(loomc_compile_write_json_string_field(
       stream, "module_name", module_name));
-  IREE_RETURN_IF_ERROR(
-      loom_output_stream_write_format(stream, ",\"config_binding_count\":%zu",
-                                      (size_t)config_options->binding_count));
   IREE_RETURN_IF_ERROR(loom_output_stream_write_format(
-      stream, ",\"has_config_json\":%s",
-      loomc_string_view_is_empty(config_options->json_object) ? "false"
-                                                              : "true"));
+      stream, ",\"has_config_module\":%s",
+      options != NULL && options->config_module != NULL ? "true" : "false"));
   IREE_RETURN_IF_ERROR(loom_output_stream_write_format(
-      stream, ",\"config_flags\":%u", (unsigned)config_options->flags));
+      stream, ",\"config_definition_count\":%zu",
+      (size_t)(config_materialized_count + config_ignored_count)));
+  IREE_RETURN_IF_ERROR(loom_output_stream_write_format(
+      stream, ",\"config_materialized_count\":%zu",
+      (size_t)config_materialized_count));
+  IREE_RETURN_IF_ERROR(loom_output_stream_write_format(
+      stream, ",\"config_ignored_count\":%zu", (size_t)config_ignored_count));
+  IREE_RETURN_IF_ERROR(loom_output_stream_write_format(
+      stream, ",\"config_flags\":%u", (unsigned)config_flags));
   IREE_RETURN_IF_ERROR(loom_output_stream_write_format(
       stream, ",\"target_specialization_count\":%zu",
       target_options ? (size_t)target_options->specialization_count : 0));
@@ -385,6 +416,7 @@ static iree_status_t loomc_compile_write_report_json(
 static loomc_status_t loomc_compile_add_report_json_artifact(
     loomc_result_t* result, const loomc_compile_options_t* options,
     const loomc_target_specialization_options_t* target_options,
+    const loomc_config_application_result_t* config_application,
     loomc_host_size_t artifact_count) {
   loomc_allocator_t allocator = loomc_result_allocator(result);
 
@@ -395,7 +427,8 @@ static loomc_status_t loomc_compile_add_report_json_artifact(
   loom_output_stream_for_builder(&builder, &stream);
   loomc_status_t status =
       loomc_status_from_iree(loomc_compile_write_report_json(
-          options, result, target_options, artifact_count, &stream));
+          options, result, target_options, config_application, artifact_count,
+          &stream));
 
   char* report_storage = NULL;
   iree_host_size_t report_length = 0;
@@ -429,6 +462,7 @@ static loomc_status_t loomc_compile_add_report_json_artifact(
 static loomc_status_t loomc_compile_emit_requested_artifacts(
     loomc_result_t* result, const loomc_compile_options_t* options,
     const loomc_target_specialization_options_t* target_options,
+    const loomc_config_application_result_t* config_application,
     const loomc_module_t* module, const loom_module_t* launch_config_module) {
   const loomc_compile_artifact_flags_t artifact_flags =
       options ? options->artifact_flags : 0;
@@ -465,7 +499,8 @@ static loomc_status_t loomc_compile_emit_requested_artifacts(
       iree_any_bit_set(artifact_flags,
                        LOOMC_COMPILE_ARTIFACT_FLAG_REPORT_JSON)) {
     status = loomc_compile_add_report_json_artifact(
-        result, options, target_options, loomc_result_artifact_count(result));
+        result, options, target_options, config_application,
+        loomc_result_artifact_count(result));
   }
   return status;
 }
@@ -548,22 +583,23 @@ static loomc_status_t loomc_compile_module_into_result(
       iree_any_bit_set(options->artifact_flags,
                        LOOMC_COMPILE_ARTIFACT_FLAG_LAUNCH_CONFIG);
   const loom_module_t* launch_config_module = NULL;
+  loomc_config_application_result_t config_application = {0};
 
   loomc_status_t status =
       loomc_result_verify_loom_module(internal_module, /*source=*/NULL, result);
   if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
-    const loomc_config_options_t empty_config_options = {0};
-    const loomc_config_options_t* config_options =
-        options ? &options->config : &empty_config_options;
-    loomc_config_apply_to_module_options_t config_apply_options = {
-        .config = config_options,
-        .module = internal_module,
+    const loomc_module_t* config_module =
+        options ? options->config_module : NULL;
+    loomc_config_apply_module_options_t config_apply_options = {
+        .config_module = loomc_module_const_loom_module(config_module),
+        .target_module = internal_module,
+        .policy_flags = options ? options->config_flags : 0,
         .result = result,
         .diagnostic_code = loomc_make_cstring_view("CONFIG/INVALID"),
         .block_pool = loomc_workspace_block_pool(workspace),
-        .allocator = loomc_result_allocator(result),
     };
-    status = loomc_config_apply_to_module(&config_apply_options);
+    status =
+        loomc_config_apply_module(&config_apply_options, &config_application);
   }
   if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
     status = loomc_compile_specialize_functions(
@@ -600,7 +636,8 @@ static loomc_status_t loomc_compile_module_into_result(
   }
   if (loomc_status_is_ok(status)) {
     status = loomc_compile_emit_requested_artifacts(
-        result, options, target_specialization, module, launch_config_module);
+        result, options, target_specialization, &config_application, module,
+        launch_config_module);
   }
   if (!loomc_status_is_ok(status) || !loomc_result_succeeded(result)) {
     loomc_module_prepare_function_versions(module);
@@ -664,14 +701,16 @@ loomc_status_t loomc_compile_module(loomc_compiler_t* compiler,
     return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
                              "pass program was created with another context");
   }
+  const loomc_target_specialization_options_t* target_specialization = NULL;
+  LOOMC_RETURN_IF_ERROR(loomc_compile_resolve_target_specialization(
+      compiler, options, &target_specialization));
   loom_module_t* internal_module = loomc_module_loom_module(module);
   if (internal_module == NULL) {
     return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
                              "module does not contain internal IR");
   }
-  const loomc_target_specialization_options_t* target_specialization = NULL;
-  LOOMC_RETURN_IF_ERROR(loomc_compile_resolve_target_specialization(
-      compiler, options, &target_specialization));
+  LOOMC_RETURN_IF_ERROR(
+      loomc_compile_validate_config_module(compiler, module, options));
 
   loomc_result_t* result = NULL;
   LOOMC_RETURN_IF_ERROR(
@@ -735,6 +774,8 @@ loomc_status_t loomc_compile_request(
   const loomc_target_specialization_options_t* target_specialization = NULL;
   LOOMC_RETURN_IF_ERROR(loomc_compile_resolve_target_specialization(
       compiler, options, &target_specialization));
+  LOOMC_RETURN_IF_ERROR(
+      loomc_compile_validate_config_module(compiler, NULL, options));
 
   loomc_module_t* module = NULL;
   loomc_result_t* result = NULL;

--- a/loom/binding/c/src/config.c
+++ b/loom/binding/c/src/config.c
@@ -10,137 +10,44 @@
 #include "loom/tooling/config/config.h"
 #include "loomc/iree.h"
 
-static loomc_status_t loomc_config_validate_string_view(
-    loomc_string_view_t value) {
-  if (value.data == NULL && value.size != 0) {
-    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
-                             "string view has length but no data");
-  }
-  return loomc_ok_status();
-}
-
-static bool loomc_config_options_empty(const loomc_config_options_t* options) {
-  return options == NULL || (options->binding_count == 0 &&
-                             loomc_string_view_is_empty(options->json_object) &&
-                             options->flags == 0);
-}
-
-loomc_status_t loomc_config_validate_options(
-    const loomc_config_options_t* options) {
-  if (options == NULL) {
-    return loomc_ok_status();
-  }
-  if (options->binding_count != 0 && options->bindings == NULL) {
-    return loomc_make_status(
-        LOOMC_STATUS_INVALID_ARGUMENT,
-        "config binding_count is non-zero but bindings is NULL");
-  }
-  for (loomc_host_size_t i = 0; i < options->binding_count; ++i) {
-    LOOMC_RETURN_IF_ERROR(
-        loomc_config_validate_string_view(options->bindings[i].key));
-    LOOMC_RETURN_IF_ERROR(
-        loomc_config_validate_string_view(options->bindings[i].value));
-  }
-  LOOMC_RETURN_IF_ERROR(
-      loomc_config_validate_string_view(options->json_object));
+loomc_status_t loomc_config_validate_policy_flags(
+    loomc_config_policy_flags_t flags) {
   const loomc_config_policy_flags_t known_flags =
       LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
-  if ((options->flags & ~known_flags) != 0) {
+  if ((flags & ~known_flags) != 0) {
     return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
-                             "config options contain unknown flag bits");
+                             "config policy contains unknown flag bits");
   }
   return loomc_ok_status();
 }
 
-static iree_string_view_t loomc_config_normalize_key(loomc_string_view_t key) {
-  iree_string_view_t normalized_key = iree_string_view_from_loomc(key);
-  normalized_key = iree_string_view_trim(normalized_key);
-  (void)iree_string_view_consume_prefix_char(&normalized_key, '@');
-  return iree_string_view_trim(normalized_key);
-}
+loomc_status_t loomc_config_apply_module(
+    const loomc_config_apply_module_options_t* options,
+    loomc_config_application_result_t* out_application_result) {
+  *out_application_result = (loomc_config_application_result_t){0};
 
-static bool loomc_config_binding_overrides_json(
-    const loomc_config_options_t* options,
-    const loom_tooling_config_binding_t* json_binding) {
-  for (loomc_host_size_t i = 0; i < options->binding_count; ++i) {
-    iree_string_view_t binding_key =
-        loomc_config_normalize_key(options->bindings[i].key);
-    if (iree_string_view_equal(binding_key, json_binding->key)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-static iree_status_t loomc_config_populate_set(
-    const loomc_config_options_t* options, iree_allocator_t host_allocator,
-    loom_tooling_config_set_t* config_set) {
-  loom_tooling_config_set_t json_config_set;
-  loom_tooling_config_set_initialize(host_allocator, &json_config_set);
-
-  iree_status_t status = iree_ok_status();
-  if (!loomc_string_view_is_empty(options->json_object)) {
-    status = loom_tooling_config_set_append_json_object(
-        &json_config_set, iree_string_view_from_loomc(options->json_object));
-  }
-  for (iree_host_size_t i = 0;
-       i < json_config_set.binding_count && iree_status_is_ok(status); ++i) {
-    const loom_tooling_config_binding_t* binding = &json_config_set.bindings[i];
-    if (loomc_config_binding_overrides_json(options, binding)) {
-      continue;
-    }
-    status = loom_tooling_config_set_append(config_set, binding->key,
-                                            binding->value);
-  }
-  for (loomc_host_size_t i = 0;
-       i < options->binding_count && iree_status_is_ok(status); ++i) {
-    status = loom_tooling_config_set_append(
-        config_set, iree_string_view_from_loomc(options->bindings[i].key),
-        iree_string_view_from_loomc(options->bindings[i].value));
-  }
-
-  loom_tooling_config_set_deinitialize(&json_config_set);
-  return status;
-}
-
-loomc_status_t loomc_config_apply_to_module(
-    const loomc_config_apply_to_module_options_t* options) {
-  if (options == NULL || options->module == NULL || options->result == NULL ||
-      options->block_pool == NULL) {
-    return loomc_make_status(
-        LOOMC_STATUS_INVALID_ARGUMENT,
-        "config application requires options, module, result, and block_pool");
-  }
-  if (loomc_config_options_empty(options->config)) {
-    return loomc_ok_status();
-  }
-
-  iree_allocator_t host_allocator =
-      iree_allocator_from_loomc(options->allocator);
-  loom_tooling_config_set_t config_set;
-  loom_tooling_config_set_initialize(host_allocator, &config_set);
-
-  loomc_status_t status = loomc_status_from_iree(
-      loomc_config_populate_set(options->config, host_allocator, &config_set));
   loom_tooling_config_materialize_result_t materialize_result = {0};
-  if (loomc_status_is_ok(status)) {
-    loom_tooling_config_materialize_options_t materialize_options;
-    loom_tooling_config_materialize_options_initialize(&materialize_options);
-    materialize_options.config_set = &config_set;
-    status = loomc_status_from_iree(loom_tooling_config_materialize_module(
-        options->module, &materialize_options, options->block_pool,
-        &materialize_result));
-  }
-  if (loomc_status_is_ok(status) &&
-      materialize_result.materialized_count != 0) {
-    status = loomc_result_verify_loom_module(options->module, /*source=*/NULL,
-                                             options->result);
+  loomc_status_t status = loomc_ok_status();
+  if (options->config_module != NULL) {
+    status = loomc_result_verify_loom_module(options->config_module,
+                                             /*source=*/NULL, options->result);
   }
   if (loomc_status_is_ok(status) && loomc_result_succeeded(options->result) &&
-      iree_any_bit_set(options->config->flags,
+      options->config_module != NULL) {
+    status = loomc_status_from_iree(loom_tooling_config_overlay_module(
+        options->target_module, options->config_module, options->block_pool,
+        &materialize_result));
+  }
+  if (loomc_status_is_ok(status) && loomc_result_succeeded(options->result) &&
+      materialize_result.materialized_count != 0) {
+    status = loomc_result_verify_loom_module(options->target_module,
+                                             /*source=*/NULL, options->result);
+  }
+  if (loomc_status_is_ok(status) && loomc_result_succeeded(options->result) &&
+      iree_any_bit_set(options->policy_flags,
                        LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED)) {
-    status = loomc_status_from_iree(
-        loom_tooling_config_require_resolved_module(options->module, NULL));
+    status = loomc_status_from_iree(loom_tooling_config_require_resolved_module(
+        options->target_module, /*out_result=*/NULL));
   }
   if (!loomc_status_is_ok(status) &&
       loomc_status_is_result_diagnostic(status)) {
@@ -149,10 +56,14 @@ loomc_status_t loomc_config_apply_to_module(
       diagnostic_code = loomc_make_cstring_view("CONFIG/INVALID");
     }
     status = loomc_result_fail_status_diagnostic_consume(
-        options->result, NULL, LOOMC_DIAGNOSTIC_SEVERITY_ERROR, diagnostic_code,
-        status);
+        options->result, /*source=*/NULL, LOOMC_DIAGNOSTIC_SEVERITY_ERROR,
+        diagnostic_code, status);
   }
-
-  loom_tooling_config_set_deinitialize(&config_set);
+  if (loomc_status_is_ok(status)) {
+    *out_application_result = (loomc_config_application_result_t){
+        .materialized_count = materialize_result.materialized_count,
+        .ignored_count = materialize_result.ignored_count,
+    };
+  }
   return status;
 }

--- a/loom/binding/c/src/config.h
+++ b/loom/binding/c/src/config.h
@@ -18,9 +18,39 @@
 extern "C" {
 #endif
 
-// Module config application options.
-typedef struct loomc_config_apply_to_module_options_t {
-  // Public per-invocation config options to materialize.
+// Structured config module application summary.
+typedef struct loomc_config_application_result_t {
+  // Number of definitions applied to matching target symbols.
+  loomc_host_size_t materialized_count;
+
+  // Number of definitions ignored because no matching config symbol exists.
+  loomc_host_size_t ignored_count;
+} loomc_config_application_result_t;
+
+// Structured config module application options.
+typedef struct loomc_config_apply_module_options_t {
+  // Typed config definitions to overlay, or NULL to apply only policy.
+  const loom_module_t* config_module;
+
+  // Module receiving exact config values.
+  loom_module_t* target_module;
+
+  // Final config validation and resolution policy.
+  loomc_config_policy_flags_t policy_flags;
+
+  // Result receiving config diagnostics.
+  loomc_result_t* result;
+
+  // Diagnostic code used when config-domain statuses become result diagnostics.
+  loomc_string_view_t diagnostic_code;
+
+  // Block pool for transient cross-module remapping storage.
+  iree_arena_block_pool_t* block_pool;
+} loomc_config_apply_module_options_t;
+
+// Text and JSON config application options.
+typedef struct loomc_config_apply_text_to_module_options_t {
+  // Public text and JSON config options to materialize.
   const loomc_config_options_t* config;
 
   // Module receiving config materialization.
@@ -37,15 +67,24 @@ typedef struct loomc_config_apply_to_module_options_t {
 
   // Host allocator used for transient config set storage.
   loomc_allocator_t allocator;
-} loomc_config_apply_to_module_options_t;
+} loomc_config_apply_text_to_module_options_t;
 
-// Validates config descriptor shape and borrowed string views.
+// Validates config policy flags shared by all input representations.
 LOOMC_API_PRIVATE loomc_status_t
-loomc_config_validate_options(const loomc_config_options_t* options);
+loomc_config_validate_policy_flags(loomc_config_policy_flags_t flags);
 
-// Applies per-invocation config to a module and records config diagnostics.
-LOOMC_API_PRIVATE loomc_status_t loomc_config_apply_to_module(
-    const loomc_config_apply_to_module_options_t* options);
+// Applies exact definitions from a typed config module and records diagnostics.
+LOOMC_API_PRIVATE loomc_status_t loomc_config_apply_module(
+    const loomc_config_apply_module_options_t* options,
+    loomc_config_application_result_t* out_application_result);
+
+// Validates text config descriptor shape and borrowed string views.
+LOOMC_API_PRIVATE loomc_status_t
+loomc_config_validate_text_options(const loomc_config_options_t* options);
+
+// Applies text and JSON config to a module and records config diagnostics.
+LOOMC_API_PRIVATE loomc_status_t loomc_config_apply_text_to_module(
+    const loomc_config_apply_text_to_module_options_t* options);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/loom/binding/c/src/config_text.c
+++ b/loom/binding/c/src/config_text.c
@@ -1,0 +1,145 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "config.h"
+#include "diagnostic.h"
+#include "loom/tooling/config/config.h"
+#include "loomc/iree.h"
+
+static loomc_status_t loomc_config_validate_string_view(
+    loomc_string_view_t value) {
+  if (value.data == NULL && value.size != 0) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "string view has length but no data");
+  }
+  return loomc_ok_status();
+}
+
+static bool loomc_config_options_empty(const loomc_config_options_t* options) {
+  return options == NULL || (options->binding_count == 0 &&
+                             loomc_string_view_is_empty(options->json_object) &&
+                             options->flags == 0);
+}
+
+loomc_status_t loomc_config_validate_text_options(
+    const loomc_config_options_t* options) {
+  if (options == NULL) {
+    return loomc_ok_status();
+  }
+  if (options->binding_count != 0 && options->bindings == NULL) {
+    return loomc_make_status(
+        LOOMC_STATUS_INVALID_ARGUMENT,
+        "config binding_count is non-zero but bindings is NULL");
+  }
+  for (loomc_host_size_t i = 0; i < options->binding_count; ++i) {
+    LOOMC_RETURN_IF_ERROR(
+        loomc_config_validate_string_view(options->bindings[i].key));
+    LOOMC_RETURN_IF_ERROR(
+        loomc_config_validate_string_view(options->bindings[i].value));
+  }
+  LOOMC_RETURN_IF_ERROR(
+      loomc_config_validate_string_view(options->json_object));
+  return loomc_config_validate_policy_flags(options->flags);
+}
+
+static iree_string_view_t loomc_config_normalize_key(loomc_string_view_t key) {
+  iree_string_view_t normalized_key = iree_string_view_from_loomc(key);
+  normalized_key = iree_string_view_trim(normalized_key);
+  (void)iree_string_view_consume_prefix_char(&normalized_key, '@');
+  return iree_string_view_trim(normalized_key);
+}
+
+static bool loomc_config_binding_overrides_json(
+    const loomc_config_options_t* options,
+    const loom_tooling_config_binding_t* json_binding) {
+  for (loomc_host_size_t i = 0; i < options->binding_count; ++i) {
+    iree_string_view_t binding_key =
+        loomc_config_normalize_key(options->bindings[i].key);
+    if (iree_string_view_equal(binding_key, json_binding->key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static iree_status_t loomc_config_populate_set(
+    const loomc_config_options_t* options, iree_allocator_t host_allocator,
+    loom_tooling_config_set_t* config_set) {
+  loom_tooling_config_set_t json_config_set;
+  loom_tooling_config_set_initialize(host_allocator, &json_config_set);
+
+  iree_status_t status = iree_ok_status();
+  if (!loomc_string_view_is_empty(options->json_object)) {
+    status = loom_tooling_config_set_append_json_object(
+        &json_config_set, iree_string_view_from_loomc(options->json_object));
+  }
+  for (iree_host_size_t i = 0;
+       i < json_config_set.binding_count && iree_status_is_ok(status); ++i) {
+    const loom_tooling_config_binding_t* binding = &json_config_set.bindings[i];
+    if (loomc_config_binding_overrides_json(options, binding)) {
+      continue;
+    }
+    status = loom_tooling_config_set_append(config_set, binding->key,
+                                            binding->value);
+  }
+  for (loomc_host_size_t i = 0;
+       i < options->binding_count && iree_status_is_ok(status); ++i) {
+    status = loom_tooling_config_set_append(
+        config_set, iree_string_view_from_loomc(options->bindings[i].key),
+        iree_string_view_from_loomc(options->bindings[i].value));
+  }
+
+  loom_tooling_config_set_deinitialize(&json_config_set);
+  return status;
+}
+
+loomc_status_t loomc_config_apply_text_to_module(
+    const loomc_config_apply_text_to_module_options_t* options) {
+  if (loomc_config_options_empty(options->config)) {
+    return loomc_ok_status();
+  }
+
+  iree_allocator_t host_allocator =
+      iree_allocator_from_loomc(options->allocator);
+  loom_tooling_config_set_t config_set;
+  loom_tooling_config_set_initialize(host_allocator, &config_set);
+
+  loomc_status_t status = loomc_status_from_iree(
+      loomc_config_populate_set(options->config, host_allocator, &config_set));
+  loom_tooling_config_materialize_result_t materialize_result = {0};
+  if (loomc_status_is_ok(status)) {
+    loom_tooling_config_materialize_options_t materialize_options;
+    loom_tooling_config_materialize_options_initialize(&materialize_options);
+    materialize_options.config_set = &config_set;
+    status = loomc_status_from_iree(loom_tooling_config_materialize_module(
+        options->module, &materialize_options, options->block_pool,
+        &materialize_result));
+  }
+  if (loomc_status_is_ok(status) &&
+      materialize_result.materialized_count != 0) {
+    status = loomc_result_verify_loom_module(options->module, /*source=*/NULL,
+                                             options->result);
+  }
+  if (loomc_status_is_ok(status) && loomc_result_succeeded(options->result) &&
+      iree_any_bit_set(options->config->flags,
+                       LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED)) {
+    status = loomc_status_from_iree(
+        loom_tooling_config_require_resolved_module(options->module, NULL));
+  }
+  if (!loomc_status_is_ok(status) &&
+      loomc_status_is_result_diagnostic(status)) {
+    loomc_string_view_t diagnostic_code = options->diagnostic_code;
+    if (loomc_string_view_is_empty(diagnostic_code)) {
+      diagnostic_code = loomc_make_cstring_view("CONFIG/INVALID");
+    }
+    status = loomc_result_fail_status_diagnostic_consume(
+        options->result, NULL, LOOMC_DIAGNOSTIC_SEVERITY_ERROR, diagnostic_code,
+        status);
+  }
+
+  loom_tooling_config_set_deinitialize(&config_set);
+  return status;
+}

--- a/loom/binding/c/src/link.c
+++ b/loom/binding/c/src/link.c
@@ -139,7 +139,7 @@ static loomc_status_t loomc_link_validate_options(
       loomc_target_specialization_options_validate_environment(
           *out_target_specialization,
           loomc_context_target_environment(linker->context)));
-  return loomc_config_validate_options(&options->config);
+  return loomc_config_validate_text_options(&options->config);
 }
 
 static loomc_status_t loomc_link_validate_request_options(
@@ -196,7 +196,7 @@ static loomc_status_t loomc_link_validate_request_options(
       loomc_target_specialization_options_validate_environment(
           *out_target_specialization,
           loomc_context_target_environment(linker->context)));
-  return loomc_config_validate_options(&options->config);
+  return loomc_config_validate_text_options(&options->config);
 }
 
 static loomc_status_t loomc_link_result_set_failed(loomc_result_t* result) {

--- a/loom/binding/c/src/link_materialization.c
+++ b/loom/binding/c/src/link_materialization.c
@@ -57,7 +57,7 @@ static iree_status_t loomc_link_materialization_prepare_module(
     iree_allocator_t allocator, loom_module_t** inout_module) {
   loomc_link_materialization_state_t* state =
       (loomc_link_materialization_state_t*)user_data;
-  const loomc_config_apply_to_module_options_t apply_options = {
+  const loomc_config_apply_text_to_module_options_t apply_options = {
       .config = state->specialization.config,
       .module = *inout_module,
       .result = state->diagnostics.result,
@@ -65,7 +65,7 @@ static iree_status_t loomc_link_materialization_prepare_module(
       .block_pool = block_pool,
       .allocator = loomc_allocator_from_iree(allocator),
   };
-  loomc_status_t status = loomc_config_apply_to_module(&apply_options);
+  loomc_status_t status = loomc_config_apply_text_to_module(&apply_options);
   if (!loomc_status_is_ok(status)) {
     return iree_status_from_loomc(status);
   }

--- a/loom/binding/c/target/cmd/program.c
+++ b/loom/binding/c/target/cmd/program.c
@@ -152,7 +152,7 @@ static loomc_status_t loomc_cmd_program_product_validate_options(
           *out_target_specialization,
           loomc_context_target_environment(
               loomc_link_index_context(options->link_index))));
-  return loomc_config_validate_options(&options->config);
+  return loomc_config_validate_text_options(&options->config);
 }
 
 static loomc_status_t loomc_cmd_program_product_validate_request_options(
@@ -220,7 +220,7 @@ static loomc_status_t loomc_cmd_program_product_validate_request_options(
       loomc_target_specialization_options_validate_environment(
           *out_target_specialization,
           loomc_context_target_environment(context)));
-  return loomc_config_validate_options(&options->config);
+  return loomc_config_validate_text_options(&options->config);
 }
 
 static bool loomc_cmd_program_product_symbol_is_command_root(

--- a/loom/binding/c/test/compile_test.cc
+++ b/loom/binding/c/test/compile_test.cc
@@ -283,8 +283,8 @@ func.def public @entry(%x: i32) -> (i32) {
   return DeserializeModule(context, workspace, source.get());
 }
 
-ModulePtr CreateConfigModule(loomc_context_t* context,
-                             loomc_workspace_t* workspace) {
+ModulePtr CreateConfigConsumerModule(loomc_context_t* context,
+                                     loomc_workspace_t* workspace) {
   SourcePtr source = CreateTextSource("config.loom", R"(
 config.decl @model36.model.hidden_size : %value: index where [range(%value, 0, 8192), mul(%value, 16)]
 
@@ -294,6 +294,29 @@ func.def public @entry() -> (index) {
 }
 )");
   return DeserializeModule(context, workspace, source.get());
+}
+
+ModulePtr CreateConfigProviderModule(loomc_context_t* context,
+                                     loomc_workspace_t* workspace,
+                                     const char* contents) {
+  SourcePtr source = CreateTextSource("config-provider.loom", contents);
+  return DeserializeModule(context, workspace, source.get());
+}
+
+ModulePtr RoundTripModuleThroughBytecode(loomc_context_t* context,
+                                         loomc_workspace_t* workspace,
+                                         ModulePtr module) {
+  SourcePtr source = SerializeModuleToBytecode(module.get(), "config.loombc");
+  module.reset();
+  loomc_module_t* round_tripped_module = nullptr;
+  loomc_result_t* result = nullptr;
+  loomc_status_t status = loomc_module_deserialize_bytecode_from_source(
+      context, workspace, source.get(), /*options=*/nullptr,
+      loomc_allocator_system(), &round_tripped_module, &result);
+  LOOMC_EXPECT_OK(status);
+  ResultPtr result_ptr(result);
+  EXPECT_TRUE(loomc_result_succeeded(result_ptr.get()));
+  return ModulePtr(round_tripped_module);
 }
 
 TEST(CompileTest, CompilerRetainRelease) {
@@ -311,24 +334,14 @@ TEST(CompileTest, CompileModuleRunsPreparedPassProgram) {
       CreatePassProgramFromPipelineText(context.get(), "canonicalize,dce");
   ModulePtr module = CreateValidModule(context.get(), workspace.get());
 
-  loomc_config_binding_t bindings[] = {
-      {
-          /*.key=*/loomc_make_cstring_view("tile_m"),
-          /*.value=*/loomc_make_cstring_view("128"),
-      },
-  };
   loomc_compile_options_t options = {
       /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
       /*.structure_size=*/sizeof(options),
       /*.next=*/nullptr,
       /*.module_name=*/loomc_make_cstring_view("jit_kernel"),
       /*.artifact_flags=*/0,
-      /*.config=*/
-      {
-          /*.bindings=*/bindings,
-          /*.binding_count=*/1,
-          /*.json_object=*/loomc_make_cstring_view("{\"tile_n\":\"64\"}"),
-      },
+      /*.config_flags=*/0,
+      /*.config_module=*/nullptr,
   };
   loomc_result_t* result = nullptr;
   loomc_status_t status = loomc_compile_module(
@@ -381,37 +394,28 @@ pass.pipeline<module> @finish pipeline {
   EXPECT_EQ(loomc_result_artifact_count(result_ptr.get()), 0u);
 }
 
-TEST(CompileTest, CompileModuleMaterializesInvocationConfig) {
+TEST(CompileTest, CompileModuleAppliesBytecodeConfigModule) {
   ContextPtr context = CreateContext();
   WorkspacePtr workspace = CreateWorkspace();
   CompilerPtr compiler = CreateCompiler(context.get());
   PassProgramPtr pass_program = CreateEmptyPassProgram(context.get());
-  ModulePtr module = CreateConfigModule(context.get(), workspace.get());
-
-  loomc_config_binding_t bindings[] = {
-      {
-          /*.key=*/loomc_make_cstring_view("@model36.model.hidden_size"),
-          /*.value=*/loomc_make_cstring_view("4096"),
-      },
-  };
+  ModulePtr module = CreateConfigConsumerModule(context.get(), workspace.get());
+  ModulePtr config_module = RoundTripModuleThroughBytecode(
+      context.get(), workspace.get(),
+      CreateConfigProviderModule(context.get(), workspace.get(), R"(
+config.def @model36.model.hidden_size = 4096 : index
+config.def @model36.unused = 1 : index
+)"));
+  const std::string config_text_before =
+      SerializeModuleToText(config_module.get());
   loomc_compile_options_t options = {
       /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
       /*.structure_size=*/sizeof(options),
       /*.next=*/nullptr,
       /*.module_name=*/loomc_string_view_empty(),
       /*.artifact_flags=*/0,
-      /*.config=*/
-      {
-          /*.bindings=*/bindings,
-          /*.binding_count=*/1,
-          /*.json_object=*/loomc_make_cstring_view(R"({
-                "model36": {
-                  "model": {"hidden_size": 2048},
-                  "unused": 1
-                }
-              })"),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-      },
+      /*.config_flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+      /*.config_module=*/config_module.get(),
   };
   loomc_result_t* result = nullptr;
   loomc_status_t status = loomc_compile_module(
@@ -420,13 +424,14 @@ TEST(CompileTest, CompileModuleMaterializesInvocationConfig) {
   LOOMC_EXPECT_OK(status);
   ResultPtr result_ptr(result);
   ExpectSucceededResult(result_ptr.get());
+  EXPECT_EQ(SerializeModuleToText(config_module.get()), config_text_before);
 
+  config_module.reset();
   std::string text = SerializeModuleToText(module.get());
   EXPECT_NE(text.find("config.def @model36.model.hidden_size = 4096 : index"),
             std::string::npos);
   EXPECT_EQ(text.find("config.decl @model36.model.hidden_size"),
             std::string::npos);
-  EXPECT_EQ(text.find("2048"), std::string::npos);
 }
 
 TEST(CompileTest, CompileModuleEmitsRequestedArtifacts) {
@@ -434,14 +439,10 @@ TEST(CompileTest, CompileModuleEmitsRequestedArtifacts) {
   WorkspacePtr workspace = CreateWorkspace();
   CompilerPtr compiler = CreateCompiler(context.get());
   PassProgramPtr pass_program = CreateEmptyPassProgram(context.get());
-  ModulePtr module = CreateConfigModule(context.get(), workspace.get());
-
-  loomc_config_binding_t bindings[] = {
-      {
-          /*.key=*/loomc_make_cstring_view("@model36.model.hidden_size"),
-          /*.value=*/loomc_make_cstring_view("4096"),
-      },
-  };
+  ModulePtr module = CreateConfigConsumerModule(context.get(), workspace.get());
+  ModulePtr config_module = CreateConfigProviderModule(
+      context.get(), workspace.get(),
+      "config.def @model36.model.hidden_size = 4096 : index\n");
   loomc_compile_options_t options = {
       /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
       /*.structure_size=*/sizeof(options),
@@ -450,13 +451,8 @@ TEST(CompileTest, CompileModuleEmitsRequestedArtifacts) {
       /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_TEXT |
           LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_BYTECODE |
           LOOMC_COMPILE_ARTIFACT_FLAG_REPORT_JSON,
-      /*.config=*/
-      {
-          /*.bindings=*/bindings,
-          /*.binding_count=*/1,
-          /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-      },
+      /*.config_flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+      /*.config_module=*/config_module.get(),
   };
   loomc_result_t* result = nullptr;
   loomc_status_t status = loomc_compile_module(
@@ -505,7 +501,10 @@ TEST(CompileTest, CompileModuleEmitsRequestedArtifacts) {
   EXPECT_NE(report.find(R"("kind":"loomc.compile")"), std::string::npos);
   EXPECT_NE(report.find(R"("state":"succeeded")"), std::string::npos);
   EXPECT_NE(report.find(R"("artifact_count":2)"), std::string::npos);
-  EXPECT_NE(report.find(R"("config_binding_count":1)"), std::string::npos);
+  EXPECT_NE(report.find(R"("has_config_module":true)"), std::string::npos);
+  EXPECT_NE(report.find(R"("config_definition_count":1)"), std::string::npos);
+  EXPECT_NE(report.find(R"("config_materialized_count":1)"), std::string::npos);
+  EXPECT_NE(report.find(R"("config_ignored_count":0)"), std::string::npos);
 }
 
 TEST(CompileTest, CompileRequestReturnsOwnedProduct) {
@@ -551,6 +550,53 @@ TEST(CompileTest, CompileRequestReturnsOwnedProduct) {
   EXPECT_NE(loomc_byte_sequence_length(artifact->contents), 0u);
 }
 
+TEST(CompileTest, CompileRequestAppliesSharedConfigModule) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  CompilerPtr compiler = CreateCompiler(context.get());
+  PassProgramPtr pass_program = CreateEmptyPassProgram(context.get());
+  ModulePtr module = CreateConfigConsumerModule(context.get(), workspace.get());
+  RequestPtr request = CreateSingleRootRequest(
+      SerializeModuleToBytecode(module.get(), "configured-request.loombc"));
+  module.reset();
+  ModulePtr config_module = RoundTripModuleThroughBytecode(
+      context.get(), workspace.get(),
+      CreateConfigProviderModule(context.get(), workspace.get(), R"(
+config.def @model36.model.hidden_size = 4096 : index
+)"));
+
+  loomc_compile_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
+      /*.structure_size=*/sizeof(options),
+      /*.next=*/nullptr,
+      /*.module_name=*/loomc_make_cstring_view("configured-request"),
+      /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_TEXT,
+      /*.config_flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+      /*.config_module=*/config_module.get(),
+  };
+  loomc_product_t* product = nullptr;
+  loomc_result_t* result = nullptr;
+  loomc_status_t status = loomc_compile_request(
+      compiler.get(), workspace.get(), pass_program.get(), request.get(),
+      &options, loomc_allocator_system(), &product, &result);
+  LOOMC_EXPECT_OK(status);
+  ProductPtr product_ptr(product);
+  ResultPtr result_ptr(result);
+  ExpectSucceededResult(result_ptr.get());
+  ASSERT_NE(product_ptr.get(), nullptr);
+  ASSERT_EQ(loomc_product_artifact_count(product_ptr.get()), 1u);
+
+  config_module.reset();
+  const loomc_artifact_t* artifact =
+      loomc_product_artifact_at(product_ptr.get(), 0);
+  ASSERT_NE(artifact, nullptr);
+  const std::string text = ToString(artifact->contents);
+  EXPECT_NE(text.find("config.def @model36.model.hidden_size = 4096 : index"),
+            std::string::npos);
+  EXPECT_EQ(text.find("config.decl @model36.model.hidden_size"),
+            std::string::npos);
+}
+
 TEST(CompileTest, CompileRequestRejectsUnavailableRoots) {
   ContextPtr context = CreateContext();
   WorkspacePtr workspace = CreateWorkspace();
@@ -571,8 +617,7 @@ TEST(CompileTest, CompileRequestRejectsUnavailableRoots) {
     loomc_status_t status = loomc_compile_request(
         compiler.get(), workspace.get(), pass_program.get(), request.get(),
         /*options=*/nullptr, loomc_allocator_system(), &product, &result);
-    EXPECT_EQ(loomc_status_code(status), LOOMC_STATUS_INVALID_ARGUMENT);
-    loomc_status_free(status);
+    LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_INVALID_ARGUMENT, status);
     EXPECT_EQ(product, nullptr);
     EXPECT_EQ(result, nullptr);
   }
@@ -593,8 +638,7 @@ TEST(CompileTest, CompileRequestRejectsAnotherProductContract) {
   loomc_status_t status = loomc_compile_request(
       compiler.get(), workspace.get(), pass_program.get(), request.get(),
       /*options=*/nullptr, loomc_allocator_system(), &product, &result);
-  EXPECT_EQ(loomc_status_code(status), LOOMC_STATUS_INVALID_ARGUMENT);
-  loomc_status_free(status);
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_INVALID_ARGUMENT, status);
   EXPECT_EQ(product, nullptr);
   EXPECT_EQ(result, nullptr);
 }
@@ -638,26 +682,16 @@ TEST(CompileTest, CompileModuleIgnoresUnusedConfig) {
   CompilerPtr compiler = CreateCompiler(context.get());
   PassProgramPtr pass_program = CreateEmptyPassProgram(context.get());
   ModulePtr module = CreateValidModule(context.get(), workspace.get());
-
-  loomc_config_binding_t bindings[] = {
-      {
-          /*.key=*/loomc_make_cstring_view("tile_m"),
-          /*.value=*/loomc_make_cstring_view("128"),
-      },
-  };
+  ModulePtr config_module = CreateConfigProviderModule(
+      context.get(), workspace.get(), "config.def @tile_m = 128 : index\n");
   loomc_compile_options_t options = {
       /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
       /*.structure_size=*/sizeof(options),
       /*.next=*/nullptr,
       /*.module_name=*/loomc_string_view_empty(),
       /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_REPORT_JSON,
-      /*.config=*/
-      {
-          /*.bindings=*/bindings,
-          /*.binding_count=*/1,
-          /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/0,
-      },
+      /*.config_flags=*/0,
+      /*.config_module=*/config_module.get(),
   };
   loomc_result_t* result = nullptr;
   loomc_status_t status = loomc_compile_module(
@@ -673,7 +707,9 @@ TEST(CompileTest, CompileModuleIgnoresUnusedConfig) {
   std::string report = ToString(report_artifact->contents);
   EXPECT_NE(report.find(R"("state":"succeeded")"), std::string::npos);
   EXPECT_NE(report.find(R"("diagnostic_count":0)"), std::string::npos);
-  EXPECT_NE(report.find(R"("config_binding_count":1)"), std::string::npos);
+  EXPECT_NE(report.find(R"("config_definition_count":1)"), std::string::npos);
+  EXPECT_NE(report.find(R"("config_materialized_count":0)"), std::string::npos);
+  EXPECT_NE(report.find(R"("config_ignored_count":1)"), std::string::npos);
 }
 
 TEST(CompileTest, CompileModuleReportsUnresolvedConfigAsResultDiagnostic) {
@@ -681,7 +717,7 @@ TEST(CompileTest, CompileModuleReportsUnresolvedConfigAsResultDiagnostic) {
   WorkspacePtr workspace = CreateWorkspace();
   CompilerPtr compiler = CreateCompiler(context.get());
   PassProgramPtr pass_program = CreateEmptyPassProgram(context.get());
-  ModulePtr module = CreateConfigModule(context.get(), workspace.get());
+  ModulePtr module = CreateConfigConsumerModule(context.get(), workspace.get());
 
   loomc_compile_options_t options = {
       /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
@@ -689,13 +725,8 @@ TEST(CompileTest, CompileModuleReportsUnresolvedConfigAsResultDiagnostic) {
       /*.next=*/nullptr,
       /*.module_name=*/loomc_string_view_empty(),
       /*.artifact_flags=*/0,
-      /*.config=*/
-      {
-          /*.bindings=*/nullptr,
-          /*.binding_count=*/0,
-          /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-      },
+      /*.config_flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+      /*.config_module=*/nullptr,
   };
   loomc_result_t* result = nullptr;
   loomc_status_t status = loomc_compile_module(
@@ -706,7 +737,61 @@ TEST(CompileTest, CompileModuleReportsUnresolvedConfigAsResultDiagnostic) {
   ExpectFailedResultCode(result_ptr.get(), "CONFIG/INVALID");
 }
 
-TEST(CompileTest, CompileModuleRejectsInvalidInvocationConfig) {
+TEST(CompileTest, CompileModuleReportsNonConfigProviderAsDiagnostic) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  CompilerPtr compiler = CreateCompiler(context.get());
+  PassProgramPtr pass_program = CreateEmptyPassProgram(context.get());
+  ModulePtr module = CreateValidModule(context.get(), workspace.get());
+  ModulePtr config_module = CreateValidModule(context.get(), workspace.get());
+
+  loomc_compile_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
+      /*.structure_size=*/sizeof(options),
+      /*.next=*/nullptr,
+      /*.module_name=*/loomc_string_view_empty(),
+      /*.artifact_flags=*/0,
+      /*.config_flags=*/0,
+      /*.config_module=*/config_module.get(),
+  };
+  loomc_result_t* result = nullptr;
+  loomc_status_t status = loomc_compile_module(
+      compiler.get(), workspace.get(), pass_program.get(), module.get(),
+      &options, loomc_allocator_system(), &result);
+  LOOMC_EXPECT_OK(status);
+  ResultPtr result_ptr(result);
+  ExpectFailedResultCode(result_ptr.get(), "CONFIG/INVALID");
+}
+
+TEST(CompileTest, CompileModuleReportsConfigConstraintFailure) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  CompilerPtr compiler = CreateCompiler(context.get());
+  PassProgramPtr pass_program = CreateEmptyPassProgram(context.get());
+  ModulePtr module = CreateConfigConsumerModule(context.get(), workspace.get());
+  ModulePtr config_module = CreateConfigProviderModule(
+      context.get(), workspace.get(),
+      "config.def @model36.model.hidden_size = 4095 : index\n");
+
+  loomc_compile_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
+      /*.structure_size=*/sizeof(options),
+      /*.next=*/nullptr,
+      /*.module_name=*/loomc_string_view_empty(),
+      /*.artifact_flags=*/0,
+      /*.config_flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+      /*.config_module=*/config_module.get(),
+  };
+  loomc_result_t* result = nullptr;
+  loomc_status_t status = loomc_compile_module(
+      compiler.get(), workspace.get(), pass_program.get(), module.get(),
+      &options, loomc_allocator_system(), &result);
+  LOOMC_EXPECT_OK(status);
+  ResultPtr result_ptr(result);
+  ExpectFailedResultCode(result_ptr.get(), "CONFIG/INVALID");
+}
+
+TEST(CompileTest, CompileModuleRejectsProgramAsConfigModule) {
   ContextPtr context = CreateContext();
   WorkspacePtr workspace = CreateWorkspace();
   CompilerPtr compiler = CreateCompiler(context.get());
@@ -719,11 +804,61 @@ TEST(CompileTest, CompileModuleRejectsInvalidInvocationConfig) {
       /*.next=*/nullptr,
       /*.module_name=*/loomc_string_view_empty(),
       /*.artifact_flags=*/0,
-      /*.config=*/
-      {
-          /*.bindings=*/nullptr,
-          /*.binding_count=*/1,
-      },
+      /*.config_flags=*/0,
+      /*.config_module=*/module.get(),
+  };
+  loomc_result_t* result = nullptr;
+  loomc_status_t status = loomc_compile_module(
+      compiler.get(), workspace.get(), pass_program.get(), module.get(),
+      &options, loomc_allocator_system(), &result);
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_INVALID_ARGUMENT, status);
+  EXPECT_EQ(result, nullptr);
+}
+
+TEST(CompileTest, CompileModuleRejectsConfigFromAnotherContext) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  CompilerPtr compiler = CreateCompiler(context.get());
+  PassProgramPtr pass_program = CreateEmptyPassProgram(context.get());
+  ModulePtr module = CreateValidModule(context.get(), workspace.get());
+  ContextPtr other_context = CreateContext();
+  WorkspacePtr other_workspace = CreateWorkspace();
+  ModulePtr config_module =
+      CreateConfigProviderModule(other_context.get(), other_workspace.get(),
+                                 "config.def @unused = 1 : index\n");
+
+  loomc_compile_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
+      /*.structure_size=*/sizeof(options),
+      /*.next=*/nullptr,
+      /*.module_name=*/loomc_string_view_empty(),
+      /*.artifact_flags=*/0,
+      /*.config_flags=*/0,
+      /*.config_module=*/config_module.get(),
+  };
+  loomc_result_t* result = nullptr;
+  loomc_status_t status = loomc_compile_module(
+      compiler.get(), workspace.get(), pass_program.get(), module.get(),
+      &options, loomc_allocator_system(), &result);
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_INVALID_ARGUMENT, status);
+  EXPECT_EQ(result, nullptr);
+}
+
+TEST(CompileTest, CompileModuleRejectsUnknownConfigPolicy) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  CompilerPtr compiler = CreateCompiler(context.get());
+  PassProgramPtr pass_program = CreateEmptyPassProgram(context.get());
+  ModulePtr module = CreateValidModule(context.get(), workspace.get());
+
+  loomc_compile_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
+      /*.structure_size=*/sizeof(options),
+      /*.next=*/nullptr,
+      /*.module_name=*/loomc_string_view_empty(),
+      /*.artifact_flags=*/0,
+      /*.config_flags=*/UINT32_MAX,
+      /*.config_module=*/nullptr,
   };
   loomc_result_t* result = nullptr;
   loomc_status_t status = loomc_compile_module(

--- a/loom/binding/c/test/link_test.cc
+++ b/loom/binding/c/test/link_test.cc
@@ -1443,7 +1443,8 @@ template.def<@demo.capi_selected> priority(1) @fallback_provider(%value: i32) ->
       /*.next=*/&target_options,
       /*.module_name=*/loomc_make_cstring_view("selected_provider_module"),
       /*.artifact_flags=*/0,
-      /*.config=*/{},
+      /*.config_flags=*/0,
+      /*.config_module=*/nullptr,
   };
   loomc_result_t* raw_compile_result = nullptr;
   loomc_status_t status = loomc_compile_module(

--- a/loom/binding/c/test/target/amdgpu/amdgpu_test.cc
+++ b/loom/binding/c/test/target/amdgpu/amdgpu_test.cc
@@ -686,7 +686,8 @@ kernel.def target(@gfx11_wave64) @target_specialized_launch(%expert_count: index
         /*.module_name=*/
         loomc_make_cstring_view("target_specialized_launch"),
         /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_LAUNCH_CONFIG,
-        /*.config=*/{},
+        /*.config_flags=*/0,
+        /*.config_module=*/nullptr,
     };
 
     loomc_result_t* result = nullptr;
@@ -774,7 +775,8 @@ kernel.def target(@gfx1151) @decode(%row_count: i32, %scale: bf16) {
       /*.next=*/nullptr,
       /*.module_name=*/loomc_make_cstring_view("multi_launch_config"),
       /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_LAUNCH_CONFIG,
-      /*.config=*/{},
+      /*.config_flags=*/0,
+      /*.config_module=*/nullptr,
   };
   loomc_result_t* result = nullptr;
   LOOMC_EXPECT_OK(loomc_compile_module(
@@ -858,16 +860,12 @@ kernel.def target(@gfx11_generic) @configured_store() {
 )");
   ModulePtr module =
       DeserializeModule(context.get(), workspace.get(), source.get());
-  loomc_config_binding_t bindings[] = {
-      {
-          /*.key=*/loomc_make_cstring_view("test.workgroups_x"),
-          /*.value=*/loomc_make_cstring_view("2"),
-      },
-      {
-          /*.key=*/loomc_make_cstring_view("test.workgroup_size_x"),
-          /*.value=*/loomc_make_cstring_view("64"),
-      },
-  };
+  SourcePtr config_source = CreateTextSource("configured_store_config.loom", R"(
+config.def @test.workgroups_x = 2 : index
+config.def @test.workgroup_size_x = 64 : index
+)");
+  ModulePtr config_module =
+      DeserializeModule(context.get(), workspace.get(), config_source.get());
   const loomc_target_specialization_t specialization = {
       /*.function_symbol=*/loomc_make_cstring_view("configured_store"),
       /*.target_profile=*/profile.get(),
@@ -885,13 +883,8 @@ kernel.def target(@gfx11_generic) @configured_store() {
       /*.next=*/&target_options,
       /*.module_name=*/loomc_make_cstring_view("configured_store"),
       /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_TEXT,
-      /*.config=*/
-      {
-          /*.bindings=*/bindings,
-          /*.binding_count=*/IREE_ARRAYSIZE(bindings),
-          /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
-      },
+      /*.config_flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+      /*.config_module=*/config_module.get(),
   };
 
   loomc_result_t* result = nullptr;

--- a/loom/binding/c/test/target/iree_hal_execution.cc
+++ b/loom/binding/c/test/target/iree_hal_execution.cc
@@ -316,7 +316,8 @@ loomc_status_t CompileModule(const IreeHalKernelExecutionTarget& target,
       /*.next=*/&target_options,
       /*.module_name=*/target.module_name,
       /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_LAUNCH_CONFIG,
-      /*.config=*/{},
+      /*.config_flags=*/0,
+      /*.config_module=*/nullptr,
   };
   loomc_result_t* result = nullptr;
   loomc_status_t status =

--- a/loom/binding/c/test/target_test.cc
+++ b/loom/binding/c/test/target_test.cc
@@ -1448,7 +1448,8 @@ TEST(TargetTest, RejectsSerializationWithoutATargetMaterializer) {
       /*.next=*/&target_options,
       /*.module_name=*/loomc_make_cstring_view("jit_kernel"),
       /*.artifact_flags=*/0,
-      /*.config=*/{},
+      /*.config_flags=*/0,
+      /*.config_module=*/nullptr,
   };
 
   for (int i = 0; i < 2; ++i) {
@@ -1574,7 +1575,8 @@ TEST(TargetTest, CompileRejectsAnUnrepresentableModuleArtifact) {
       /*.next=*/&target_options,
       /*.module_name=*/loomc_make_cstring_view("jit_kernel"),
       /*.artifact_flags=*/LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_TEXT,
-      /*.config=*/{},
+      /*.config_flags=*/0,
+      /*.config_module=*/nullptr,
   };
 
   WorkspacePtr workspace = CreateWorkspace();

--- a/loom/src/loom/tooling/config/BUILD.bazel
+++ b/loom/src/loom/tooling/config/BUILD.bazel
@@ -14,7 +14,11 @@ package(
 
 loom_cc_library(
     name = "config",
-    srcs = ["config.c"],
+    srcs = [
+        "config.c",
+        "config_application.h",
+        "config_text.c",
+    ],
     hdrs = ["config.h"],
     deps = [
         "//loom/src/loom/analysis:symbol_value_constraints",

--- a/loom/src/loom/tooling/config/BUILD.bazel
+++ b/loom/src/loom/tooling/config/BUILD.bazel
@@ -23,6 +23,7 @@ loom_cc_library(
         "//loom/src/loom/ir",
         "//loom/src/loom/ops/config",
         "//loom/src/loom/ops/encoding",
+        "//loom/src/loom/rewrite:remap",
         "//loom/src/loom/tooling/io:file",
         "//loom/src/loom/util:json",
         "//loom/src/loom/util:stream",

--- a/loom/src/loom/tooling/config/CMakeLists.txt
+++ b/loom/src/loom/tooling/config/CMakeLists.txt
@@ -26,6 +26,7 @@ loom_cc_library(
     loom::ir
     loom::ops::config
     loom::ops::encoding
+    loom::rewrite::remap
     loom::tooling::io::file
     loom::util::json
     loom::util::stream

--- a/loom/src/loom/tooling/config/CMakeLists.txt
+++ b/loom/src/loom/tooling/config/CMakeLists.txt
@@ -16,6 +16,8 @@ loom_cc_library(
     "config.h"
   SRCS
     "config.c"
+    "config_application.h"
+    "config_text.c"
   DEPS
     iree::base
     iree::base::internal::arena

--- a/loom/src/loom/tooling/config/config.c
+++ b/loom/src/loom/tooling/config/config.c
@@ -7,371 +7,20 @@
 #include "loom/tooling/config/config.h"
 
 #include <inttypes.h>
-#include <string.h>
 
 #include "iree/base/api.h"
-#include "iree/base/internal/json.h"
 #include "loom/analysis/symbol_value_constraints.h"
-#include "loom/format/text/parser.h"
-#include "loom/format/text/printer.h"
-#include "loom/ir/attribute.h"
-#include "loom/ir/encoding.h"
 #include "loom/ops/config/ops.h"
-#include "loom/ops/encoding/roles.h"
 #include "loom/rewrite/remap.h"
-#include "loom/tooling/io/file.h"
-#include "loom/util/json.h"
-#include "loom/util/stream.h"
+#include "loom/tooling/config/config_application.h"
 
-static loom_value_id_t loom_tooling_config_symbol_result_value(
-    const loom_op_t* op) {
+loom_value_id_t loom_tooling_config_symbol_result_value(const loom_op_t* op) {
   if (loom_config_decl_isa(op)) return loom_config_decl_type(op);
   if (loom_config_def_isa(op)) return loom_config_def_type(op);
   return LOOM_VALUE_ID_INVALID;
 }
 
-void loom_tooling_config_materialize_options_initialize(
-    loom_tooling_config_materialize_options_t* out_options) {
-  IREE_ASSERT_ARGUMENT(out_options);
-  memset(out_options, 0, sizeof(*out_options));
-}
-
-void loom_tooling_config_set_initialize(
-    iree_allocator_t host_allocator,
-    loom_tooling_config_set_t* out_config_set) {
-  IREE_ASSERT_ARGUMENT(out_config_set);
-  memset(out_config_set, 0, sizeof(*out_config_set));
-  out_config_set->host_allocator = host_allocator;
-}
-
-void loom_tooling_config_set_deinitialize(
-    loom_tooling_config_set_t* config_set) {
-  if (!config_set) {
-    return;
-  }
-  for (iree_host_size_t i = 0; i < config_set->binding_count; ++i) {
-    iree_allocator_free(config_set->host_allocator,
-                        (void*)config_set->bindings[i].key.data);
-    iree_allocator_free(config_set->host_allocator,
-                        (void*)config_set->bindings[i].value.data);
-  }
-  iree_allocator_free(config_set->host_allocator, config_set->bindings);
-  iree_allocator_t host_allocator = config_set->host_allocator;
-  memset(config_set, 0, sizeof(*config_set));
-  config_set->host_allocator = host_allocator;
-}
-
-static iree_string_view_t loom_tooling_config_normalize_key(
-    iree_string_view_t key) {
-  key = iree_string_view_trim(key);
-  (void)iree_string_view_consume_prefix_char(&key, '@');
-  return iree_string_view_trim(key);
-}
-
-iree_status_t loom_tooling_config_parse_assignment(
-    iree_string_view_t assignment, loom_tooling_config_binding_t* out_binding) {
-  IREE_ASSERT_ARGUMENT(out_binding);
-  iree_string_view_t key = iree_string_view_empty();
-  iree_string_view_t value = iree_string_view_empty();
-  if (iree_string_view_split(assignment, '=', &key, &value) < 0) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "config assignment must use key=value syntax, got '%.*s'",
-        (int)assignment.size, assignment.data);
-  }
-  key = loom_tooling_config_normalize_key(key);
-  value = iree_string_view_trim(value);
-  if (iree_string_view_is_empty(key)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config assignment key must not be empty");
-  }
-  if (iree_string_view_is_empty(value)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "config assignment for '%.*s' must provide a non-empty value",
-        (int)key.size, key.data);
-  }
-  *out_binding = (loom_tooling_config_binding_t){
-      .key = key,
-      .value = value,
-  };
-  return iree_ok_status();
-}
-
-static iree_status_t loom_tooling_config_clone_string_view(
-    iree_allocator_t allocator, iree_string_view_t value,
-    iree_string_view_t* out_value) {
-  iree_host_size_t byte_length = 0;
-  if (!iree_host_size_checked_add(value.size, 1, &byte_length)) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "config string length overflow");
-  }
-  char* data = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_allocator_malloc(allocator, byte_length, (void**)&data));
-  memcpy(data, value.data, value.size);
-  data[value.size] = '\0';
-  *out_value = iree_make_string_view(data, value.size);
-  return iree_ok_status();
-}
-
-static iree_status_t loom_tooling_config_set_reserve(
-    loom_tooling_config_set_t* config_set, iree_host_size_t minimum_capacity) {
-  if (config_set->binding_capacity >= minimum_capacity) {
-    return iree_ok_status();
-  }
-  iree_host_size_t new_capacity =
-      config_set->binding_capacity ? config_set->binding_capacity : 4;
-  while (new_capacity < minimum_capacity) {
-    if (new_capacity > IREE_HOST_SIZE_MAX / 2) {
-      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                              "config binding capacity overflow");
-    }
-    new_capacity *= 2;
-  }
-  IREE_RETURN_IF_ERROR(iree_allocator_realloc_array(
-      config_set->host_allocator, new_capacity, sizeof(*config_set->bindings),
-      (void**)&config_set->bindings));
-  config_set->binding_capacity = new_capacity;
-  return iree_ok_status();
-}
-
-static iree_status_t loom_tooling_config_set_check_duplicate(
-    const loom_tooling_config_set_t* config_set, iree_string_view_t key) {
-  for (iree_host_size_t i = 0; i < config_set->binding_count; ++i) {
-    if (!iree_string_view_equal(config_set->bindings[i].key, key)) {
-      continue;
-    }
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "duplicate config binding for '%.*s'",
-                            (int)key.size, key.data);
-  }
-  return iree_ok_status();
-}
-
-iree_status_t loom_tooling_config_set_append(
-    loom_tooling_config_set_t* config_set, iree_string_view_t key,
-    iree_string_view_t value) {
-  IREE_ASSERT_ARGUMENT(config_set);
-  key = loom_tooling_config_normalize_key(key);
-  value = iree_string_view_trim(value);
-  if (iree_string_view_is_empty(key)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config binding key must not be empty");
-  }
-  if (iree_string_view_is_empty(value)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "config binding for '%.*s' must provide a non-empty value",
-        (int)key.size, key.data);
-  }
-  IREE_RETURN_IF_ERROR(
-      loom_tooling_config_set_check_duplicate(config_set, key));
-  iree_host_size_t minimum_capacity = 0;
-  if (!iree_host_size_checked_add(config_set->binding_count, 1,
-                                  &minimum_capacity)) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "config binding count overflow");
-  }
-  IREE_RETURN_IF_ERROR(
-      loom_tooling_config_set_reserve(config_set, minimum_capacity));
-
-  iree_string_view_t copied_key = iree_string_view_empty();
-  iree_status_t status = loom_tooling_config_clone_string_view(
-      config_set->host_allocator, key, &copied_key);
-  iree_string_view_t copied_value = iree_string_view_empty();
-  if (iree_status_is_ok(status)) {
-    status = loom_tooling_config_clone_string_view(config_set->host_allocator,
-                                                   value, &copied_value);
-  }
-  if (!iree_status_is_ok(status)) {
-    iree_allocator_free(config_set->host_allocator, (void*)copied_key.data);
-    return status;
-  }
-
-  config_set->bindings[config_set->binding_count++] =
-      (loom_tooling_config_binding_t){
-          .key = copied_key,
-          .value = copied_value,
-      };
-  return iree_ok_status();
-}
-
-iree_status_t loom_tooling_config_set_append_assignment(
-    loom_tooling_config_set_t* config_set, iree_string_view_t assignment) {
-  IREE_ASSERT_ARGUMENT(config_set);
-  loom_tooling_config_binding_t binding = {0};
-  IREE_RETURN_IF_ERROR(
-      loom_tooling_config_parse_assignment(assignment, &binding));
-  return loom_tooling_config_set_append(config_set, binding.key, binding.value);
-}
-
-static iree_status_t loom_tooling_config_append_unescaped_json_string(
-    iree_string_view_t escaped_string, iree_string_builder_t* builder,
-    iree_host_size_t* out_length) {
-  iree_host_size_t unescaped_length = 0;
-  IREE_RETURN_IF_ERROR(
-      iree_json_unescape_string(escaped_string, 0, NULL, &unescaped_length));
-  char* target = NULL;
-  if (unescaped_length > 0) {
-    IREE_RETURN_IF_ERROR(
-        iree_string_builder_append_inline(builder, unescaped_length, &target));
-    IREE_RETURN_IF_ERROR(iree_json_unescape_string(
-        escaped_string, unescaped_length, target, &unescaped_length));
-  }
-  *out_length = unescaped_length;
-  return iree_ok_status();
-}
-
-static iree_status_t loom_tooling_config_append_json_key(
-    iree_string_view_t prefix, iree_string_view_t escaped_key,
-    iree_string_builder_t* builder) {
-  if (!iree_string_view_is_empty(prefix)) {
-    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(builder, prefix));
-    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, "."));
-  }
-  iree_host_size_t key_length = 0;
-  IREE_RETURN_IF_ERROR(loom_tooling_config_append_unescaped_json_string(
-      escaped_key, builder, &key_length));
-  if (key_length == 0) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config JSON object keys must not be empty");
-  }
-  return iree_ok_status();
-}
-
-static iree_status_t loom_tooling_config_set_append_json_value(
-    loom_tooling_config_set_t* config_set, iree_string_view_t key,
-    iree_json_value_type_t value_type, iree_string_view_t value) {
-  switch (value_type) {
-    case IREE_JSON_VALUE_TYPE_STRING: {
-      iree_string_builder_t value_builder;
-      iree_string_builder_initialize(config_set->host_allocator,
-                                     &value_builder);
-      iree_host_size_t value_length = 0;
-      iree_status_t status = loom_tooling_config_append_unescaped_json_string(
-          value, &value_builder, &value_length);
-      if (iree_status_is_ok(status)) {
-        status = loom_tooling_config_set_append(
-            config_set, key, iree_string_builder_view(&value_builder));
-      }
-      iree_string_builder_deinitialize(&value_builder);
-      return status;
-    }
-    case IREE_JSON_VALUE_TYPE_NUMBER:
-    case IREE_JSON_VALUE_TYPE_TRUE:
-    case IREE_JSON_VALUE_TYPE_FALSE:
-      return loom_tooling_config_set_append(config_set, key, value);
-    case IREE_JSON_VALUE_TYPE_ARRAY:
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "config JSON binding '%.*s' uses an unsupported array value",
-          (int)key.size, key.data);
-    case IREE_JSON_VALUE_TYPE_NULL:
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "config JSON binding '%.*s' must not be null",
-                              (int)key.size, key.data);
-    case IREE_JSON_VALUE_TYPE_OBJECT:
-    default:
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "config JSON binding '%.*s' has unsupported value type",
-          (int)key.size, key.data);
-  }
-}
-
-typedef struct loom_tooling_config_json_object_state_t {
-  loom_tooling_config_set_t* config_set;
-  iree_string_view_t prefix;
-  uint8_t depth;
-} loom_tooling_config_json_object_state_t;
-
-static iree_status_t loom_tooling_config_set_append_json_object_impl(
-    loom_tooling_config_set_t* config_set, iree_string_view_t object,
-    iree_string_view_t prefix, uint8_t depth);
-
-static iree_status_t loom_tooling_config_set_append_json_member(
-    void* user_data, iree_string_view_t escaped_key,
-    iree_json_value_type_t value_type, iree_string_view_t value) {
-  loom_tooling_config_json_object_state_t* state =
-      (loom_tooling_config_json_object_state_t*)user_data;
-  iree_string_builder_t key_builder;
-  iree_string_builder_initialize(state->config_set->host_allocator,
-                                 &key_builder);
-  iree_status_t status = loom_tooling_config_append_json_key(
-      state->prefix, escaped_key, &key_builder);
-  if (iree_status_is_ok(status)) {
-    iree_string_view_t key = iree_string_builder_view(&key_builder);
-    if (value_type == IREE_JSON_VALUE_TYPE_OBJECT) {
-      status = loom_tooling_config_set_append_json_object_impl(
-          state->config_set, value, key, (uint8_t)(state->depth + 1));
-    } else {
-      status = loom_tooling_config_set_append_json_value(state->config_set, key,
-                                                         value_type, value);
-    }
-  }
-  iree_string_builder_deinitialize(&key_builder);
-  return status;
-}
-
-static iree_status_t loom_tooling_config_set_append_json_object_impl(
-    loom_tooling_config_set_t* config_set, iree_string_view_t object,
-    iree_string_view_t prefix, uint8_t depth) {
-  if (depth >= 128) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config JSON object nesting is too deep");
-  }
-  loom_tooling_config_json_object_state_t state = {
-      .config_set = config_set,
-      .prefix = prefix,
-      .depth = depth,
-  };
-  return iree_json_enumerate_object_typed(
-      object, loom_tooling_config_set_append_json_member, &state);
-}
-
-iree_status_t loom_tooling_config_set_append_json_object(
-    loom_tooling_config_set_t* config_set, iree_string_view_t json_object) {
-  IREE_ASSERT_ARGUMENT(config_set);
-  iree_string_view_t cursor = json_object;
-  iree_string_view_t object = iree_string_view_empty();
-  IREE_RETURN_IF_ERROR(iree_json_consume_object(&cursor, &object));
-  IREE_RETURN_IF_ERROR(iree_json_consume_insignificant(&cursor));
-  if (!iree_string_view_is_empty(cursor)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "unexpected trailing content after config JSON");
-  }
-  return loom_tooling_config_set_append_json_object_impl(
-      config_set, object, iree_string_view_empty(), /*depth=*/0);
-}
-
-iree_status_t loom_tooling_config_set_append_json_file(
-    loom_tooling_config_set_t* config_set, iree_string_view_t path,
-    iree_allocator_t host_allocator) {
-  IREE_ASSERT_ARGUMENT(config_set);
-  path = iree_string_view_trim(path);
-  if (loom_tooling_file_path_is_stdio(path)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "config JSON file requires a filesystem path, not stdin");
-  }
-
-  iree_io_file_contents_t* contents = NULL;
-  iree_status_t status =
-      loom_tooling_read_input_file(path, host_allocator, &contents);
-  if (iree_status_is_ok(status)) {
-    status = loom_tooling_config_set_append_json_object(
-        config_set, loom_tooling_file_contents_string_view(contents));
-  }
-  if (!iree_status_is_ok(status)) {
-    status = iree_status_annotate_f(status, "config JSON file '%.*s'",
-                                    (int)path.size, path.data);
-  }
-  iree_io_file_contents_free(contents);
-  return status;
-}
-
-static iree_string_view_t loom_tooling_config_symbol_name(
+iree_string_view_t loom_tooling_config_symbol_name(
     const loom_module_t* module, const loom_symbol_t* symbol) {
   if (!module || !symbol || symbol->name_id == LOOM_STRING_ID_INVALID ||
       symbol->name_id >= module->strings.count) {
@@ -380,23 +29,20 @@ static iree_string_view_t loom_tooling_config_symbol_name(
   return module->strings.entries[symbol->name_id];
 }
 
-static iree_status_t loom_tooling_config_lookup_symbol(
-    loom_module_t* module, iree_string_view_t key, uint16_t* out_symbol_id) {
-  loom_string_id_t name_id = loom_module_lookup_string(module, key);
-  if (name_id == LOOM_STRING_ID_INVALID) {
-    *out_symbol_id = LOOM_SYMBOL_ID_INVALID;
-    return iree_ok_status();
-  }
-  *out_symbol_id = loom_module_find_symbol(module, name_id);
-  return iree_ok_status();
+uint16_t loom_tooling_config_find_symbol(const loom_module_t* module,
+                                         iree_string_view_t key) {
+  const loom_string_id_t name_id = loom_module_lookup_string(module, key);
+  return name_id == LOOM_STRING_ID_INVALID
+             ? LOOM_SYMBOL_ID_INVALID
+             : loom_module_find_symbol(module, name_id);
 }
 
-static bool loom_tooling_config_symbol_is_config(const loom_symbol_t* symbol) {
+bool loom_tooling_config_symbol_is_config(const loom_symbol_t* symbol) {
   return symbol && symbol->defining_op &&
          loom_symbol_implements(symbol, LOOM_SYMBOL_INTERFACE_CONFIG);
 }
 
-static iree_status_t loom_tooling_config_remap_type_and_value(
+iree_status_t loom_tooling_config_remap_type_and_value(
     const loom_module_t* source_module, loom_module_t* target_module,
     loom_type_t source_type, loom_attribute_t source_value,
     iree_arena_block_pool_t* block_pool, loom_type_t* out_target_type,
@@ -420,188 +66,15 @@ static iree_status_t loom_tooling_config_remap_type_and_value(
   return status;
 }
 
-static iree_status_t loom_tooling_config_parse_encoding_value(
-    loom_module_t* module, loom_type_t type, iree_string_view_t value_text,
-    iree_arena_block_pool_t* block_pool, loom_attribute_t* out_attr,
-    iree_allocator_t host_allocator) {
-  iree_string_builder_t builder;
-  iree_string_builder_initialize(host_allocator, &builder);
-  loom_output_stream_t stream;
-  loom_output_stream_for_builder(&builder, &stream);
-
-  iree_status_t status = iree_string_builder_append_cstring(
-      &builder, "config.def @__config_value = ");
-  if (iree_status_is_ok(status)) {
-    status = iree_string_builder_append_string(&builder, value_text);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_string_builder_append_cstring(&builder, " : ");
-  }
-  if (iree_status_is_ok(status)) {
-    status = loom_text_print_type(type, module, &stream);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_string_builder_append_cstring(&builder, "\n");
-  }
-
-  loom_module_t* parsed_module = NULL;
-  if (iree_status_is_ok(status)) {
-    loom_text_parse_options_t parse_options = {
-        .max_errors = 20,
-    };
-    status = loom_text_parse(iree_string_builder_view(&builder),
-                             IREE_SV("<config>"), module->context, block_pool,
-                             &parse_options, &parsed_module);
-  }
-  if (iree_status_is_ok(status) && !parsed_module) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "failed to parse config encoding value '%.*s'",
-                              (int)value_text.size, value_text.data);
-  }
-  if (iree_status_is_ok(status)) {
-    loom_op_t* op = loom_module_block(parsed_module)->first_op;
-    if (!op || !loom_config_def_isa(op)) {
-      status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                                "failed to parse config encoding value");
-    } else {
-      loom_type_t remapped_type = {0};
-      status = loom_tooling_config_remap_type_and_value(
-          parsed_module, module,
-          loom_module_value_type(parsed_module, loom_config_def_type(op)),
-          loom_config_def_value(op), block_pool, &remapped_type, out_attr);
-      if (iree_status_is_ok(status) && !loom_type_equal(remapped_type, type)) {
-        status = iree_make_status(
-            IREE_STATUS_INVALID_ARGUMENT,
-            "parsed config encoding value has an incompatible type");
-      }
-    }
-  }
-
-  if (parsed_module) {
-    loom_module_free(parsed_module);
-  }
-  iree_string_builder_deinitialize(&builder);
-  return status;
-}
-
-static iree_status_t loom_tooling_config_check_encoding_role(
-    const loom_module_t* module, iree_string_view_t key, loom_type_t type,
-    loom_attribute_t value) {
-  loom_encoding_role_t expected_role = loom_type_encoding_role(type);
-  if (expected_role == LOOM_ENCODING_ROLE_UNKNOWN) {
-    return iree_ok_status();
-  }
-  const loom_encoding_t* encoding =
-      loom_module_encoding(module, loom_attr_as_encoding_id(value));
-  loom_encoding_role_t actual_role =
-      loom_encoding_static_role(module, encoding);
-  if (actual_role == expected_role) {
-    return iree_ok_status();
-  }
-  iree_string_view_t expected = loom_encoding_role_description(expected_role);
-  iree_string_view_t actual = loom_encoding_role_description(actual_role);
-  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                          "config '%.*s' expects %.*s, got %.*s", (int)key.size,
-                          key.data, (int)expected.size, expected.data,
-                          (int)actual.size, actual.data);
-}
-
-static iree_status_t loom_tooling_config_parse_scalar_value(
-    iree_string_view_t key, loom_type_t type, iree_string_view_t value_text,
-    loom_attribute_t* out_attr) {
-  loom_scalar_type_t scalar_type = loom_type_element_type(type);
-  if (scalar_type == LOOM_SCALAR_TYPE_I1) {
-    if (iree_string_view_equal_case(value_text, IREE_SV("true"))) {
-      *out_attr = loom_attr_bool(true);
-      return iree_ok_status();
-    }
-    if (iree_string_view_equal_case(value_text, IREE_SV("false"))) {
-      *out_attr = loom_attr_bool(false);
-      return iree_ok_status();
-    }
-    int64_t value = 0;
-    if (!iree_string_view_atoi_int64(value_text, &value) ||
-        (value != 0 && value != 1)) {
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "config '%.*s' expects i1 value true/false/0/1, got '%.*s'",
-          (int)key.size, key.data, (int)value_text.size, value_text.data);
-    }
-    *out_attr = loom_attr_bool(value != 0);
-    return iree_ok_status();
-  }
-
-  if (scalar_type == LOOM_SCALAR_TYPE_INDEX ||
-      scalar_type == LOOM_SCALAR_TYPE_OFFSET ||
-      loom_scalar_type_is_integer(scalar_type)) {
-    int64_t value = 0;
-    if (!iree_string_view_atoi_int64(value_text, &value)) {
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "config '%.*s' expects integer value, got '%.*s'",
-                              (int)key.size, key.data, (int)value_text.size,
-                              value_text.data);
-    }
-    int64_t domain_lo = INT64_MIN;
-    int64_t domain_hi = INT64_MAX;
-    if (loom_scalar_type_integer_domain(scalar_type, &domain_lo, &domain_hi) &&
-        (value < domain_lo || value > domain_hi)) {
-      return iree_make_status(
-          IREE_STATUS_OUT_OF_RANGE,
-          "config '%.*s' value %" PRId64 " is outside the %s domain [%" PRId64
-          ", %" PRId64 "]",
-          (int)key.size, key.data, value, loom_scalar_type_name(scalar_type),
-          domain_lo, domain_hi);
-    }
-    *out_attr = loom_attr_i64(value);
-    return iree_ok_status();
-  }
-
-  if (loom_scalar_type_is_float(scalar_type)) {
-    double value = 0.0;
-    if (!iree_string_view_atod(value_text, &value)) {
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "config '%.*s' expects floating-point value, got '%.*s'",
-          (int)key.size, key.data, (int)value_text.size, value_text.data);
-    }
-    *out_attr = loom_attr_f64(value);
-    return iree_ok_status();
-  }
-
-  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                          "config '%.*s' has unsupported scalar type %s",
-                          (int)key.size, key.data,
-                          loom_scalar_type_name(scalar_type));
-}
-
-static iree_status_t loom_tooling_config_parse_value(
-    loom_module_t* module, iree_string_view_t key, loom_type_t type,
-    iree_string_view_t value_text, iree_arena_block_pool_t* block_pool,
-    loom_attribute_t* out_attr) {
-  if (loom_type_is_scalar(type)) {
-    return loom_tooling_config_parse_scalar_value(key, type, value_text,
-                                                  out_attr);
-  }
-  if (loom_type_is_encoding(type)) {
-    IREE_RETURN_IF_ERROR(loom_tooling_config_parse_encoding_value(
-        module, type, value_text, block_pool, out_attr,
-        iree_allocator_system()));
-    return loom_tooling_config_check_encoding_role(module, key, type,
-                                                   *out_attr);
-  }
-  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                          "config '%.*s' has unsupported type", (int)key.size,
-                          key.data);
-}
-
 static iree_status_t loom_tooling_config_replace_with_def(
     loom_module_t* module, loom_op_t* old_op, loom_symbol_ref_t symbol,
     loom_attribute_t value, loom_type_t type) {
   loom_block_t* block = old_op->parent_block;
   loom_op_t* before_op = old_op->next_op;
   loom_op_t* parent_op = old_op->parent_op;
-  loom_location_id_t location = old_op->location;
-  loom_value_id_t old_result = loom_tooling_config_symbol_result_value(old_op);
+  const loom_location_id_t location = old_op->location;
+  const loom_value_id_t old_result =
+      loom_tooling_config_symbol_result_value(old_op);
 
   IREE_RETURN_IF_ERROR(loom_op_erase(module, old_op));
 
@@ -619,9 +92,11 @@ static iree_status_t loom_tooling_config_replace_with_def(
   return iree_ok_status();
 }
 
-static iree_status_t loom_tooling_config_apply_exact_value(
-    loom_module_t* module, iree_string_view_t key, loom_op_t* old_op,
-    loom_type_t type, loom_attribute_t value) {
+iree_status_t loom_tooling_config_apply_exact_value(loom_module_t* module,
+                                                    iree_string_view_t key,
+                                                    loom_op_t* old_op,
+                                                    loom_type_t type,
+                                                    loom_attribute_t value) {
   if (loom_config_decl_isa(old_op)) {
     IREE_RETURN_IF_ERROR(loom_symbol_value_constraints_check_exact(
         key, type, loom_config_decl_type(old_op), value,
@@ -673,9 +148,8 @@ iree_status_t loom_tooling_config_overlay_module(
     const iree_string_view_t key =
         loom_tooling_config_symbol_name(config_module, source_symbol);
 
-    uint16_t target_symbol_id = LOOM_SYMBOL_ID_INVALID;
-    IREE_RETURN_IF_ERROR(
-        loom_tooling_config_lookup_symbol(module, key, &target_symbol_id));
+    const uint16_t target_symbol_id =
+        loom_tooling_config_find_symbol(module, key);
     if (target_symbol_id == LOOM_SYMBOL_ID_INVALID) {
       ++result.ignored_count;
       continue;
@@ -725,69 +199,6 @@ iree_status_t loom_tooling_config_overlay_module(
   return iree_ok_status();
 }
 
-iree_status_t loom_tooling_config_materialize_module(
-    loom_module_t* module,
-    const loom_tooling_config_materialize_options_t* options,
-    iree_arena_block_pool_t* block_pool,
-    loom_tooling_config_materialize_result_t* out_result) {
-  IREE_ASSERT_ARGUMENT(module);
-  IREE_ASSERT_ARGUMENT(options);
-  IREE_ASSERT_ARGUMENT(block_pool);
-  const loom_tooling_config_set_t* config_set = options->config_set;
-  const iree_host_size_t binding_count =
-      config_set ? config_set->binding_count : 0;
-  if (config_set && !config_set->bindings && binding_count > 0) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config bindings pointer is NULL");
-  }
-
-  loom_tooling_config_materialize_result_t result = {0};
-  if (binding_count == 0) {
-    if (out_result) *out_result = result;
-    return iree_ok_status();
-  }
-
-  for (iree_host_size_t i = 0; i < binding_count; ++i) {
-    const loom_tooling_config_binding_t* binding = &config_set->bindings[i];
-    iree_string_view_t key = binding->key;
-    iree_string_view_t value_text = binding->value;
-    uint16_t symbol_id = LOOM_SYMBOL_ID_INVALID;
-    IREE_RETURN_IF_ERROR(
-        loom_tooling_config_lookup_symbol(module, key, &symbol_id));
-    if (symbol_id == LOOM_SYMBOL_ID_INVALID) {
-      ++result.ignored_count;
-      continue;
-    }
-
-    loom_symbol_t* symbol = &module->symbols.entries[symbol_id];
-    if (!loom_tooling_config_symbol_is_config(symbol)) {
-      ++result.ignored_count;
-      continue;
-    }
-    loom_op_t* old_op = symbol->defining_op;
-    loom_value_id_t config_value =
-        loom_tooling_config_symbol_result_value(old_op);
-    if (config_value == LOOM_VALUE_ID_INVALID ||
-        config_value >= module->values.count) {
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "config '%.*s' has no result value",
-                              (int)key.size, key.data);
-    }
-    loom_type_t config_type = loom_module_value_type(module, config_value);
-
-    loom_attribute_t value = {0};
-    IREE_RETURN_IF_ERROR(loom_tooling_config_parse_value(
-        module, key, config_type, value_text, block_pool, &value));
-    IREE_RETURN_IF_ERROR(loom_tooling_config_apply_exact_value(
-        module, loom_tooling_config_symbol_name(module, symbol), old_op,
-        config_type, value));
-    ++result.materialized_count;
-  }
-
-  if (out_result) *out_result = result;
-  return iree_ok_status();
-}
-
 iree_status_t loom_tooling_config_require_resolved_module(
     const loom_module_t* module,
     loom_tooling_config_resolution_result_t* out_result) {
@@ -816,195 +227,4 @@ iree_status_t loom_tooling_config_require_resolved_module(
       " unresolved config%s total)",
       (int)first_unresolved_name.size, first_unresolved_name.data,
       result.unresolved_count, result.unresolved_count == 1 ? "" : "s");
-}
-
-static iree_status_t loom_tooling_config_write_printed_type_string(
-    const loom_module_t* module, loom_type_t type,
-    loom_output_stream_t* stream) {
-  IREE_RETURN_IF_ERROR(loom_output_stream_write_char(stream, '"'));
-  loom_json_escape_stream_t escape_data;
-  loom_output_stream_t escape_stream;
-  loom_json_escape_stream_init(stream, &escape_data, &escape_stream);
-  IREE_RETURN_IF_ERROR(loom_text_print_type(type, module, &escape_stream));
-  return loom_output_stream_write_char(stream, '"');
-}
-
-static iree_status_t loom_tooling_config_write_printed_attr_string(
-    const loom_module_t* module, loom_attribute_t attr,
-    loom_output_stream_t* stream) {
-  IREE_RETURN_IF_ERROR(loom_output_stream_write_char(stream, '"'));
-  loom_json_escape_stream_t escape_data;
-  loom_output_stream_t escape_stream;
-  loom_json_escape_stream_init(stream, &escape_data, &escape_stream);
-  IREE_RETURN_IF_ERROR(
-      loom_text_print_attribute(&attr, module, &escape_stream));
-  return loom_output_stream_write_char(stream, '"');
-}
-
-static iree_string_view_t loom_tooling_config_predicate_arg_kind_name(
-    uint8_t tag) {
-  switch ((loom_predicate_arg_tag_t)tag) {
-    case LOOM_PRED_ARG_NONE:
-      return IREE_SV("none");
-    case LOOM_PRED_ARG_VALUE:
-      return IREE_SV("value");
-    case LOOM_PRED_ARG_CONST:
-      return IREE_SV("const");
-    default:
-      return IREE_SV("unknown");
-  }
-}
-
-static iree_status_t loom_tooling_config_format_predicate_arg_json(
-    const loom_predicate_t* predicate, uint8_t arg_index,
-    loom_output_stream_t* stream) {
-  uint8_t tag = LOOM_PRED_ARG_NONE;
-  int64_t value = 0;
-  if (arg_index < predicate->arg_count) {
-    tag = predicate->arg_tags[arg_index];
-    value = predicate->args[arg_index];
-  }
-  loom_json_object_writer_t object;
-  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
-  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
-      &object, IREE_SV("kind"),
-      loom_tooling_config_predicate_arg_kind_name(tag)));
-  switch ((loom_predicate_arg_tag_t)tag) {
-    case LOOM_PRED_ARG_VALUE: {
-      IREE_RETURN_IF_ERROR(loom_json_object_write_int64_field(
-          &object, IREE_SV("value_id"), value));
-      break;
-    }
-    case LOOM_PRED_ARG_CONST: {
-      IREE_RETURN_IF_ERROR(
-          loom_json_object_write_int64_field(&object, IREE_SV("value"), value));
-      break;
-    }
-    default:
-      break;
-  }
-  return loom_json_object_end(&object);
-}
-
-static iree_status_t loom_tooling_config_format_predicate_json(
-    const loom_predicate_t* predicate, loom_output_stream_t* stream) {
-  const char* kind_name = loom_predicate_kind_name(predicate->kind);
-  loom_json_object_writer_t object;
-  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
-  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
-      &object, IREE_SV("kind"),
-      kind_name ? iree_make_cstring_view(kind_name) : IREE_SV("unknown")));
-  IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&object, IREE_SV("args")));
-  loom_json_array_writer_t args;
-  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &args));
-  for (uint8_t i = 0; i < predicate->arg_count; ++i) {
-    IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&args));
-    IREE_RETURN_IF_ERROR(
-        loom_tooling_config_format_predicate_arg_json(predicate, i, stream));
-  }
-  IREE_RETURN_IF_ERROR(loom_json_array_end(&args));
-  return loom_json_object_end(&object);
-}
-
-static iree_status_t loom_tooling_config_format_predicates_json(
-    loom_attribute_t predicates, loom_output_stream_t* stream) {
-  if (predicates.kind != LOOM_ATTR_ABSENT &&
-      predicates.kind != LOOM_ATTR_PREDICATE_LIST) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config constraints must be a predicate list");
-  }
-  if (predicates.kind == LOOM_ATTR_PREDICATE_LIST && predicates.count > 0 &&
-      !predicates.predicate_list) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config constraints predicate list is missing");
-  }
-  loom_json_array_writer_t array;
-  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &array));
-  if (predicates.kind == LOOM_ATTR_PREDICATE_LIST) {
-    for (uint16_t i = 0; i < predicates.count; ++i) {
-      IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&array));
-      IREE_RETURN_IF_ERROR(loom_tooling_config_format_predicate_json(
-          &predicates.predicate_list[i], stream));
-    }
-  }
-  return loom_json_array_end(&array);
-}
-
-static iree_status_t loom_tooling_config_format_schema_entry_json(
-    const loom_module_t* module, const loom_symbol_t* symbol,
-    loom_output_stream_t* stream) {
-  loom_op_t* op = symbol->defining_op;
-  const bool is_decl = loom_config_decl_isa(op);
-  const bool is_def = loom_config_def_isa(op);
-  if (!is_decl && !is_def) {
-    iree_string_view_t symbol_name =
-        loom_tooling_config_symbol_name(module, symbol);
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config symbol '@%.*s' is not a config.decl/def",
-                            (int)symbol_name.size, symbol_name.data);
-  }
-
-  loom_value_id_t config_value = loom_tooling_config_symbol_result_value(op);
-  if (config_value == LOOM_VALUE_ID_INVALID ||
-      config_value >= module->values.count) {
-    iree_string_view_t symbol_name =
-        loom_tooling_config_symbol_name(module, symbol);
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config symbol '@%.*s' has no result value",
-                            (int)symbol_name.size, symbol_name.data);
-  }
-  loom_type_t config_type = loom_module_value_type(module, config_value);
-
-  loom_json_object_writer_t object;
-  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
-  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
-      &object, IREE_SV("name"),
-      loom_tooling_config_symbol_name(module, symbol)));
-  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
-      &object, IREE_SV("state"), is_decl ? IREE_SV("decl") : IREE_SV("def")));
-  IREE_RETURN_IF_ERROR(
-      loom_json_object_write_bool_field(&object, IREE_SV("required"), is_decl));
-  IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&object, IREE_SV("type")));
-  IREE_RETURN_IF_ERROR(loom_tooling_config_write_printed_type_string(
-      module, config_type, stream));
-  if (is_def) {
-    IREE_RETURN_IF_ERROR(
-        loom_json_object_begin_field(&object, IREE_SV("default")));
-    IREE_RETURN_IF_ERROR(loom_tooling_config_write_printed_attr_string(
-        module, loom_config_def_value(op), stream));
-  }
-  IREE_RETURN_IF_ERROR(
-      loom_json_object_begin_field(&object, IREE_SV("constraints")));
-  loom_attribute_t predicates =
-      is_decl ? loom_config_decl_predicates(op) : loom_attr_absent();
-  IREE_RETURN_IF_ERROR(
-      loom_tooling_config_format_predicates_json(predicates, stream));
-  return loom_json_object_end(&object);
-}
-
-iree_status_t loom_tooling_config_format_schema_json(
-    const loom_module_t* module, loom_output_stream_t* stream) {
-  IREE_ASSERT_ARGUMENT(module);
-  IREE_ASSERT_ARGUMENT(stream);
-  loom_json_object_writer_t object;
-  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
-  IREE_RETURN_IF_ERROR(
-      loom_json_object_begin_field(&object, IREE_SV("configs")));
-  loom_json_array_writer_t configs;
-  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &configs));
-  iree_host_size_t config_count = 0;
-  const loom_symbol_t* symbol = NULL;
-  loom_module_for_each_symbol(module, symbol) {
-    if (!loom_tooling_config_symbol_is_config(symbol)) {
-      continue;
-    }
-    IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&configs));
-    IREE_RETURN_IF_ERROR(
-        loom_tooling_config_format_schema_entry_json(module, symbol, stream));
-    ++config_count;
-  }
-  IREE_RETURN_IF_ERROR(loom_json_array_end(&configs));
-  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
-      &object, IREE_SV("count"), config_count));
-  return loom_json_object_end(&object);
 }

--- a/loom/src/loom/tooling/config/config.c
+++ b/loom/src/loom/tooling/config/config.c
@@ -18,6 +18,7 @@
 #include "loom/ir/encoding.h"
 #include "loom/ops/config/ops.h"
 #include "loom/ops/encoding/roles.h"
+#include "loom/rewrite/remap.h"
 #include "loom/tooling/io/file.h"
 #include "loom/util/json.h"
 #include "loom/util/stream.h"
@@ -395,193 +396,28 @@ static bool loom_tooling_config_symbol_is_config(const loom_symbol_t* symbol) {
          loom_symbol_implements(symbol, LOOM_SYMBOL_INTERFACE_CONFIG);
 }
 
-static iree_status_t loom_tooling_config_copy_attr(
+static iree_status_t loom_tooling_config_remap_type_and_value(
     const loom_module_t* source_module, loom_module_t* target_module,
-    loom_attribute_t source_attr, uint8_t depth, loom_attribute_t* out_attr);
+    loom_type_t source_type, loom_attribute_t source_value,
+    iree_arena_block_pool_t* block_pool, loom_type_t* out_target_type,
+    loom_attribute_t* out_target_value) {
+  *out_target_type = (loom_type_t){0};
+  *out_target_value = loom_attr_absent();
 
-static iree_status_t loom_tooling_config_copy_string_id(
-    const loom_module_t* source_module, loom_module_t* target_module,
-    loom_string_id_t source_string_id, loom_string_id_t* out_target_string_id) {
-  if (source_string_id == LOOM_STRING_ID_INVALID) {
-    *out_target_string_id = LOOM_STRING_ID_INVALID;
-    return iree_ok_status();
+  iree_arena_allocator_t remap_arena;
+  iree_arena_initialize(block_pool, &remap_arena);
+  loom_ir_remap_t remap = {0};
+  const loom_ir_remap_options_t remap_options = {0};
+  iree_status_t status = loom_ir_remap_initialize(
+      source_module, target_module, &remap_arena, &remap_options, &remap);
+  if (iree_status_is_ok(status)) {
+    status = loom_ir_remap_type(&remap, source_type, out_target_type);
   }
-  if (source_string_id >= source_module->strings.count) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config value references invalid string id %u",
-                            (unsigned)source_string_id);
+  if (iree_status_is_ok(status)) {
+    status = loom_ir_remap_attribute(&remap, source_value, out_target_value);
   }
-  return loom_module_intern_string(
-      target_module, source_module->strings.entries[source_string_id],
-      out_target_string_id);
-}
-
-static iree_status_t loom_tooling_config_copy_named_attrs(
-    const loom_module_t* source_module, loom_module_t* target_module,
-    const loom_named_attr_t* source_entries, iree_host_size_t count,
-    uint8_t depth, loom_named_attr_t** out_target_entries) {
-  if (count == 0) {
-    *out_target_entries = NULL;
-    return iree_ok_status();
-  }
-  if (depth >= LOOM_ATTR_AGGREGATE_MAX_NESTING_DEPTH) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config value attribute nesting exceeds max %u",
-                            (unsigned)LOOM_ATTR_AGGREGATE_MAX_NESTING_DEPTH);
-  }
-  loom_named_attr_t* target_entries = NULL;
-  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(&target_module->arena, count,
-                                                 sizeof(*target_entries),
-                                                 (void**)&target_entries));
-  for (iree_host_size_t i = 0; i < count; ++i) {
-    IREE_RETURN_IF_ERROR(loom_tooling_config_copy_string_id(
-        source_module, target_module, source_entries[i].name_id,
-        &target_entries[i].name_id));
-    IREE_RETURN_IF_ERROR(loom_tooling_config_copy_attr(
-        source_module, target_module, source_entries[i].value,
-        (uint8_t)(depth + 1), &target_entries[i].value));
-    target_entries[i].reserved = 0;
-  }
-  *out_target_entries = target_entries;
-  return iree_ok_status();
-}
-
-static iree_status_t loom_tooling_config_copy_encoding(
-    const loom_module_t* source_module, loom_module_t* target_module,
-    uint16_t source_encoding_id, uint8_t depth,
-    uint16_t* out_target_encoding_id) {
-  if (depth >= LOOM_ATTR_AGGREGATE_MAX_NESTING_DEPTH) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config encoding nesting exceeds max %u",
-                            (unsigned)LOOM_ATTR_AGGREGATE_MAX_NESTING_DEPTH);
-  }
-  const loom_encoding_t* source_encoding =
-      loom_module_encoding(source_module, source_encoding_id);
-  if (!source_encoding) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "config value references invalid encoding id %u",
-                            (unsigned)source_encoding_id);
-  }
-
-  loom_encoding_t target_encoding = {0};
-  IREE_RETURN_IF_ERROR(loom_tooling_config_copy_string_id(
-      source_module, target_module, source_encoding->name_id,
-      &target_encoding.name_id));
-  IREE_RETURN_IF_ERROR(loom_tooling_config_copy_string_id(
-      source_module, target_module, source_encoding->alias_id,
-      &target_encoding.alias_id));
-  target_encoding.attribute_count = source_encoding->attribute_count;
-  loom_named_attr_t* target_entries = NULL;
-  IREE_RETURN_IF_ERROR(loom_tooling_config_copy_named_attrs(
-      source_module, target_module, source_encoding->attributes,
-      source_encoding->attribute_count, (uint8_t)(depth + 1), &target_entries));
-  target_encoding.attributes = target_entries;
-  return loom_module_add_encoding(target_module, &target_encoding,
-                                  out_target_encoding_id);
-}
-
-static iree_status_t loom_tooling_config_copy_attr(
-    const loom_module_t* source_module, loom_module_t* target_module,
-    loom_attribute_t source_attr, uint8_t depth, loom_attribute_t* out_attr) {
-  *out_attr = source_attr;
-  switch ((loom_attr_kind_t)source_attr.kind) {
-    case LOOM_ATTR_ABSENT:
-    case LOOM_ATTR_I64:
-    case LOOM_ATTR_F64:
-    case LOOM_ATTR_BOOL:
-    case LOOM_ATTR_ENUM:
-      return iree_ok_status();
-    case LOOM_ATTR_STRING: {
-      loom_string_id_t target_string_id = LOOM_STRING_ID_INVALID;
-      IREE_RETURN_IF_ERROR(loom_tooling_config_copy_string_id(
-          source_module, target_module, source_attr.string_id,
-          &target_string_id));
-      *out_attr = loom_attr_string(target_string_id);
-      return iree_ok_status();
-    }
-    case LOOM_ATTR_I64_ARRAY: {
-      if (source_attr.count == 0) {
-        *out_attr = loom_attr_i64_array(NULL, 0);
-        return iree_ok_status();
-      }
-      int64_t* target_values = NULL;
-      IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-          &target_module->arena, source_attr.count, sizeof(*target_values),
-          (void**)&target_values));
-      memcpy(target_values, source_attr.i64_array,
-             (iree_host_size_t)source_attr.count * sizeof(*target_values));
-      *out_attr = loom_attr_i64_array(target_values, source_attr.count);
-      return iree_ok_status();
-    }
-    case LOOM_ATTR_DICT: {
-      if (source_attr.count == 0) {
-        *out_attr = loom_make_canonical_attr_dict(NULL, 0);
-        return iree_ok_status();
-      }
-      loom_named_attr_t* target_entries = NULL;
-      IREE_RETURN_IF_ERROR(loom_tooling_config_copy_named_attrs(
-          source_module, target_module, source_attr.dict_entries,
-          source_attr.count, depth, &target_entries));
-      return loom_module_make_canonical_attr_dict(
-          target_module,
-          loom_make_named_attr_slice(target_entries, source_attr.count),
-          out_attr);
-    }
-    case LOOM_ATTR_PARAMETERIZED: {
-      loom_attribute_t target_slots[UINT8_MAX];
-      for (uint16_t i = 0; i < source_attr.count; ++i) {
-        IREE_RETURN_IF_ERROR(loom_tooling_config_copy_attr(
-            source_module, target_module, source_attr.parameterized_slots[i],
-            (uint8_t)(depth + 1), &target_slots[i]));
-      }
-      return loom_module_make_parameterized_attr(
-          target_module, (loom_parameterized_attr_kind_t)source_attr.reserved_1,
-          target_slots, source_attr.count, out_attr);
-    }
-    case LOOM_ATTR_PARAMETERIZED_ARRAY: {
-      loom_attribute_t* target_attributes = NULL;
-      if (source_attr.count > 0) {
-        IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-            &target_module->arena, source_attr.count,
-            sizeof(*target_attributes), (void**)&target_attributes));
-        for (uint16_t i = 0; i < source_attr.count; ++i) {
-          IREE_RETURN_IF_ERROR(loom_tooling_config_copy_attr(
-              source_module, target_module, source_attr.parameterized_array[i],
-              (uint8_t)(depth + 1), &target_attributes[i]));
-        }
-      }
-      *out_attr =
-          loom_attr_parameterized_array(target_attributes, source_attr.count);
-      return iree_ok_status();
-    }
-    case LOOM_ATTR_ENCODING: {
-      uint16_t target_encoding_id = 0;
-      IREE_RETURN_IF_ERROR(loom_tooling_config_copy_encoding(
-          source_module, target_module,
-          (uint16_t)loom_attr_as_encoding_id(source_attr), (uint8_t)(depth + 1),
-          &target_encoding_id));
-      *out_attr = loom_attr_encoding(target_encoding_id);
-      return iree_ok_status();
-    }
-    case LOOM_ATTR_SYMBOL:
-    case LOOM_ATTR_SYMBOL_ARRAY:
-    case LOOM_ATTR_SYMBOL_SET:
-    case LOOM_ATTR_TYPE:
-    case LOOM_ATTR_PREDICATE_LIST:
-    case LOOM_ATTR_SCOPED_ENUM:
-    case LOOM_ATTR_ENUM_ARRAY:
-    case LOOM_ATTR_SIGNED_ENUM_SET:
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "config encoding value contains unsupported attribute kind %u",
-          (unsigned)source_attr.kind);
-    case LOOM_ATTR_ANY:
-    case LOOM_ATTR_COUNT_:
-    default:
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "unknown config attribute kind %u",
-                              (unsigned)source_attr.kind);
-  }
+  iree_arena_deinitialize(&remap_arena);
+  return status;
 }
 
 static iree_status_t loom_tooling_config_parse_encoding_value(
@@ -628,9 +464,16 @@ static iree_status_t loom_tooling_config_parse_encoding_value(
       status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "failed to parse config encoding value");
     } else {
-      status = loom_tooling_config_copy_attr(parsed_module, module,
-                                             loom_config_def_value(op),
-                                             /*depth=*/0, out_attr);
+      loom_type_t remapped_type = {0};
+      status = loom_tooling_config_remap_type_and_value(
+          parsed_module, module,
+          loom_module_value_type(parsed_module, loom_config_def_type(op)),
+          loom_config_def_value(op), block_pool, &remapped_type, out_attr);
+      if (iree_status_is_ok(status) && !loom_type_equal(remapped_type, type)) {
+        status = iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "parsed config encoding value has an incompatible type");
+      }
     }
   }
 
@@ -776,6 +619,112 @@ static iree_status_t loom_tooling_config_replace_with_def(
   return iree_ok_status();
 }
 
+static iree_status_t loom_tooling_config_apply_exact_value(
+    loom_module_t* module, iree_string_view_t key, loom_op_t* old_op,
+    loom_type_t type, loom_attribute_t value) {
+  if (loom_config_decl_isa(old_op)) {
+    IREE_RETURN_IF_ERROR(loom_symbol_value_constraints_check_exact(
+        key, type, loom_config_decl_type(old_op), value,
+        loom_config_decl_predicates(old_op)));
+  }
+  const loom_symbol_ref_t symbol = loom_config_decl_isa(old_op)
+                                       ? loom_config_decl_symbol(old_op)
+                                       : loom_config_def_symbol(old_op);
+  return loom_tooling_config_replace_with_def(module, old_op, symbol, value,
+                                              type);
+}
+
+iree_status_t loom_tooling_config_overlay_module(
+    loom_module_t* module, const loom_module_t* config_module,
+    iree_arena_block_pool_t* block_pool,
+    loom_tooling_config_materialize_result_t* out_result) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(config_module);
+  IREE_ASSERT_ARGUMENT(block_pool);
+  if (module == config_module) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "config module must be distinct from target module");
+  }
+  if (module->context != config_module->context) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config and target modules use different contexts");
+  }
+
+  loom_tooling_config_materialize_result_t result = {0};
+  const loom_block_t* config_block =
+      loom_region_const_entry_block(config_module->body);
+  for (const loom_op_t* config_op = config_block->first_op; config_op != NULL;
+       config_op = config_op->next_op) {
+    if (!loom_config_def_isa(config_op)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "config module contains non-config.def operation kind %u",
+          (unsigned)config_op->kind);
+    }
+    const loom_symbol_ref_t source_ref = loom_config_def_symbol(config_op);
+    if (!loom_symbol_ref_is_valid(source_ref) || source_ref.module_id != 0 ||
+        source_ref.symbol_id >= config_module->symbols.count) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "config.def has an invalid symbol reference");
+    }
+    const loom_symbol_t* source_symbol =
+        &config_module->symbols.entries[source_ref.symbol_id];
+    const iree_string_view_t key =
+        loom_tooling_config_symbol_name(config_module, source_symbol);
+
+    uint16_t target_symbol_id = LOOM_SYMBOL_ID_INVALID;
+    IREE_RETURN_IF_ERROR(
+        loom_tooling_config_lookup_symbol(module, key, &target_symbol_id));
+    if (target_symbol_id == LOOM_SYMBOL_ID_INVALID) {
+      ++result.ignored_count;
+      continue;
+    }
+    loom_symbol_t* target_symbol = &module->symbols.entries[target_symbol_id];
+    if (!loom_tooling_config_symbol_is_config(target_symbol)) {
+      ++result.ignored_count;
+      continue;
+    }
+    loom_op_t* target_op = target_symbol->defining_op;
+    const loom_value_id_t target_value =
+        loom_tooling_config_symbol_result_value(target_op);
+    if (target_value == LOOM_VALUE_ID_INVALID ||
+        target_value >= module->values.count) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "config '%.*s' has no result value",
+                              (int)key.size, key.data);
+    }
+    const loom_type_t target_type =
+        loom_module_value_type(module, target_value);
+    const loom_value_id_t source_value = loom_config_def_type(config_op);
+    if (source_value >= config_module->values.count) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "config definition '%.*s' has no result value",
+                              (int)key.size, key.data);
+    }
+
+    loom_type_t remapped_type = {0};
+    loom_attribute_t remapped_value = loom_attr_absent();
+    IREE_RETURN_IF_ERROR(loom_tooling_config_remap_type_and_value(
+        config_module, module,
+        loom_module_value_type(config_module, source_value),
+        loom_config_def_value(config_op), block_pool, &remapped_type,
+        &remapped_value));
+    if (!loom_type_equal(remapped_type, target_type)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "config definition '%.*s' type does not match the target declaration",
+          (int)key.size, key.data);
+    }
+    IREE_RETURN_IF_ERROR(loom_tooling_config_apply_exact_value(
+        module, key, target_op, target_type, remapped_value));
+    ++result.materialized_count;
+  }
+
+  if (out_result) *out_result = result;
+  return iree_ok_status();
+}
+
 iree_status_t loom_tooling_config_materialize_module(
     loom_module_t* module,
     const loom_tooling_config_materialize_options_t* options,
@@ -829,14 +778,9 @@ iree_status_t loom_tooling_config_materialize_module(
     loom_attribute_t value = {0};
     IREE_RETURN_IF_ERROR(loom_tooling_config_parse_value(
         module, key, config_type, value_text, block_pool, &value));
-    if (loom_config_decl_isa(old_op)) {
-      IREE_RETURN_IF_ERROR(loom_symbol_value_constraints_check_exact(
-          loom_tooling_config_symbol_name(module, symbol), config_type,
-          loom_config_decl_type(old_op), value,
-          loom_config_decl_predicates(old_op)));
-    }
-    IREE_RETURN_IF_ERROR(loom_tooling_config_replace_with_def(
-        module, old_op, (loom_symbol_ref_t){0, symbol_id}, value, config_type));
+    IREE_RETURN_IF_ERROR(loom_tooling_config_apply_exact_value(
+        module, loom_tooling_config_symbol_name(module, symbol), old_op,
+        config_type, value));
     ++result.materialized_count;
   }
 

--- a/loom/src/loom/tooling/config/config.h
+++ b/loom/src/loom/tooling/config/config.h
@@ -150,6 +150,20 @@ iree_status_t loom_tooling_config_materialize_module(
     iree_arena_block_pool_t* block_pool,
     loom_tooling_config_materialize_result_t* out_result);
 
+// Overlays exact config.def values from |config_module| onto matching config
+// symbols in |module|.
+//
+// Both modules must belong to the same context and be distinct. The config
+// module is borrowed and remains unchanged. It must contain only top-level
+// config.def operations; unresolved declarations and unrelated program
+// operations are rejected. Definitions without matching config symbols in the
+// target module are ignored so one reusable config module can serve several
+// related programs.
+iree_status_t loom_tooling_config_overlay_module(
+    loom_module_t* module, const loom_module_t* config_module,
+    iree_arena_block_pool_t* block_pool,
+    loom_tooling_config_materialize_result_t* out_result);
+
 // Requires that |module| contains no remaining config.decl symbols.
 //
 // Linkable/library outputs should not call this: unresolved declarations are

--- a/loom/src/loom/tooling/config/config_application.h
+++ b/loom/src/loom/tooling/config/config_application.h
@@ -1,0 +1,52 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Shared IR application mechanics for structured and textual configuration.
+
+#ifndef LOOM_TOOLING_CONFIG_CONFIG_APPLICATION_H_
+#define LOOM_TOOLING_CONFIG_CONFIG_APPLICATION_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+#include "loom/ir/module.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Returns the result value defined by a config.decl/config.def operation.
+loom_value_id_t loom_tooling_config_symbol_result_value(const loom_op_t* op);
+
+// Returns the display name of |symbol| or a stable invalid-name marker.
+iree_string_view_t loom_tooling_config_symbol_name(const loom_module_t* module,
+                                                   const loom_symbol_t* symbol);
+
+// Finds a symbol named |key| or returns LOOM_SYMBOL_ID_INVALID.
+uint16_t loom_tooling_config_find_symbol(const loom_module_t* module,
+                                         iree_string_view_t key);
+
+// Returns true when |symbol| is defined by a config operation.
+bool loom_tooling_config_symbol_is_config(const loom_symbol_t* symbol);
+
+// Remaps one config type/value pair into target-module-owned storage.
+iree_status_t loom_tooling_config_remap_type_and_value(
+    const loom_module_t* source_module, loom_module_t* target_module,
+    loom_type_t source_type, loom_attribute_t source_value,
+    iree_arena_block_pool_t* block_pool, loom_type_t* out_target_type,
+    loom_attribute_t* out_target_value);
+
+// Replaces |old_op| with an exact config.def after checking its contract.
+iree_status_t loom_tooling_config_apply_exact_value(loom_module_t* module,
+                                                    iree_string_view_t key,
+                                                    loom_op_t* old_op,
+                                                    loom_type_t type,
+                                                    loom_attribute_t value);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TOOLING_CONFIG_CONFIG_APPLICATION_H_

--- a/loom/src/loom/tooling/config/config_test.cc
+++ b/loom/src/loom/tooling/config/config_test.cc
@@ -97,6 +97,13 @@ class ConfigMaterializeTest : public ::testing::Test {
     return status;
   }
 
+  iree_status_t Overlay(loom_module_t* module,
+                        const loom_module_t* config_module,
+                        loom_tooling_config_materialize_result_t* out_result) {
+    return loom_tooling_config_overlay_module(module, config_module,
+                                              &block_pool_, out_result);
+  }
+
   iree_arena_block_pool_t block_pool_;
   loom_context_t context_;
 };
@@ -114,10 +121,10 @@ TEST_F(ConfigMaterializeTest, ConfigSetOwnsAssignmentsAndRejectsDuplicates) {
   EXPECT_TRUE(iree_string_view_equal(config_set.bindings[0].value,
                                      iree_make_cstring_view("4096")));
 
-  iree_status_t status = loom_tooling_config_set_append_assignment(
-      &config_set, IREE_SV("model36.model.hidden_size=8192"));
-  EXPECT_EQ(iree_status_code(status), IREE_STATUS_INVALID_ARGUMENT);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_tooling_config_set_append_assignment(
+          &config_set, IREE_SV("model36.model.hidden_size=8192")));
 
   loom_tooling_config_set_deinitialize(&config_set);
 }
@@ -185,10 +192,10 @@ TEST_F(ConfigMaterializeTest, ConfigSetAppendsJsonFileBindings) {
   EXPECT_TRUE(iree_string_view_equal(config_set.bindings[0].value,
                                      iree_make_cstring_view("4096")));
 
-  iree_status_t status = loom_tooling_config_set_append_json_file(
-      &config_set, IREE_SV("-"), iree_allocator_system());
-  EXPECT_EQ(iree_status_code(status), IREE_STATUS_INVALID_ARGUMENT);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_tooling_config_set_append_json_file(&config_set, IREE_SV("-"),
+                                               iree_allocator_system()));
 
   loom_tooling_config_set_deinitialize(&config_set);
 }
@@ -250,9 +257,8 @@ config.decl @model36.model.hidden_size : %value: index where [range(%value, 0, 8
       /*.key=*/IREE_SV("model36.model.hidden_size"),
       /*.value=*/IREE_SV("4103"),
   };
-  iree_status_t status = Materialize(module.get(), &binding, 1, nullptr);
-  EXPECT_EQ(iree_status_code(status), IREE_STATUS_INVALID_ARGUMENT);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        Materialize(module.get(), &binding, 1, nullptr));
 }
 
 TEST_F(ConfigMaterializeTest, MaterializesEncodingValue) {
@@ -284,9 +290,78 @@ config.decl @model36.layout : encoding<layout>
       /*.key=*/IREE_SV("model36.layout"),
       /*.value=*/IREE_SV("#ggml.q4_0"),
   };
-  iree_status_t status = Materialize(module.get(), &binding, 1, nullptr);
-  EXPECT_EQ(iree_status_code(status), IREE_STATUS_INVALID_ARGUMENT);
-  iree_status_free(status);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        Materialize(module.get(), &binding, 1, nullptr));
+}
+
+TEST_F(ConfigMaterializeTest, OverlaysExactDefinitionsFromConfigModule) {
+  ModulePtr module = Parse(R"(
+config.decl @model36.model.hidden_size : %value: index where [range(%value, 0, 8192), mul(%value, 16)]
+config.decl @model36.layout : encoding<layout>
+)");
+  ModulePtr config_module = Parse(R"(
+config.def @model36.model.hidden_size = 4096 : index
+config.def @model36.layout = #encoding.layout.dense : encoding<layout>
+config.def @model36.unused = true : i1
+)");
+
+  loom_tooling_config_materialize_result_t result = {0};
+  IREE_ASSERT_OK(Overlay(module.get(), config_module.get(), &result));
+  EXPECT_EQ(result.materialized_count, 2u);
+  EXPECT_EQ(result.ignored_count, 1u);
+
+  std::string config_printed = Print(config_module.get());
+  EXPECT_NE(config_printed.find("config.def @model36.unused = true : i1"),
+            std::string::npos);
+  config_module.reset();
+
+  std::string printed = Print(module.get());
+  EXPECT_NE(
+      printed.find("config.def @model36.model.hidden_size = 4096 : index"),
+      std::string::npos);
+  EXPECT_NE(
+      printed.find("config.def @model36.layout = #encoding.layout.dense : "
+                   "encoding<layout>"),
+      std::string::npos);
+  EXPECT_EQ(printed.find("model36.unused"), std::string::npos);
+}
+
+TEST_F(ConfigMaterializeTest, ConfigModuleMustSatisfyTargetContract) {
+  ModulePtr module = Parse(R"(
+config.decl @model36.model.hidden_size : %value: index where [range(%value, 0, 8192), mul(%value, 16)]
+)");
+  ModulePtr config_module = Parse(R"(
+config.def @model36.model.hidden_size = 4103 : index
+)");
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        Overlay(module.get(), config_module.get(), nullptr));
+}
+
+TEST_F(ConfigMaterializeTest, ConfigModuleDefinitionTypesMustMatch) {
+  ModulePtr module = Parse(R"(
+config.decl @model36.model.hidden_size : index
+)");
+  ModulePtr config_module = Parse(R"(
+config.def @model36.model.hidden_size = 4096.0 : f32
+)");
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        Overlay(module.get(), config_module.get(), nullptr));
+}
+
+TEST_F(ConfigMaterializeTest, ConfigModuleRejectsProgramOperations) {
+  ModulePtr module = Parse(R"(
+config.decl @model36.model.hidden_size : index
+)");
+  ModulePtr config_module = Parse(R"(
+func.def @not_config() {
+  func.return
+}
+)");
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        Overlay(module.get(), config_module.get(), nullptr));
 }
 
 TEST_F(ConfigMaterializeTest, RequireResolvedRejectsRemainingDecls) {
@@ -295,11 +370,10 @@ config.decl @model36.model.hidden_size : index
 )");
 
   loom_tooling_config_resolution_result_t result = {0};
-  iree_status_t status =
-      loom_tooling_config_require_resolved_module(module.get(), &result);
-  EXPECT_EQ(iree_status_code(status), IREE_STATUS_FAILED_PRECONDITION);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_FAILED_PRECONDITION,
+      loom_tooling_config_require_resolved_module(module.get(), &result));
   EXPECT_EQ(result.unresolved_count, 1u);
-  iree_status_free(status);
 }
 
 TEST_F(ConfigMaterializeTest, RequireResolvedAcceptsDefs) {

--- a/loom/src/loom/tooling/config/config_text.c
+++ b/loom/src/loom/tooling/config/config_text.c
@@ -1,0 +1,789 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <inttypes.h>
+#include <string.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/json.h"
+#include "loom/format/text/parser.h"
+#include "loom/format/text/printer.h"
+#include "loom/ir/attribute.h"
+#include "loom/ir/encoding.h"
+#include "loom/ops/config/ops.h"
+#include "loom/ops/encoding/roles.h"
+#include "loom/tooling/config/config.h"
+#include "loom/tooling/config/config_application.h"
+#include "loom/tooling/io/file.h"
+#include "loom/util/json.h"
+#include "loom/util/stream.h"
+
+void loom_tooling_config_materialize_options_initialize(
+    loom_tooling_config_materialize_options_t* out_options) {
+  IREE_ASSERT_ARGUMENT(out_options);
+  memset(out_options, 0, sizeof(*out_options));
+}
+
+void loom_tooling_config_set_initialize(
+    iree_allocator_t host_allocator,
+    loom_tooling_config_set_t* out_config_set) {
+  IREE_ASSERT_ARGUMENT(out_config_set);
+  memset(out_config_set, 0, sizeof(*out_config_set));
+  out_config_set->host_allocator = host_allocator;
+}
+
+void loom_tooling_config_set_deinitialize(
+    loom_tooling_config_set_t* config_set) {
+  if (!config_set) {
+    return;
+  }
+  for (iree_host_size_t i = 0; i < config_set->binding_count; ++i) {
+    iree_allocator_free(config_set->host_allocator,
+                        (void*)config_set->bindings[i].key.data);
+    iree_allocator_free(config_set->host_allocator,
+                        (void*)config_set->bindings[i].value.data);
+  }
+  iree_allocator_free(config_set->host_allocator, config_set->bindings);
+  iree_allocator_t host_allocator = config_set->host_allocator;
+  memset(config_set, 0, sizeof(*config_set));
+  config_set->host_allocator = host_allocator;
+}
+
+static iree_string_view_t loom_tooling_config_normalize_key(
+    iree_string_view_t key) {
+  key = iree_string_view_trim(key);
+  (void)iree_string_view_consume_prefix_char(&key, '@');
+  return iree_string_view_trim(key);
+}
+
+iree_status_t loom_tooling_config_parse_assignment(
+    iree_string_view_t assignment, loom_tooling_config_binding_t* out_binding) {
+  IREE_ASSERT_ARGUMENT(out_binding);
+  iree_string_view_t key = iree_string_view_empty();
+  iree_string_view_t value = iree_string_view_empty();
+  if (iree_string_view_split(assignment, '=', &key, &value) < 0) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "config assignment must use key=value syntax, got '%.*s'",
+        (int)assignment.size, assignment.data);
+  }
+  key = loom_tooling_config_normalize_key(key);
+  value = iree_string_view_trim(value);
+  if (iree_string_view_is_empty(key)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config assignment key must not be empty");
+  }
+  if (iree_string_view_is_empty(value)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "config assignment for '%.*s' must provide a non-empty value",
+        (int)key.size, key.data);
+  }
+  *out_binding = (loom_tooling_config_binding_t){
+      .key = key,
+      .value = value,
+  };
+  return iree_ok_status();
+}
+
+static iree_status_t loom_tooling_config_clone_string_view(
+    iree_allocator_t allocator, iree_string_view_t value,
+    iree_string_view_t* out_value) {
+  iree_host_size_t byte_length = 0;
+  if (!iree_host_size_checked_add(value.size, 1, &byte_length)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "config string length overflow");
+  }
+  char* data = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(allocator, byte_length, (void**)&data));
+  memcpy(data, value.data, value.size);
+  data[value.size] = '\0';
+  *out_value = iree_make_string_view(data, value.size);
+  return iree_ok_status();
+}
+
+static iree_status_t loom_tooling_config_set_reserve(
+    loom_tooling_config_set_t* config_set, iree_host_size_t minimum_capacity) {
+  if (config_set->binding_capacity >= minimum_capacity) {
+    return iree_ok_status();
+  }
+  iree_host_size_t new_capacity =
+      config_set->binding_capacity ? config_set->binding_capacity : 4;
+  while (new_capacity < minimum_capacity) {
+    if (new_capacity > IREE_HOST_SIZE_MAX / 2) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "config binding capacity overflow");
+    }
+    new_capacity *= 2;
+  }
+  IREE_RETURN_IF_ERROR(iree_allocator_realloc_array(
+      config_set->host_allocator, new_capacity, sizeof(*config_set->bindings),
+      (void**)&config_set->bindings));
+  config_set->binding_capacity = new_capacity;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_tooling_config_set_check_duplicate(
+    const loom_tooling_config_set_t* config_set, iree_string_view_t key) {
+  for (iree_host_size_t i = 0; i < config_set->binding_count; ++i) {
+    if (!iree_string_view_equal(config_set->bindings[i].key, key)) {
+      continue;
+    }
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "duplicate config binding for '%.*s'",
+                            (int)key.size, key.data);
+  }
+  return iree_ok_status();
+}
+
+iree_status_t loom_tooling_config_set_append(
+    loom_tooling_config_set_t* config_set, iree_string_view_t key,
+    iree_string_view_t value) {
+  IREE_ASSERT_ARGUMENT(config_set);
+  key = loom_tooling_config_normalize_key(key);
+  value = iree_string_view_trim(value);
+  if (iree_string_view_is_empty(key)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config binding key must not be empty");
+  }
+  if (iree_string_view_is_empty(value)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "config binding for '%.*s' must provide a non-empty value",
+        (int)key.size, key.data);
+  }
+  IREE_RETURN_IF_ERROR(
+      loom_tooling_config_set_check_duplicate(config_set, key));
+  iree_host_size_t minimum_capacity = 0;
+  if (!iree_host_size_checked_add(config_set->binding_count, 1,
+                                  &minimum_capacity)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "config binding count overflow");
+  }
+  IREE_RETURN_IF_ERROR(
+      loom_tooling_config_set_reserve(config_set, minimum_capacity));
+
+  iree_string_view_t copied_key = iree_string_view_empty();
+  iree_status_t status = loom_tooling_config_clone_string_view(
+      config_set->host_allocator, key, &copied_key);
+  iree_string_view_t copied_value = iree_string_view_empty();
+  if (iree_status_is_ok(status)) {
+    status = loom_tooling_config_clone_string_view(config_set->host_allocator,
+                                                   value, &copied_value);
+  }
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free(config_set->host_allocator, (void*)copied_key.data);
+    return status;
+  }
+
+  config_set->bindings[config_set->binding_count++] =
+      (loom_tooling_config_binding_t){
+          .key = copied_key,
+          .value = copied_value,
+      };
+  return iree_ok_status();
+}
+
+iree_status_t loom_tooling_config_set_append_assignment(
+    loom_tooling_config_set_t* config_set, iree_string_view_t assignment) {
+  IREE_ASSERT_ARGUMENT(config_set);
+  loom_tooling_config_binding_t binding = {0};
+  IREE_RETURN_IF_ERROR(
+      loom_tooling_config_parse_assignment(assignment, &binding));
+  return loom_tooling_config_set_append(config_set, binding.key, binding.value);
+}
+
+static iree_status_t loom_tooling_config_append_unescaped_json_string(
+    iree_string_view_t escaped_string, iree_string_builder_t* builder,
+    iree_host_size_t* out_length) {
+  iree_host_size_t unescaped_length = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_json_unescape_string(escaped_string, 0, NULL, &unescaped_length));
+  char* target = NULL;
+  if (unescaped_length > 0) {
+    IREE_RETURN_IF_ERROR(
+        iree_string_builder_append_inline(builder, unescaped_length, &target));
+    IREE_RETURN_IF_ERROR(iree_json_unescape_string(
+        escaped_string, unescaped_length, target, &unescaped_length));
+  }
+  *out_length = unescaped_length;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_tooling_config_append_json_key(
+    iree_string_view_t prefix, iree_string_view_t escaped_key,
+    iree_string_builder_t* builder) {
+  if (!iree_string_view_is_empty(prefix)) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(builder, prefix));
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, "."));
+  }
+  iree_host_size_t key_length = 0;
+  IREE_RETURN_IF_ERROR(loom_tooling_config_append_unescaped_json_string(
+      escaped_key, builder, &key_length));
+  if (key_length == 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config JSON object keys must not be empty");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_tooling_config_set_append_json_value(
+    loom_tooling_config_set_t* config_set, iree_string_view_t key,
+    iree_json_value_type_t value_type, iree_string_view_t value) {
+  switch (value_type) {
+    case IREE_JSON_VALUE_TYPE_STRING: {
+      iree_string_builder_t value_builder;
+      iree_string_builder_initialize(config_set->host_allocator,
+                                     &value_builder);
+      iree_host_size_t value_length = 0;
+      iree_status_t status = loom_tooling_config_append_unescaped_json_string(
+          value, &value_builder, &value_length);
+      if (iree_status_is_ok(status)) {
+        status = loom_tooling_config_set_append(
+            config_set, key, iree_string_builder_view(&value_builder));
+      }
+      iree_string_builder_deinitialize(&value_builder);
+      return status;
+    }
+    case IREE_JSON_VALUE_TYPE_NUMBER:
+    case IREE_JSON_VALUE_TYPE_TRUE:
+    case IREE_JSON_VALUE_TYPE_FALSE:
+      return loom_tooling_config_set_append(config_set, key, value);
+    case IREE_JSON_VALUE_TYPE_ARRAY:
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "config JSON binding '%.*s' uses an unsupported array value",
+          (int)key.size, key.data);
+    case IREE_JSON_VALUE_TYPE_NULL:
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "config JSON binding '%.*s' must not be null",
+                              (int)key.size, key.data);
+    case IREE_JSON_VALUE_TYPE_OBJECT:
+    default:
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "config JSON binding '%.*s' has unsupported value type",
+          (int)key.size, key.data);
+  }
+}
+
+typedef struct loom_tooling_config_json_object_state_t {
+  loom_tooling_config_set_t* config_set;
+  iree_string_view_t prefix;
+  uint8_t depth;
+} loom_tooling_config_json_object_state_t;
+
+static iree_status_t loom_tooling_config_set_append_json_object_impl(
+    loom_tooling_config_set_t* config_set, iree_string_view_t object,
+    iree_string_view_t prefix, uint8_t depth);
+
+static iree_status_t loom_tooling_config_set_append_json_member(
+    void* user_data, iree_string_view_t escaped_key,
+    iree_json_value_type_t value_type, iree_string_view_t value) {
+  loom_tooling_config_json_object_state_t* state =
+      (loom_tooling_config_json_object_state_t*)user_data;
+  iree_string_builder_t key_builder;
+  iree_string_builder_initialize(state->config_set->host_allocator,
+                                 &key_builder);
+  iree_status_t status = loom_tooling_config_append_json_key(
+      state->prefix, escaped_key, &key_builder);
+  if (iree_status_is_ok(status)) {
+    iree_string_view_t key = iree_string_builder_view(&key_builder);
+    if (value_type == IREE_JSON_VALUE_TYPE_OBJECT) {
+      status = loom_tooling_config_set_append_json_object_impl(
+          state->config_set, value, key, (uint8_t)(state->depth + 1));
+    } else {
+      status = loom_tooling_config_set_append_json_value(state->config_set, key,
+                                                         value_type, value);
+    }
+  }
+  iree_string_builder_deinitialize(&key_builder);
+  return status;
+}
+
+static iree_status_t loom_tooling_config_set_append_json_object_impl(
+    loom_tooling_config_set_t* config_set, iree_string_view_t object,
+    iree_string_view_t prefix, uint8_t depth) {
+  if (depth >= 128) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config JSON object nesting is too deep");
+  }
+  loom_tooling_config_json_object_state_t state = {
+      .config_set = config_set,
+      .prefix = prefix,
+      .depth = depth,
+  };
+  return iree_json_enumerate_object_typed(
+      object, loom_tooling_config_set_append_json_member, &state);
+}
+
+iree_status_t loom_tooling_config_set_append_json_object(
+    loom_tooling_config_set_t* config_set, iree_string_view_t json_object) {
+  IREE_ASSERT_ARGUMENT(config_set);
+  iree_string_view_t cursor = json_object;
+  iree_string_view_t object = iree_string_view_empty();
+  IREE_RETURN_IF_ERROR(iree_json_consume_object(&cursor, &object));
+  IREE_RETURN_IF_ERROR(iree_json_consume_insignificant(&cursor));
+  if (!iree_string_view_is_empty(cursor)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "unexpected trailing content after config JSON");
+  }
+  return loom_tooling_config_set_append_json_object_impl(
+      config_set, object, iree_string_view_empty(), /*depth=*/0);
+}
+
+iree_status_t loom_tooling_config_set_append_json_file(
+    loom_tooling_config_set_t* config_set, iree_string_view_t path,
+    iree_allocator_t host_allocator) {
+  IREE_ASSERT_ARGUMENT(config_set);
+  path = iree_string_view_trim(path);
+  if (loom_tooling_file_path_is_stdio(path)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "config JSON file requires a filesystem path, not stdin");
+  }
+
+  iree_io_file_contents_t* contents = NULL;
+  iree_status_t status =
+      loom_tooling_read_input_file(path, host_allocator, &contents);
+  if (iree_status_is_ok(status)) {
+    status = loom_tooling_config_set_append_json_object(
+        config_set, loom_tooling_file_contents_string_view(contents));
+  }
+  if (!iree_status_is_ok(status)) {
+    status = iree_status_annotate_f(status, "config JSON file '%.*s'",
+                                    (int)path.size, path.data);
+  }
+  iree_io_file_contents_free(contents);
+  return status;
+}
+
+static iree_status_t loom_tooling_config_parse_encoding_value(
+    loom_module_t* module, loom_type_t type, iree_string_view_t value_text,
+    iree_arena_block_pool_t* block_pool, loom_attribute_t* out_attr,
+    iree_allocator_t host_allocator) {
+  iree_string_builder_t builder;
+  iree_string_builder_initialize(host_allocator, &builder);
+  loom_output_stream_t stream;
+  loom_output_stream_for_builder(&builder, &stream);
+
+  iree_status_t status = iree_string_builder_append_cstring(
+      &builder, "config.def @__config_value = ");
+  if (iree_status_is_ok(status)) {
+    status = iree_string_builder_append_string(&builder, value_text);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_string_builder_append_cstring(&builder, " : ");
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_text_print_type(type, module, &stream);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_string_builder_append_cstring(&builder, "\n");
+  }
+
+  loom_module_t* parsed_module = NULL;
+  if (iree_status_is_ok(status)) {
+    loom_text_parse_options_t parse_options = {
+        .max_errors = 20,
+    };
+    status = loom_text_parse(iree_string_builder_view(&builder),
+                             IREE_SV("<config>"), module->context, block_pool,
+                             &parse_options, &parsed_module);
+  }
+  if (iree_status_is_ok(status) && !parsed_module) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "failed to parse config encoding value '%.*s'",
+                              (int)value_text.size, value_text.data);
+  }
+  if (iree_status_is_ok(status)) {
+    loom_op_t* op = loom_module_block(parsed_module)->first_op;
+    if (!op || !loom_config_def_isa(op)) {
+      status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "failed to parse config encoding value");
+    } else {
+      loom_type_t remapped_type = {0};
+      status = loom_tooling_config_remap_type_and_value(
+          parsed_module, module,
+          loom_module_value_type(parsed_module, loom_config_def_type(op)),
+          loom_config_def_value(op), block_pool, &remapped_type, out_attr);
+      if (iree_status_is_ok(status) && !loom_type_equal(remapped_type, type)) {
+        status = iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "parsed config encoding value has an incompatible type");
+      }
+    }
+  }
+
+  if (parsed_module) {
+    loom_module_free(parsed_module);
+  }
+  iree_string_builder_deinitialize(&builder);
+  return status;
+}
+
+static iree_status_t loom_tooling_config_check_encoding_role(
+    const loom_module_t* module, iree_string_view_t key, loom_type_t type,
+    loom_attribute_t value) {
+  loom_encoding_role_t expected_role = loom_type_encoding_role(type);
+  if (expected_role == LOOM_ENCODING_ROLE_UNKNOWN) {
+    return iree_ok_status();
+  }
+  const loom_encoding_t* encoding =
+      loom_module_encoding(module, loom_attr_as_encoding_id(value));
+  loom_encoding_role_t actual_role =
+      loom_encoding_static_role(module, encoding);
+  if (actual_role == expected_role) {
+    return iree_ok_status();
+  }
+  iree_string_view_t expected = loom_encoding_role_description(expected_role);
+  iree_string_view_t actual = loom_encoding_role_description(actual_role);
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "config '%.*s' expects %.*s, got %.*s", (int)key.size,
+                          key.data, (int)expected.size, expected.data,
+                          (int)actual.size, actual.data);
+}
+
+static iree_status_t loom_tooling_config_parse_scalar_value(
+    iree_string_view_t key, loom_type_t type, iree_string_view_t value_text,
+    loom_attribute_t* out_attr) {
+  loom_scalar_type_t scalar_type = loom_type_element_type(type);
+  if (scalar_type == LOOM_SCALAR_TYPE_I1) {
+    if (iree_string_view_equal_case(value_text, IREE_SV("true"))) {
+      *out_attr = loom_attr_bool(true);
+      return iree_ok_status();
+    }
+    if (iree_string_view_equal_case(value_text, IREE_SV("false"))) {
+      *out_attr = loom_attr_bool(false);
+      return iree_ok_status();
+    }
+    int64_t value = 0;
+    if (!iree_string_view_atoi_int64(value_text, &value) ||
+        (value != 0 && value != 1)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "config '%.*s' expects i1 value true/false/0/1, got '%.*s'",
+          (int)key.size, key.data, (int)value_text.size, value_text.data);
+    }
+    *out_attr = loom_attr_bool(value != 0);
+    return iree_ok_status();
+  }
+
+  if (scalar_type == LOOM_SCALAR_TYPE_INDEX ||
+      scalar_type == LOOM_SCALAR_TYPE_OFFSET ||
+      loom_scalar_type_is_integer(scalar_type)) {
+    int64_t value = 0;
+    if (!iree_string_view_atoi_int64(value_text, &value)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "config '%.*s' expects integer value, got '%.*s'",
+                              (int)key.size, key.data, (int)value_text.size,
+                              value_text.data);
+    }
+    int64_t domain_lo = INT64_MIN;
+    int64_t domain_hi = INT64_MAX;
+    if (loom_scalar_type_integer_domain(scalar_type, &domain_lo, &domain_hi) &&
+        (value < domain_lo || value > domain_hi)) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "config '%.*s' value %" PRId64 " is outside the %s domain [%" PRId64
+          ", %" PRId64 "]",
+          (int)key.size, key.data, value, loom_scalar_type_name(scalar_type),
+          domain_lo, domain_hi);
+    }
+    *out_attr = loom_attr_i64(value);
+    return iree_ok_status();
+  }
+
+  if (loom_scalar_type_is_float(scalar_type)) {
+    double value = 0.0;
+    if (!iree_string_view_atod(value_text, &value)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "config '%.*s' expects floating-point value, got '%.*s'",
+          (int)key.size, key.data, (int)value_text.size, value_text.data);
+    }
+    *out_attr = loom_attr_f64(value);
+    return iree_ok_status();
+  }
+
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "config '%.*s' has unsupported scalar type %s",
+                          (int)key.size, key.data,
+                          loom_scalar_type_name(scalar_type));
+}
+
+static iree_status_t loom_tooling_config_parse_value(
+    loom_module_t* module, iree_string_view_t key, loom_type_t type,
+    iree_string_view_t value_text, iree_arena_block_pool_t* block_pool,
+    loom_attribute_t* out_attr) {
+  if (loom_type_is_scalar(type)) {
+    return loom_tooling_config_parse_scalar_value(key, type, value_text,
+                                                  out_attr);
+  }
+  if (loom_type_is_encoding(type)) {
+    IREE_RETURN_IF_ERROR(loom_tooling_config_parse_encoding_value(
+        module, type, value_text, block_pool, out_attr,
+        iree_allocator_system()));
+    return loom_tooling_config_check_encoding_role(module, key, type,
+                                                   *out_attr);
+  }
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "config '%.*s' has unsupported type", (int)key.size,
+                          key.data);
+}
+
+iree_status_t loom_tooling_config_materialize_module(
+    loom_module_t* module,
+    const loom_tooling_config_materialize_options_t* options,
+    iree_arena_block_pool_t* block_pool,
+    loom_tooling_config_materialize_result_t* out_result) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(options);
+  IREE_ASSERT_ARGUMENT(block_pool);
+  const loom_tooling_config_set_t* config_set = options->config_set;
+  const iree_host_size_t binding_count =
+      config_set ? config_set->binding_count : 0;
+  if (config_set && !config_set->bindings && binding_count > 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config bindings pointer is NULL");
+  }
+
+  loom_tooling_config_materialize_result_t result = {0};
+  if (binding_count == 0) {
+    if (out_result) *out_result = result;
+    return iree_ok_status();
+  }
+
+  for (iree_host_size_t i = 0; i < binding_count; ++i) {
+    const loom_tooling_config_binding_t* binding = &config_set->bindings[i];
+    iree_string_view_t key = binding->key;
+    iree_string_view_t value_text = binding->value;
+    const uint16_t symbol_id = loom_tooling_config_find_symbol(module, key);
+    if (symbol_id == LOOM_SYMBOL_ID_INVALID) {
+      ++result.ignored_count;
+      continue;
+    }
+
+    loom_symbol_t* symbol = &module->symbols.entries[symbol_id];
+    if (!loom_tooling_config_symbol_is_config(symbol)) {
+      ++result.ignored_count;
+      continue;
+    }
+    loom_op_t* old_op = symbol->defining_op;
+    loom_value_id_t config_value =
+        loom_tooling_config_symbol_result_value(old_op);
+    if (config_value == LOOM_VALUE_ID_INVALID ||
+        config_value >= module->values.count) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "config '%.*s' has no result value",
+                              (int)key.size, key.data);
+    }
+    loom_type_t config_type = loom_module_value_type(module, config_value);
+
+    loom_attribute_t value = {0};
+    IREE_RETURN_IF_ERROR(loom_tooling_config_parse_value(
+        module, key, config_type, value_text, block_pool, &value));
+    IREE_RETURN_IF_ERROR(loom_tooling_config_apply_exact_value(
+        module, loom_tooling_config_symbol_name(module, symbol), old_op,
+        config_type, value));
+    ++result.materialized_count;
+  }
+
+  if (out_result) *out_result = result;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_tooling_config_write_printed_type_string(
+    const loom_module_t* module, loom_type_t type,
+    loom_output_stream_t* stream) {
+  IREE_RETURN_IF_ERROR(loom_output_stream_write_char(stream, '"'));
+  loom_json_escape_stream_t escape_data;
+  loom_output_stream_t escape_stream;
+  loom_json_escape_stream_init(stream, &escape_data, &escape_stream);
+  IREE_RETURN_IF_ERROR(loom_text_print_type(type, module, &escape_stream));
+  return loom_output_stream_write_char(stream, '"');
+}
+
+static iree_status_t loom_tooling_config_write_printed_attr_string(
+    const loom_module_t* module, loom_attribute_t attr,
+    loom_output_stream_t* stream) {
+  IREE_RETURN_IF_ERROR(loom_output_stream_write_char(stream, '"'));
+  loom_json_escape_stream_t escape_data;
+  loom_output_stream_t escape_stream;
+  loom_json_escape_stream_init(stream, &escape_data, &escape_stream);
+  IREE_RETURN_IF_ERROR(
+      loom_text_print_attribute(&attr, module, &escape_stream));
+  return loom_output_stream_write_char(stream, '"');
+}
+
+static iree_string_view_t loom_tooling_config_predicate_arg_kind_name(
+    uint8_t tag) {
+  switch ((loom_predicate_arg_tag_t)tag) {
+    case LOOM_PRED_ARG_NONE:
+      return IREE_SV("none");
+    case LOOM_PRED_ARG_VALUE:
+      return IREE_SV("value");
+    case LOOM_PRED_ARG_CONST:
+      return IREE_SV("const");
+    default:
+      return IREE_SV("unknown");
+  }
+}
+
+static iree_status_t loom_tooling_config_format_predicate_arg_json(
+    const loom_predicate_t* predicate, uint8_t arg_index,
+    loom_output_stream_t* stream) {
+  uint8_t tag = LOOM_PRED_ARG_NONE;
+  int64_t value = 0;
+  if (arg_index < predicate->arg_count) {
+    tag = predicate->arg_tags[arg_index];
+    value = predicate->args[arg_index];
+  }
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &object, IREE_SV("kind"),
+      loom_tooling_config_predicate_arg_kind_name(tag)));
+  switch ((loom_predicate_arg_tag_t)tag) {
+    case LOOM_PRED_ARG_VALUE: {
+      IREE_RETURN_IF_ERROR(loom_json_object_write_int64_field(
+          &object, IREE_SV("value_id"), value));
+      break;
+    }
+    case LOOM_PRED_ARG_CONST: {
+      IREE_RETURN_IF_ERROR(
+          loom_json_object_write_int64_field(&object, IREE_SV("value"), value));
+      break;
+    }
+    default:
+      break;
+  }
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t loom_tooling_config_format_predicate_json(
+    const loom_predicate_t* predicate, loom_output_stream_t* stream) {
+  const char* kind_name = loom_predicate_kind_name(predicate->kind);
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &object, IREE_SV("kind"),
+      kind_name ? iree_make_cstring_view(kind_name) : IREE_SV("unknown")));
+  IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&object, IREE_SV("args")));
+  loom_json_array_writer_t args;
+  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &args));
+  for (uint8_t i = 0; i < predicate->arg_count; ++i) {
+    IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&args));
+    IREE_RETURN_IF_ERROR(
+        loom_tooling_config_format_predicate_arg_json(predicate, i, stream));
+  }
+  IREE_RETURN_IF_ERROR(loom_json_array_end(&args));
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t loom_tooling_config_format_predicates_json(
+    loom_attribute_t predicates, loom_output_stream_t* stream) {
+  if (predicates.kind != LOOM_ATTR_ABSENT &&
+      predicates.kind != LOOM_ATTR_PREDICATE_LIST) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config constraints must be a predicate list");
+  }
+  if (predicates.kind == LOOM_ATTR_PREDICATE_LIST && predicates.count > 0 &&
+      !predicates.predicate_list) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config constraints predicate list is missing");
+  }
+  loom_json_array_writer_t array;
+  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &array));
+  if (predicates.kind == LOOM_ATTR_PREDICATE_LIST) {
+    for (uint16_t i = 0; i < predicates.count; ++i) {
+      IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&array));
+      IREE_RETURN_IF_ERROR(loom_tooling_config_format_predicate_json(
+          &predicates.predicate_list[i], stream));
+    }
+  }
+  return loom_json_array_end(&array);
+}
+
+static iree_status_t loom_tooling_config_format_schema_entry_json(
+    const loom_module_t* module, const loom_symbol_t* symbol,
+    loom_output_stream_t* stream) {
+  loom_op_t* op = symbol->defining_op;
+  const bool is_decl = loom_config_decl_isa(op);
+  const bool is_def = loom_config_def_isa(op);
+  if (!is_decl && !is_def) {
+    iree_string_view_t symbol_name =
+        loom_tooling_config_symbol_name(module, symbol);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config symbol '@%.*s' is not a config.decl/def",
+                            (int)symbol_name.size, symbol_name.data);
+  }
+
+  loom_value_id_t config_value = loom_tooling_config_symbol_result_value(op);
+  if (config_value == LOOM_VALUE_ID_INVALID ||
+      config_value >= module->values.count) {
+    iree_string_view_t symbol_name =
+        loom_tooling_config_symbol_name(module, symbol);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "config symbol '@%.*s' has no result value",
+                            (int)symbol_name.size, symbol_name.data);
+  }
+  loom_type_t config_type = loom_module_value_type(module, config_value);
+
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &object, IREE_SV("name"),
+      loom_tooling_config_symbol_name(module, symbol)));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &object, IREE_SV("state"), is_decl ? IREE_SV("decl") : IREE_SV("def")));
+  IREE_RETURN_IF_ERROR(
+      loom_json_object_write_bool_field(&object, IREE_SV("required"), is_decl));
+  IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&object, IREE_SV("type")));
+  IREE_RETURN_IF_ERROR(loom_tooling_config_write_printed_type_string(
+      module, config_type, stream));
+  if (is_def) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("default")));
+    IREE_RETURN_IF_ERROR(loom_tooling_config_write_printed_attr_string(
+        module, loom_config_def_value(op), stream));
+  }
+  IREE_RETURN_IF_ERROR(
+      loom_json_object_begin_field(&object, IREE_SV("constraints")));
+  loom_attribute_t predicates =
+      is_decl ? loom_config_decl_predicates(op) : loom_attr_absent();
+  IREE_RETURN_IF_ERROR(
+      loom_tooling_config_format_predicates_json(predicates, stream));
+  return loom_json_object_end(&object);
+}
+
+iree_status_t loom_tooling_config_format_schema_json(
+    const loom_module_t* module, loom_output_stream_t* stream) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(stream);
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(
+      loom_json_object_begin_field(&object, IREE_SV("configs")));
+  loom_json_array_writer_t configs;
+  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &configs));
+  iree_host_size_t config_count = 0;
+  const loom_symbol_t* symbol = NULL;
+  loom_module_for_each_symbol(module, symbol) {
+    if (!loom_tooling_config_symbol_is_config(symbol)) {
+      continue;
+    }
+    IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&configs));
+    IREE_RETURN_IF_ERROR(
+        loom_tooling_config_format_schema_entry_json(module, symbol, stream));
+    ++config_count;
+  }
+  IREE_RETURN_IF_ERROR(loom_json_array_end(&configs));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("count"), config_count));
+  return loom_json_object_end(&object);
+}


### PR DESCRIPTION
LoomC bytecode-only JITs can now configure compilation without retaining Loom's text parser. The direct compile boundary borrows an ordinary verified module containing exact `config.def` operations, applies matching definitions to the mutable program module, and leaves the configuration module immutable and reusable across programs and concurrent compiler workers.

This aligns configuration with the representation Loom already verifies, serializes, and owns. Textual key/value and JSON conveniences remain available where they belong—link and command-product materialization—but they no longer impose a parser dependency on every direct compiler embedding.

## Make configuration an ordinary typed module

Previously, `loomc_compile_options_t` embedded text and JSON bindings. Scalar bindings could be parsed directly, but encoding-valued bindings printed a miniature `config.def` module and invoked the full Loom module parser. Consequently, a production bytecode-to-HSACO JIT retained the parser and tokenizer even though it never accepted program text.

Compile options now carry resolution policy plus an optional typed module:

```c
loomc_compile_options_t options = {
    .type = LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
    .structure_size = sizeof(options),
    .config_flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
    .config_module = config_module,
};

loomc_status_t status = loomc_compile_module(
    compiler, workspace, pass_program, program_module, &options,
    allocator, &result);
```

`config_module` is loaded through the normal text- or bytecode-specific module API. It must share the compiler context, remain distinct from the mutable program module, and contain exact `config.def` operations. The invocation borrows it only for the call and never mutates or retains it, so one deserialized config module can serve many independent compilation workspaces.

Application matches definitions by symbol, remaps their types and values into program-module ownership, checks structural type equality and authored declaration predicates, and replaces the matching declaration or default. Definitions without a matching program symbol are ignored deliberately, preserving the stable-config-bag behavior needed by frameworks that reuse one configuration across related kernels. Unresolved declarations, wrong types, failed predicates, and non-config provider contents retain structured `CONFIG/INVALID` diagnostics.

The implementation uses Loom's generic cross-module IR remapper for scalar and encoding attributes. This deletes the config-specific recursive attribute copier and ensures copied values survive provider-module teardown without introducing an opaque prepared-config handle, second grammar, or config-specific serialization format.

## Keep textual adapters independently linkable

Structured module application and text/JSON materialization are separate archive members of one config library. `config.c` owns typed overlay and final-resolution policy; `config_text.c` owns key/value normalization, JSON parsing, and textual value materialization. Bazel and generated CMake metadata keep both sources in one library ownership surface, while an ordinary static final link selects only the object required by the APIs the embedding actually calls.

`loomc_link_*` and command-product operations continue to accept `loomc_config_options_t`, including JSON plus explicit binding override semantics. Direct compile operations accept only the typed module. There is no wrapper family combining program format with config format: both program and config use the existing module codecs before entering one compile pipeline.

Compile reports now describe the structured operation directly:

- `has_config_module`
- `config_definition_count`
- `config_materialized_count`
- `config_ignored_count`
- `config_flags`

The throughput benchmarks prepare typed configuration modules during scenario setup and borrow them during timed compilation. This models a real JIT/autotuner that prepares candidate configurations once instead of charging text parsing to every compile.

## Product impact

The production witness is the public selected-gfx1151 LoomC path from Loom bytecode through a prepared-low pipeline to an in-memory HSACO, built with optimized ThinLTO and compact IREE status payloads.

| Product | Parent | This change | Delta |
| --- | ---: | ---: | ---: |
| Selected gfx1151 bytecode-to-HSACO JIT, stripped | 6,359,288 bytes | 6,137,304 bytes | -221,984 bytes (-3.49%) |

The final link contains no Loom parser, tokenizer, or text-config object. The rich diagnostic printer remains because structured source diagnostics are a core product feature. Equivalent configuration emits the same 9,192-byte HSACO byte for byte, with SHA-256 `37c39a9e5b71b750d04287bebbf31426a68da564ad7d402c82abb7b4b65f9fac`.

Locked, balanced A/B measurements of the config-bearing gfx1100 compile benchmark put the typed-module candidate at 9,646,177 ns and the parent at 9,582,756 ns per 16 kernels: +0.66%, within the established 1% measurement noise floor. A targetless compile control also showed no regression. The size reduction therefore comes from final-link reachability rather than moving parser work onto the compile hot path.

## Reviewer notes

The highest-value review surfaces are the public module lifetime/context contract in `loomc_compile_options_t`, exact-value remapping and predicate enforcement in the typed overlay, and the ownership split that keeps text/JSON available without retaining it in bytecode-only products. The three commits keep those concerns separate: target-neutral typed overlay, archive-member isolation, and public LoomC integration.
