### PR TITLE
[CI] Keep credentials off cross-origin redirects

### DIFF
--- a/build_tools/ci/loom_binary_size.py
+++ b/build_tools/ci/loom_binary_size.py
@@ -646,6 +646,43 @@ def report(args: argparse.Namespace) -> None:
     (args.output_dir / "summary.md").write_text(summary, encoding="utf-8")
 
 
+def _url_origin(url: str) -> tuple[str, str | None, int | None]:
+    parsed = urllib.parse.urlsplit(url)
+    scheme = parsed.scheme.casefold()
+    port = parsed.port
+    if port is None:
+        port = {"http": 80, "https": 443}.get(scheme)
+    hostname = parsed.hostname.casefold() if parsed.hostname else None
+    return scheme, hostname, port
+
+
+class _GitHubRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Keeps GitHub API credentials within the request's origin."""
+
+    def redirect_request(
+        self,
+        request: urllib.request.Request,
+        file_pointer: Any,
+        code: int,
+        message: str,
+        headers: Any,
+        new_url: str,
+    ) -> urllib.request.Request | None:
+        redirected_request = super().redirect_request(
+            request, file_pointer, code, message, headers, new_url
+        )
+        if redirected_request is not None and _url_origin(
+            request.full_url
+        ) != _url_origin(new_url):
+            redirected_request.remove_header("Authorization")
+        return redirected_request
+
+
+def _open_github_request(request: urllib.request.Request) -> Any:
+    opener = urllib.request.build_opener(_GitHubRedirectHandler())
+    return opener.open(request)
+
+
 def _github_json(url: str, token: str) -> Any:
     request = urllib.request.Request(
         url,
@@ -655,7 +692,7 @@ def _github_json(url: str, token: str) -> Any:
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    with urllib.request.urlopen(request) as response:
+    with _open_github_request(request) as response:
         return json.load(response)
 
 
@@ -668,7 +705,7 @@ def _github_bytes(url: str, token: str) -> bytes:
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
-    with urllib.request.urlopen(request) as response:
+    with _open_github_request(request) as response:
         return response.read()
 
 

--- a/build_tools/ci/loom_binary_size_test.py
+++ b/build_tools/ci/loom_binary_size_test.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import tempfile
 import unittest
+import urllib.request
 import zipfile
 from io import BytesIO
 from pathlib import Path
@@ -299,6 +300,35 @@ class LoomBinarySizeTest(unittest.TestCase):
             loom_binary_size.BinarySizeError, "head does not match"
         ):
             loom_binary_size.history_from_zip(payload.getvalue(), COMMIT_B)
+
+    def test_github_authorization_does_not_cross_redirect_origins(self):
+        handler = loom_binary_size._GitHubRedirectHandler()
+        request = urllib.request.Request(
+            "https://api.github.com/repos/ROCm/hrx-system/actions/artifacts/1/zip",
+            headers={"Authorization": "Bearer secret"},
+        )
+
+        cross_origin_request = handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            "https://results.example.com/artifact.zip",
+        )
+        same_origin_request = handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            "https://API.GITHUB.COM:443/artifact.zip",
+        )
+
+        self.assertIsNotNone(cross_origin_request)
+        self.assertFalse(cross_origin_request.has_header("Authorization"))
+        self.assertIsNotNone(same_origin_request)
+        self.assertTrue(same_origin_request.has_header("Authorization"))
 
     def test_report_writes_rolling_state_and_summary(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
GitHub Actions serves artifact archives through an authenticated API endpoint that redirects to a signed object-store URL. Python urllib copied the GitHub Authorization header onto that cross-origin redirect, so the object store rejected the otherwise valid archive with HTTP 401. The first main size-analysis run could publish its baseline because there was no history to fetch; consuming that newly published artifact exposed the failure.

GitHub requests now use an origin-aware redirect handler. Authentication remains attached when the scheme, host, and normalized port still identify the same origin, while cross-origin redirects rely solely on their signed URL. This keeps credentials within the GitHub API trust boundary and lets the rolling history reader consume the baseline published by main.