### PR TITLE
[Loom] Preserve value facts across no-op compiler work

### DIFF
--- a/loom/src/loom/codegen/low/transforms/pipeline/target_legalize.c
+++ b/loom/src/loom/codegen/low/transforms/pipeline/target_legalize.c
@@ -1279,7 +1279,7 @@ static iree_status_t loom_low_target_legalize_rewrite_op(
     return iree_ok_status();
   }
   IREE_RETURN_IF_ERROR(loom_low_target_legalize_check_assume_predicates(
-      state, op, driver->latest_facts));
+      state, op, driver->fact_table));
   if (state->preflight_error_count != 0) {
     return iree_ok_status();
   }
@@ -1299,7 +1299,7 @@ static iree_status_t loom_low_target_legalize_rewrite_op(
                         : iree_string_view_empty();
   const uint32_t source_op_kind = op->kind;
 
-  state->legalization_context.fact_table = driver->latest_facts;
+  state->legalization_context.fact_table = driver->fact_table;
   state->legalization_context.rewriter = &driver->rewriter;
   state->legalization_context.arena = driver->scratch_arena;
   loom_target_contract_query_result_t query_result =
@@ -1509,6 +1509,29 @@ static iree_status_t loom_low_target_legalize_acquire_final_facts(
   return iree_ok_status();
 }
 
+static iree_status_t loom_low_target_legalize_prepare_rewrite_facts(
+    loom_module_t* module, const loom_low_source_selection_t* selection,
+    const loom_value_fact_table_t* seed_facts,
+    loom_pass_value_fact_owner_t* rewrite_value_facts,
+    loom_value_fact_table_t** out_rewrite_fact_table) {
+  iree_status_t status = loom_pass_value_fact_owner_prepare(
+      rewrite_value_facts, module,
+      loom_pass_value_fact_scope_region_for_target(
+          selection->func, loom_func_like_body(selection->func),
+          selection->func.op, selection->target_facts),
+      out_rewrite_fact_table);
+  if (iree_status_is_ok(status) && seed_facts) {
+    status = loom_value_fact_table_clone_defined_facts(*out_rewrite_fact_table,
+                                                       seed_facts, module);
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_value_fact_table_compute_region(
+        *out_rewrite_fact_table, module, selection->func,
+        loom_func_like_body(selection->func), selection->func.op);
+  }
+  return status;
+}
+
 static iree_status_t loom_low_target_legalize_function(
     loom_pass_t* pass, loom_module_t* module,
     const loom_low_target_legalize_pass_state_t* pass_state,
@@ -1563,11 +1586,18 @@ static iree_status_t loom_low_target_legalize_function(
   loom_pass_value_fact_owner_t rewrite_value_facts = {0};
   loom_pass_value_fact_owner_initialize(module->arena.block_pool,
                                         &rewrite_value_facts);
+  loom_value_fact_table_t* rewrite_fact_table = NULL;
+  iree_status_t status = loom_low_target_legalize_prepare_rewrite_facts(
+      module, selection, seed_facts, &rewrite_value_facts, &rewrite_fact_table);
+  if (!iree_status_is_ok(status)) {
+    loom_pass_value_fact_owner_deinitialize(&rewrite_value_facts);
+    return status;
+  }
   iree_arena_allocator_t rewrite_arena;
   iree_arena_initialize(module->arena.block_pool, &rewrite_arena);
   loom_greedy_rewrite_driver_t rewrite_driver;
   loom_greedy_rewrite_driver_initialize(module, &rewrite_arena,
-                                        &rewrite_value_facts, &rewrite_driver);
+                                        rewrite_fact_table, &rewrite_driver);
 
   state.legalization_context = (loom_target_legalization_context_t){
       .pass = pass,
@@ -1585,8 +1615,6 @@ static iree_status_t loom_low_target_legalize_function(
   };
   const loom_greedy_rewrite_options_t rewrite_options = {
       .max_iterations = pass_state->max_iterations,
-      .target_facts = selection->target_facts,
-      .seed_facts = seed_facts,
   };
   const loom_greedy_rewrite_callbacks_t rewrite_callbacks = {
       .user_data = &state,
@@ -1594,10 +1622,10 @@ static iree_status_t loom_low_target_legalize_function(
       .changed = loom_low_target_legalize_changed,
   };
   loom_greedy_rewrite_result_t rewrite_result = {0};
-  iree_status_t status = loom_greedy_rewrite_run_region(
-      &rewrite_driver, selection->func, loom_func_like_body(selection->func),
-      selection->func.op, &rewrite_options, &rewrite_callbacks,
-      &rewrite_result);
+  status = loom_greedy_rewrite_run_region(&rewrite_driver, selection->func,
+                                          loom_func_like_body(selection->func),
+                                          selection->func.op, &rewrite_options,
+                                          &rewrite_callbacks, &rewrite_result);
   if (iree_status_is_ok(status) && rewrite_result.changed) {
     loom_pass_mark_changed(pass);
     if (pass->value_facts != NULL) {

--- a/loom/src/loom/pass/interpreter.c
+++ b/loom/src/loom/pass/interpreter.c
@@ -175,6 +175,41 @@ static void loom_pass_interpreter_accumulate_diagnostics(
   state->result->remark_count += counter->remark_count;
 }
 
+static bool loom_pass_interpreter_has_value_fact_lifecycle_counts(
+    const loom_pass_value_fact_lifecycle_counts_t* counts) {
+  return counts->acquisition_count != 0 || counts->cache_hit_count != 0 ||
+         counts->recomputation_count != 0 || counts->preparation_count != 0 ||
+         counts->invalidation_count != 0 || counts->scope_clear_count != 0 ||
+         counts->computed_value_count != 0 || counts->cleared_value_count != 0;
+}
+
+static iree_status_t loom_pass_interpreter_append_value_fact_lifecycle_detail(
+    loom_pass_t* pass, const loom_pass_value_fact_lifecycle_counts_t* counts) {
+  if (!loom_pass_interpreter_has_value_fact_lifecycle_counts(counts)) {
+    return iree_ok_status();
+  }
+  const loom_pass_report_detail_field_t fields[] = {
+      loom_pass_report_detail_uint64_field(IREE_SV("acquisition_count"),
+                                           counts->acquisition_count),
+      loom_pass_report_detail_uint64_field(IREE_SV("cache_hit_count"),
+                                           counts->cache_hit_count),
+      loom_pass_report_detail_uint64_field(IREE_SV("recomputation_count"),
+                                           counts->recomputation_count),
+      loom_pass_report_detail_uint64_field(IREE_SV("preparation_count"),
+                                           counts->preparation_count),
+      loom_pass_report_detail_uint64_field(IREE_SV("invalidation_count"),
+                                           counts->invalidation_count),
+      loom_pass_report_detail_uint64_field(IREE_SV("scope_clear_count"),
+                                           counts->scope_clear_count),
+      loom_pass_report_detail_uint64_field(IREE_SV("computed_value_count"),
+                                           counts->computed_value_count),
+      loom_pass_report_detail_uint64_field(IREE_SV("cleared_value_count"),
+                                           counts->cleared_value_count),
+  };
+  return loom_pass_report_append_detail(pass, IREE_SV("value-facts"), fields,
+                                        IREE_ARRAYSIZE(fields));
+}
+
 static iree_status_code_t loom_pass_interpreter_invocation_status_code(
     iree_status_code_t status_code,
     const loom_pass_interpreter_diagnostic_counter_t* counter) {
@@ -342,6 +377,7 @@ static iree_status_t loom_pass_interpreter_invoke(
   };
 
   loom_pass_t pass = {0};
+  loom_pass_value_fact_lifecycle_counts_t value_fact_lifecycle_counts = {0};
   iree_status_t trace_status = loom_pass_trace_emit(
       state->options->trace, &(loom_pass_trace_event_t){
                                  .module = state->module,
@@ -357,6 +393,9 @@ static iree_status_t loom_pass_interpreter_invoke(
                              });
   iree_status_t status = iree_ok_status();
   bool pass_execution_allowed = iree_status_is_ok(trace_status);
+  if (state->options->report && pass_execution_allowed) {
+    state->value_facts.lifecycle_counts = &value_fact_lifecycle_counts;
+  }
   if (pass_execution_allowed) {
     status = loom_pass_interpreter_make_pass(
         state, instruction, pass_diagnostic_emitter, &instance_arena, &pass);
@@ -393,6 +432,7 @@ static iree_status_t loom_pass_interpreter_invoke(
   if (created && invoke->descriptor->destroy) {
     invoke->descriptor->destroy(&pass);
   }
+  state->value_facts.lifecycle_counts = NULL;
 
   iree_status_code_t status_code = loom_pass_interpreter_invocation_status_code(
       iree_status_code(status), &diagnostic_counter);
@@ -421,21 +461,25 @@ static iree_status_t loom_pass_interpreter_invoke(
 
   if (state->options->report && pass_execution_allowed) {
     iree_duration_t duration_nanoseconds = iree_time_now() - start_time;
-    report_status = loom_pass_report_append_invocation(
-        state->options->report,
-        &(loom_pass_report_invocation_options_t){
-            .instruction = instruction,
-            .instruction_index = instruction_index,
-            .anchor_kind = frame->kind,
-            .pipeline_symbol = pipeline_symbol,
-            .symbol_name = symbol_name,
-            .duration_nanoseconds = duration_nanoseconds,
-            .changed = invocation_changed,
-            .status_code = status_code,
-            .statistic_storage = pass.statistic_storage,
-            .detail_head = pass.report_detail_head,
-            .detail_count = pass.report_detail_count,
-        });
+    report_status = loom_pass_interpreter_append_value_fact_lifecycle_detail(
+        &pass, &value_fact_lifecycle_counts);
+    if (iree_status_is_ok(report_status)) {
+      report_status = loom_pass_report_append_invocation(
+          state->options->report,
+          &(loom_pass_report_invocation_options_t){
+              .instruction = instruction,
+              .instruction_index = instruction_index,
+              .anchor_kind = frame->kind,
+              .pipeline_symbol = pipeline_symbol,
+              .symbol_name = symbol_name,
+              .duration_nanoseconds = duration_nanoseconds,
+              .changed = invocation_changed,
+              .status_code = status_code,
+              .statistic_storage = pass.statistic_storage,
+              .detail_head = pass.report_detail_head,
+              .detail_count = pass.report_detail_count,
+          });
+    }
     if (iree_status_is_ok(report_status)) {
       pass.report_detail_head = NULL;
       pass.report_detail_tail = NULL;

--- a/loom/src/loom/pass/interpreter_test.cc
+++ b/loom/src/loom/pass/interpreter_test.cc
@@ -28,6 +28,28 @@ struct DiagnosticCapture {
   loom_diagnostic_param_t params[4] = {};
 };
 
+static const loom_pass_report_detail_t* FindReportDetail(
+    const loom_pass_report_invocation_t& invocation,
+    iree_string_view_t category) {
+  const loom_pass_report_detail_t* detail = invocation.details;
+  while (detail) {
+    if (iree_string_view_equal(detail->category, category)) return detail;
+    detail = detail->next;
+  }
+  return nullptr;
+}
+
+static const loom_pass_report_detail_field_t* FindReportDetailField(
+    const loom_pass_report_detail_t* detail, iree_string_view_t name) {
+  if (!detail) return nullptr;
+  for (uint16_t i = 0; i < detail->field_count; ++i) {
+    if (iree_string_view_equal(detail->fields[i].name, name)) {
+      return &detail->fields[i];
+    }
+  }
+  return nullptr;
+}
+
 class PassInterpreterTest : public PassTestHarness {
  protected:
   static iree_status_t CaptureDiagnostic(
@@ -230,6 +252,79 @@ TEST_F(PassInterpreterTest, AppendsExecutionReportRecords) {
   EXPECT_TRUE(iree_string_view_equal(function_record.details->fields[2].name,
                                      IREE_SV("synthetic_event_count")));
   EXPECT_EQ(function_record.details->fields[2].uint64_value, 1u);
+}
+
+TEST_F(PassInterpreterTest, ReportsValueFactReuseAndInvalidation) {
+  loom_module_t* module =
+      Parse(IREE_SV("pass.pipeline<module> @pipeline pipeline {\n"
+                    "  for func {\n"
+                    "    test.acquire-value-facts\n"
+                    "    test.acquire-value-facts\n"
+                    "    test.mark-changed\n"
+                    "    test.acquire-value-facts\n"
+                    "  }\n"
+                    "}\n"
+                    "test.func @main() {\n"
+                    "  %value = test.constant 42 : i32\n"
+                    "  test.yield\n"
+                    "}\n"));
+  ASSERT_NE(module, nullptr);
+
+  PassProgramStorage storage;
+  IREE_ASSERT_OK(Compile(module, Pipeline(module, 0), &storage.program));
+
+  PassReportStorage report_storage;
+  loom_test_pass_trace_t trace = {};
+  loom_pass_interpreter_options_t options =
+      InterpreterOptions(&trace, {}, &report_storage.report);
+  loom_pass_run_result_t result = {};
+  IREE_ASSERT_OK(loom_pass_interpreter_run_module(&storage.program, module,
+                                                  &options, &result));
+
+  ASSERT_EQ(report_storage.report.invocation_count, 4u);
+  const loom_pass_report_detail_t* first_acquire = FindReportDetail(
+      report_storage.report.invocations[0], IREE_SV("value-facts"));
+  ASSERT_NE(first_acquire, nullptr);
+  const loom_pass_report_detail_field_t* first_recomputation =
+      FindReportDetailField(first_acquire, IREE_SV("recomputation_count"));
+  ASSERT_NE(first_recomputation, nullptr);
+  EXPECT_EQ(first_recomputation->uint64_value, 1u);
+  const loom_pass_report_detail_field_t* first_computed_values =
+      FindReportDetailField(first_acquire, IREE_SV("computed_value_count"));
+  ASSERT_NE(first_computed_values, nullptr);
+  EXPECT_GT(first_computed_values->uint64_value, 0u);
+
+  const loom_pass_report_detail_t* second_acquire = FindReportDetail(
+      report_storage.report.invocations[1], IREE_SV("value-facts"));
+  ASSERT_NE(second_acquire, nullptr);
+  const loom_pass_report_detail_field_t* cache_hits =
+      FindReportDetailField(second_acquire, IREE_SV("cache_hit_count"));
+  ASSERT_NE(cache_hits, nullptr);
+  EXPECT_EQ(cache_hits->uint64_value, 1u);
+
+  const loom_pass_report_detail_t* invalidation = FindReportDetail(
+      report_storage.report.invocations[2], IREE_SV("value-facts"));
+  ASSERT_NE(invalidation, nullptr);
+  const loom_pass_report_detail_field_t* invalidation_count =
+      FindReportDetailField(invalidation, IREE_SV("invalidation_count"));
+  ASSERT_NE(invalidation_count, nullptr);
+  EXPECT_EQ(invalidation_count->uint64_value, 1u);
+  const loom_pass_report_detail_field_t* scope_clears =
+      FindReportDetailField(invalidation, IREE_SV("scope_clear_count"));
+  ASSERT_NE(scope_clears, nullptr);
+  EXPECT_EQ(scope_clears->uint64_value, 1u);
+  const loom_pass_report_detail_field_t* cleared_values =
+      FindReportDetailField(invalidation, IREE_SV("cleared_value_count"));
+  ASSERT_NE(cleared_values, nullptr);
+  EXPECT_EQ(cleared_values->uint64_value, first_computed_values->uint64_value);
+
+  const loom_pass_report_detail_t* reacquire = FindReportDetail(
+      report_storage.report.invocations[3], IREE_SV("value-facts"));
+  ASSERT_NE(reacquire, nullptr);
+  const loom_pass_report_detail_field_t* reacquire_recomputation =
+      FindReportDetailField(reacquire, IREE_SV("recomputation_count"));
+  ASSERT_NE(reacquire_recomputation, nullptr);
+  EXPECT_EQ(reacquire_recomputation->uint64_value, 1u);
 }
 
 TEST_F(PassInterpreterTest, AppliesNamePredicateToCurrentFunction) {

--- a/loom/src/loom/pass/test/BUILD.bazel
+++ b/loom/src/loom/pass/test/BUILD.bazel
@@ -30,6 +30,7 @@ loom_cc_library(
         "//loom/src/loom/pass:registry",
         "//loom/src/loom/pass:report",
         "//loom/src/loom/pass:types",
+        "//loom/src/loom/pass:value_facts",
         "//runtime/src/iree/base",
     ],
 )

--- a/loom/src/loom/pass/test/CMakeLists.txt
+++ b/loom/src/loom/pass/test/CMakeLists.txt
@@ -25,6 +25,7 @@ loom_cc_library(
     loom::pass::registry
     loom::pass::report
     loom::pass::types
+    loom::pass::value_facts
   TESTONLY
   PUBLIC
 )

--- a/loom/src/loom/pass/test/registry.c
+++ b/loom/src/loom/pass/test/registry.c
@@ -12,6 +12,7 @@
 #include "loom/ops/op_defs.h"
 #include "loom/ops/test/ops.h"
 #include "loom/pass/report.h"
+#include "loom/pass/value_facts.h"
 
 static bool loom_test_pass_target_record_satisfies_requirement(
     const loom_pass_environment_capability_t* capability,
@@ -146,6 +147,14 @@ static iree_status_t loom_test_noop_run(loom_pass_t* pass,
       loom_test_invocation_statistics(pass);
   ++statistics->invocations;
   return iree_ok_status();
+}
+
+static iree_status_t loom_test_acquire_value_facts_run(
+    loom_pass_t* pass, loom_module_t* module, loom_func_like_t function) {
+  loom_value_fact_table_t* value_facts = NULL;
+  return loom_pass_value_facts_acquire(
+      pass, module, loom_pass_value_fact_scope_function(function),
+      &value_facts);
 }
 
 static iree_status_t loom_test_mark_changed_run(loom_pass_t* pass,
@@ -405,6 +414,16 @@ static const loom_pass_info_t* loom_test_noop_pass_info(void) {
   return &kTestNoopPassInfo;
 }
 
+static const loom_pass_info_t kTestAcquireValueFactsPassInfo = {
+    .name = IREE_SVL("test.acquire-value-facts"),
+    .description = IREE_SVL("Acquire function-scoped value facts."),
+    .kind = LOOM_PASS_FUNCTION,
+};
+
+static const loom_pass_info_t* loom_test_acquire_value_facts_pass_info(void) {
+  return &kTestAcquireValueFactsPassInfo;
+}
+
 static const loom_pass_info_t kTestOptionsPassInfo = {
     .name = IREE_SVL("test.options"),
     .description = IREE_SVL("Synthetic function pass with typed options."),
@@ -463,6 +482,11 @@ static const loom_pass_info_t* loom_test_unavailable_pass_info(void) {
 }
 
 static const loom_pass_descriptor_t kTestPassDescriptors[] = {
+    {
+        .key = IREE_SVL("test.acquire-value-facts"),
+        .info = loom_test_acquire_value_facts_pass_info,
+        .function_run = loom_test_acquire_value_facts_run,
+    },
     {
         .key = IREE_SVL("test.fail"),
         .info = loom_test_fail_pass_info,

--- a/loom/src/loom/pass/test/registry_test.cc
+++ b/loom/src/loom/pass/test/registry_test.cc
@@ -28,27 +28,6 @@ TEST(PassTestRegistryTest, Verifies) {
   IREE_ASSERT_OK(loom_pass_registry_verify(loom_test_pass_registry()));
 }
 
-TEST(PassTestRegistryTest, ContainsExpectedPasses) {
-  const loom_pass_registry_t* registry = loom_test_pass_registry();
-  const iree_string_view_t expected_keys[] = {
-      IREE_SV("test.fail"),
-      IREE_SV("test.mark-changed"),
-      IREE_SV("test.module-noop"),
-      IREE_SV("test.noop"),
-      IREE_SV("test.options"),
-      IREE_SV("test.required"),
-      IREE_SV("test.requires-target"),
-      IREE_SV("test.resource-lifetime"),
-      IREE_SV("test.unavailable"),
-  };
-  ASSERT_EQ(registry->descriptor_count, IREE_ARRAYSIZE(expected_keys));
-  for (iree_host_size_t i = 0; i < registry->descriptor_count; ++i) {
-    EXPECT_TRUE(
-        iree_string_view_equal(registry->descriptors[i].key, expected_keys[i]))
-        << "unexpected test pass registry entry " << i;
-  }
-}
-
 TEST(PassTestRegistryTest, ValidatesOptions) {
   const loom_pass_descriptor_t* descriptor =
       LookupTestPass(IREE_SV("test.options"));

--- a/loom/src/loom/pass/value_facts.c
+++ b/loom/src/loom/pass/value_facts.c
@@ -55,6 +55,30 @@ static iree_status_t loom_pass_value_fact_scope_validate(
   }
 }
 
+static void loom_pass_value_fact_owner_record_scope_clear(
+    loom_pass_value_fact_owner_t* owner) {
+  if (!owner->lifecycle_counts) return;
+  if (owner->active_scope.kind == LOOM_PASS_VALUE_FACT_SCOPE_NONE &&
+      owner->table.touched_count == 0) {
+    return;
+  }
+  ++owner->lifecycle_counts->scope_clear_count;
+  owner->lifecycle_counts->cleared_value_count += owner->table.touched_count;
+}
+
+static void loom_pass_value_fact_owner_clear_scope(
+    loom_pass_value_fact_owner_t* owner) {
+  if (!iree_any_bit_set(owner->flags,
+                        LOOM_PASS_VALUE_FACT_OWNER_FLAG_TABLE_INITIALIZED)) {
+    owner->active_scope = loom_pass_value_fact_scope_none();
+    return;
+  }
+  loom_pass_value_fact_owner_record_scope_clear(owner);
+  loom_value_fact_table_clear_scope(&owner->table);
+  iree_arena_reset(&owner->transient_arena);
+  owner->active_scope = loom_pass_value_fact_scope_none();
+}
+
 static iree_status_t loom_pass_value_fact_owner_ensure_table(
     loom_pass_value_fact_owner_t* owner, const loom_module_t* module) {
   iree_host_size_t capacity = loom_value_table_capacity(&module->values);
@@ -64,6 +88,7 @@ static iree_status_t loom_pass_value_fact_owner_ensure_table(
     return iree_ok_status();
   }
 
+  loom_pass_value_fact_owner_record_scope_clear(owner);
   iree_arena_reset(&owner->storage_arena);
   iree_arena_reset(&owner->transient_arena);
   owner->module = module;
@@ -119,9 +144,10 @@ void loom_pass_value_fact_owner_invalidate(
     owner->active_scope = loom_pass_value_fact_scope_none();
     return;
   }
-  loom_value_fact_table_clear_scope(&owner->table);
-  iree_arena_reset(&owner->transient_arena);
-  owner->active_scope = loom_pass_value_fact_scope_none();
+  if (owner->lifecycle_counts) {
+    ++owner->lifecycle_counts->invalidation_count;
+  }
+  loom_pass_value_fact_owner_clear_scope(owner);
 }
 
 iree_status_t loom_pass_value_fact_owner_prepare(
@@ -129,9 +155,12 @@ iree_status_t loom_pass_value_fact_owner_prepare(
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table) {
   *out_table = NULL;
 
+  if (owner->lifecycle_counts) {
+    ++owner->lifecycle_counts->preparation_count;
+  }
   IREE_RETURN_IF_ERROR(loom_pass_value_fact_scope_validate(scope));
   IREE_RETURN_IF_ERROR(loom_pass_value_fact_owner_ensure_table(owner, module));
-  loom_pass_value_fact_owner_invalidate(owner);
+  loom_pass_value_fact_owner_clear_scope(owner);
   owner->table.context.target_facts = scope.target_facts;
   *out_table = &owner->table;
   return iree_ok_status();
@@ -142,16 +171,26 @@ iree_status_t loom_pass_value_fact_owner_acquire(
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table) {
   *out_table = NULL;
 
+  if (owner->lifecycle_counts) {
+    ++owner->lifecycle_counts->acquisition_count;
+  }
   IREE_RETURN_IF_ERROR(loom_pass_value_fact_scope_validate(scope));
   IREE_RETURN_IF_ERROR(loom_pass_value_fact_owner_ensure_table(owner, module));
   if (owner->module == module &&
       loom_pass_value_fact_scope_equal(owner->active_scope, scope)) {
+    if (owner->lifecycle_counts) {
+      ++owner->lifecycle_counts->cache_hit_count;
+    }
     *out_table = &owner->table;
     return iree_ok_status();
   }
 
-  IREE_RETURN_IF_ERROR(
-      loom_pass_value_fact_owner_prepare(owner, module, scope, out_table));
+  loom_pass_value_fact_owner_clear_scope(owner);
+  owner->table.context.target_facts = scope.target_facts;
+  *out_table = &owner->table;
+  if (owner->lifecycle_counts) {
+    ++owner->lifecycle_counts->recomputation_count;
+  }
   iree_status_t status = iree_ok_status();
   switch (scope.kind) {
     case LOOM_PASS_VALUE_FACT_SCOPE_FUNCTION:
@@ -172,9 +211,13 @@ iree_status_t loom_pass_value_fact_owner_acquire(
   }
   if (iree_status_is_ok(status)) {
     owner->active_scope = scope;
+    if (owner->lifecycle_counts) {
+      owner->lifecycle_counts->computed_value_count +=
+          owner->table.touched_count;
+    }
     return iree_ok_status();
   }
-  loom_pass_value_fact_owner_invalidate(owner);
+  loom_pass_value_fact_owner_clear_scope(owner);
   return status;
 }
 

--- a/loom/src/loom/pass/value_facts.h
+++ b/loom/src/loom/pass/value_facts.h
@@ -36,6 +36,29 @@ typedef enum loom_pass_value_fact_owner_flag_bits_e {
 } loom_pass_value_fact_owner_flag_bits_t;
 typedef uint32_t loom_pass_value_fact_owner_flags_t;
 
+// Optional deterministic counts for one observed value-fact owner interval.
+// The owner checks for and updates these only at lifecycle transitions while
+// lifecycle_counts is non-NULL; ordinary pass execution performs no counter
+// updates.
+typedef struct loom_pass_value_fact_lifecycle_counts_t {
+  // Number of computed-fact acquisition requests.
+  uint64_t acquisition_count;
+  // Number of acquisitions served by the already-active scope.
+  uint64_t cache_hit_count;
+  // Number of complete scope computations attempted after cache misses.
+  uint64_t recomputation_count;
+  // Number of empty scopes prepared for caller-maintained facts.
+  uint64_t preparation_count;
+  // Number of explicit invalidation requests against an initialized table.
+  uint64_t invalidation_count;
+  // Number of populated scopes actually cleared for any lifecycle reason.
+  uint64_t scope_clear_count;
+  // Total number of SSA value entries produced by complete computations.
+  uint64_t computed_value_count;
+  // Total number of populated SSA value entries discarded by scope clears.
+  uint64_t cleared_value_count;
+} loom_pass_value_fact_lifecycle_counts_t;
+
 typedef struct loom_pass_value_fact_scope_t {
   // Requested fact population scope.
   loom_pass_value_fact_scope_kind_t kind;
@@ -125,6 +148,8 @@ struct loom_pass_value_fact_owner_t {
   loom_pass_value_fact_scope_t active_scope;
   // Owner state flags.
   loom_pass_value_fact_owner_flags_t flags;
+  // Optional borrowed counters updated at owner lifecycle transitions.
+  loom_pass_value_fact_lifecycle_counts_t* lifecycle_counts;
 };
 
 // Initializes a dormant owner. This performs no fact-table allocation and no

--- a/loom/src/loom/pass/value_facts_test.cc
+++ b/loom/src/loom/pass/value_facts_test.cc
@@ -358,5 +358,55 @@ TEST_F(PassValueFactsTest, InvalidateClearsActiveScopeWithoutLosingStorage) {
   loom_pass_value_fact_owner_deinitialize(&owner);
 }
 
+TEST_F(PassValueFactsTest,
+       LifecycleCountsDistinguishReuseAndRedundantInvalidation) {
+  loom_module_t* module =
+      Parse(IREE_SV("test.func @main() {\n"
+                    "  %value = test.constant 99 : i32\n"
+                    "  test.yield\n"
+                    "}\n"));
+  ASSERT_NE(module, nullptr);
+  loom_func_like_t function = Function(module, 0);
+
+  loom_pass_value_fact_owner_t owner = {};
+  loom_pass_value_fact_owner_initialize(block_pool(), &owner);
+  loom_pass_value_fact_lifecycle_counts_t counts = {};
+  owner.lifecycle_counts = &counts;
+
+  loom_value_fact_table_t* facts = nullptr;
+  IREE_ASSERT_OK(loom_pass_value_fact_owner_acquire(
+      &owner, module, loom_pass_value_fact_scope_function(function), &facts));
+  ASSERT_NE(facts, nullptr);
+  const iree_host_size_t populated_value_count = facts->touched_count;
+  EXPECT_GT(populated_value_count, 0u);
+
+  loom_value_fact_table_t* reused_facts = nullptr;
+  IREE_ASSERT_OK(loom_pass_value_fact_owner_acquire(
+      &owner, module, loom_pass_value_fact_scope_function(function),
+      &reused_facts));
+  EXPECT_EQ(reused_facts, facts);
+  EXPECT_EQ(counts.acquisition_count, 2u);
+  EXPECT_EQ(counts.cache_hit_count, 1u);
+  EXPECT_EQ(counts.recomputation_count, 1u);
+  EXPECT_EQ(counts.computed_value_count, populated_value_count);
+
+  loom_pass_value_fact_owner_invalidate(&owner);
+  loom_pass_value_fact_owner_invalidate(&owner);
+  EXPECT_EQ(counts.invalidation_count, 2u);
+  EXPECT_EQ(counts.scope_clear_count, 1u);
+  EXPECT_EQ(counts.cleared_value_count, populated_value_count);
+
+  loom_value_fact_table_t* prepared_facts = nullptr;
+  IREE_ASSERT_OK(loom_pass_value_fact_owner_prepare(
+      &owner, module, loom_pass_value_fact_scope_function(function),
+      &prepared_facts));
+  EXPECT_EQ(prepared_facts, facts);
+  EXPECT_EQ(counts.preparation_count, 1u);
+  EXPECT_EQ(counts.scope_clear_count, 1u);
+
+  owner.lifecycle_counts = nullptr;
+  loom_pass_value_fact_owner_deinitialize(&owner);
+}
+
 }  // namespace
 }  // namespace loom

--- a/loom/src/loom/rewrite/BUILD.bazel
+++ b/loom/src/loom/rewrite/BUILD.bazel
@@ -33,7 +33,6 @@ loom_cc_library(
     deps = [
         ":rewriter",
         "//loom/src/loom/ir",
-        "//loom/src/loom/pass:value_facts",
         "//loom/src/loom/util:fact_table",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",
@@ -48,6 +47,7 @@ loom_cc_test(
         "//loom/src/loom/ir",
         "//loom/src/loom/ops:op_defs",
         "//loom/src/loom/ops/test",
+        "//loom/src/loom/pass:value_facts",
         "//loom/src/loom/target:facts",
         "//loom/src/loom/target:types",
         "//runtime/src/iree/base/internal:arena",

--- a/loom/src/loom/rewrite/CMakeLists.txt
+++ b/loom/src/loom/rewrite/CMakeLists.txt
@@ -38,7 +38,6 @@ loom_cc_library(
     iree::base
     iree::base::internal::arena
     loom::ir
-    loom::pass::value_facts
     loom::util::fact_table
   PUBLIC
 )
@@ -56,6 +55,7 @@ loom_cc_test(
     loom::ir
     loom::ops::op_defs
     loom::ops::test
+    loom::pass::value_facts
     loom::target::facts
     loom::target::types
 )

--- a/loom/src/loom/rewrite/greedy.c
+++ b/loom/src/loom/rewrite/greedy.c
@@ -10,12 +10,18 @@
 
 void loom_greedy_rewrite_driver_initialize(
     loom_module_t* module, iree_arena_allocator_t* scratch_arena,
-    loom_pass_value_fact_owner_t* value_facts,
+    loom_value_fact_table_t* fact_table,
     loom_greedy_rewrite_driver_t* out_driver) {
   memset(out_driver, 0, sizeof(*out_driver));
   out_driver->module = module;
   out_driver->scratch_arena = scratch_arena;
-  out_driver->value_facts = value_facts;
+  out_driver->fact_table = fact_table;
+}
+
+void loom_greedy_rewrite_driver_set_fact_table(
+    loom_greedy_rewrite_driver_t* driver, loom_value_fact_table_t* fact_table) {
+  IREE_ASSERT(!driver->rewriter_initialized);
+  driver->fact_table = fact_table;
 }
 
 void loom_greedy_rewrite_driver_reset(loom_greedy_rewrite_driver_t* driver) {
@@ -24,10 +30,6 @@ void loom_greedy_rewrite_driver_reset(loom_greedy_rewrite_driver_t* driver) {
     loom_rewriter_deinitialize(&driver->rewriter);
     driver->rewriter_initialized = false;
   }
-  if (driver->value_facts) {
-    loom_pass_value_fact_owner_invalidate(driver->value_facts);
-  }
-  driver->latest_facts = NULL;
   if (driver->scratch_arena) {
     iree_arena_reset(driver->scratch_arena);
   }
@@ -42,7 +44,7 @@ void loom_greedy_rewrite_driver_deinitialize(
 
 const loom_value_fact_table_t* loom_greedy_rewrite_driver_fact_table(
     const loom_greedy_rewrite_driver_t* driver) {
-  return driver ? driver->latest_facts : NULL;
+  return driver ? driver->fact_table : NULL;
 }
 
 void loom_greedy_rewrite_result_record_rewriter_flags(
@@ -68,33 +70,6 @@ void loom_greedy_rewrite_result_record_change(
   }
 }
 
-static iree_status_t loom_greedy_rewrite_enable_region_facts(
-    loom_greedy_rewrite_driver_t* driver, loom_func_like_t function,
-    loom_region_t* region, loom_op_t* parent_op,
-    const loom_greedy_rewrite_options_t* options) {
-  if (!driver->value_facts) {
-    if (options && (options->target_facts || options->seed_facts)) {
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "target and seed facts require a greedy rewrite value-fact owner");
-    }
-    return iree_ok_status();
-  }
-
-  loom_value_fact_table_t* facts = NULL;
-  const loom_target_facts_t* target_facts =
-      options ? options->target_facts : NULL;
-  IREE_RETURN_IF_ERROR(loom_pass_value_fact_owner_prepare(
-      driver->value_facts, driver->module,
-      loom_pass_value_fact_scope_region_for_target(function, region, parent_op,
-                                                   target_facts),
-      &facts));
-  driver->latest_facts = facts;
-  return loom_rewriter_enable_region_analysis_with_seed_facts(
-      &driver->rewriter, function, region, parent_op, facts,
-      options ? options->seed_facts : NULL);
-}
-
 iree_status_t loom_greedy_rewrite_run_region(
     loom_greedy_rewrite_driver_t* driver, loom_func_like_t function,
     loom_region_t* region, loom_op_t* parent_op,
@@ -113,13 +88,10 @@ iree_status_t loom_greedy_rewrite_run_region(
       &driver->rewriter, driver->module, driver->scratch_arena);
   if (iree_status_is_ok(status)) {
     driver->rewriter_initialized = true;
+    loom_rewriter_attach_value_facts(&driver->rewriter, driver->fact_table);
     if (options) {
       driver->rewriter.materialize_constant = options->materialize_constant;
     }
-  }
-  if (iree_status_is_ok(status)) {
-    status = loom_greedy_rewrite_enable_region_facts(driver, function, region,
-                                                     parent_op, options);
   }
   bool prepare_region_called = false;
   if (iree_status_is_ok(status) && callbacks && callbacks->prepare_region) {
@@ -244,7 +216,8 @@ iree_status_t loom_greedy_rewrite(iree_arena_allocator_t* arena,
                                   iree_host_size_t pattern_count,
                                   const loom_rewrite_config_t* config) {
   loom_greedy_rewrite_driver_t driver;
-  loom_greedy_rewrite_driver_initialize(module, arena, NULL, &driver);
+  loom_greedy_rewrite_driver_initialize(module, arena, /*fact_table=*/NULL,
+                                        &driver);
   loom_greedy_rewrite_options_t options = {
       .max_iterations = config ? config->max_iterations : 0,
   };

--- a/loom/src/loom/rewrite/greedy.h
+++ b/loom/src/loom/rewrite/greedy.h
@@ -18,7 +18,6 @@
 #include "iree/base/api.h"
 #include "iree/base/internal/arena.h"
 #include "loom/ir/ir.h"
-#include "loom/pass/value_facts.h"
 #include "loom/rewrite/rewriter.h"
 #include "loom/util/fact_table.h"
 
@@ -38,15 +37,6 @@ typedef uint32_t loom_greedy_rewrite_change_flags_t;
 typedef struct loom_greedy_rewrite_options_t {
   // Maximum number of fixed-point iterations. Zero selects the default.
   uint32_t max_iterations;
-
-  // Optional immutable target facts used by target-sensitive fact inference.
-  // Requires a driver with a value-fact owner.
-  const loom_target_facts_t* target_facts;
-
-  // Optional seed facts cloned into the driver-owned fact table before the
-  // initial region analysis. The target scope is supplied independently by
-  // target_facts. Requires a driver with a value-fact owner.
-  const loom_value_fact_table_t* seed_facts;
 
   // Optional constant materialization hook installed on the active rewriter.
   loom_materialize_constant_fn_t materialize_constant;
@@ -74,20 +64,17 @@ typedef struct loom_greedy_rewrite_result_t {
 } loom_greedy_rewrite_result_t;
 
 // Stateful greedy rewrite driver. The caller owns the module, scratch arena,
-// and value-fact owner. The driver keeps successful run facts queryable until
-// the next run, reset, or deinitialize.
+// and optional precomputed fact table. Rewrites incrementally maintain the
+// borrowed facts but never acquire, clear, or otherwise own their scope.
 typedef struct loom_greedy_rewrite_driver_t {
   // Module being transformed.
   loom_module_t* module;
 
-  // Optional reusable value-fact storage used for region analysis.
-  loom_pass_value_fact_owner_t* value_facts;
-
   // Caller-owned scratch arena for the active rewriter and pass callbacks.
   iree_arena_allocator_t* scratch_arena;
 
-  // Borrowed facts from value_facts for the most recent successful run.
-  loom_value_fact_table_t* latest_facts;
+  // Optional caller-computed facts incrementally maintained by rewrites.
+  loom_value_fact_table_t* fact_table;
 
   // Rewriter state for the active run.
   loom_rewriter_t rewriter;
@@ -145,19 +132,23 @@ typedef struct loom_greedy_rewrite_callbacks_t {
 // runs but remains owned by the caller.
 void loom_greedy_rewrite_driver_initialize(
     loom_module_t* module, iree_arena_allocator_t* scratch_arena,
-    loom_pass_value_fact_owner_t* value_facts,
+    loom_value_fact_table_t* fact_table,
     loom_greedy_rewrite_driver_t* out_driver);
 
-// Clears active rewriter state, invalidates borrowed facts, and resets scratch.
+// Replaces the caller-owned fact table used by subsequent runs. The driver must
+// not have an active run. NULL disables incremental fact maintenance.
+void loom_greedy_rewrite_driver_set_fact_table(
+    loom_greedy_rewrite_driver_t* driver, loom_value_fact_table_t* fact_table);
+
+// Clears active rewriter state and resets scratch. Borrowed facts remain valid.
 void loom_greedy_rewrite_driver_reset(loom_greedy_rewrite_driver_t* driver);
 
 // Releases active run state. Does not deinitialize the caller-owned scratch
-// arena or value-fact owner.
+// arena or fact table.
 void loom_greedy_rewrite_driver_deinitialize(
     loom_greedy_rewrite_driver_t* driver);
 
-// Returns the fact table from the most recent successful run. The table is
-// invalidated by the next driver run, reset, or deinitialize.
+// Returns the caller-owned fact table incrementally maintained by the driver.
 const loom_value_fact_table_t* loom_greedy_rewrite_driver_fact_table(
     const loom_greedy_rewrite_driver_t* driver);
 
@@ -170,10 +161,11 @@ void loom_greedy_rewrite_result_record_change(
     loom_greedy_rewrite_result_t* result, const loom_rewriter_t* rewriter,
     loom_greedy_rewrite_change_flags_t flags);
 
-// Runs greedy rewriting on an explicit region tree. |function| supplies the
-// logical function context for value-fact inference and may be empty for
-// detached regions. |parent_op| owns the root entry block arguments when
-// provided.
+// Runs greedy rewriting on an explicit region tree. |function| and |parent_op|
+// describe the region to policy callbacks; the driver does not rediscover or
+// recompute facts for the region. On failure the borrowed fact table may
+// contain partial incremental updates and its owner must invalidate it before
+// reuse.
 iree_status_t loom_greedy_rewrite_run_region(
     loom_greedy_rewrite_driver_t* driver, loom_func_like_t function,
     loom_region_t* region, loom_op_t* parent_op,

--- a/loom/src/loom/rewrite/greedy_test.cc
+++ b/loom/src/loom/rewrite/greedy_test.cc
@@ -15,6 +15,7 @@
 #include "loom/ir/module.h"
 #include "loom/ops/op_defs.h"
 #include "loom/ops/test/ops.h"
+#include "loom/pass/value_facts.h"
 #include "loom/target/facts.h"
 #include "loom/target/types.h"
 
@@ -221,22 +222,25 @@ TEST_F(GreedyRewriteTest, ExplicitTargetFactsSetAnalysisScope) {
   iree_arena_initialize(&block_pool_, &arena);
   loom_pass_value_fact_owner_t fact_owner;
   loom_pass_value_fact_owner_initialize(&block_pool_, &fact_owner);
+  loom_value_fact_table_t* fact_table = nullptr;
+  IREE_ASSERT_OK(loom_pass_value_fact_owner_acquire(
+      &fact_owner, module_,
+      loom_pass_value_fact_scope_function_for_target(function_, &target_facts),
+      &fact_table));
   loom_greedy_rewrite_driver_t driver;
-  loom_greedy_rewrite_driver_initialize(module_, &arena, &fact_owner, &driver);
+  loom_greedy_rewrite_driver_initialize(module_, &arena, fact_table, &driver);
 
   const loom_greedy_rewrite_options_t options = {
       /*.max_iterations=*/{},
-      /*.target_facts=*/&target_facts,
-      /*.seed_facts=*/NULL,
   };
   IREE_ASSERT_OK(loom_greedy_rewrite_run_region(
       &driver, function_, loom_func_like_body(function_), function_.op,
       &options, /*callbacks=*/NULL, /*out_result=*/NULL));
 
-  const loom_value_fact_table_t* latest_facts =
+  const loom_value_fact_table_t* maintained_facts =
       loom_greedy_rewrite_driver_fact_table(&driver);
-  ASSERT_NE(latest_facts, nullptr);
-  EXPECT_EQ(latest_facts->context.target_facts, &target_facts);
+  ASSERT_NE(maintained_facts, nullptr);
+  EXPECT_EQ(maintained_facts->context.target_facts, &target_facts);
 
   loom_greedy_rewrite_driver_deinitialize(&driver);
   loom_pass_value_fact_owner_deinitialize(&fact_owner);

--- a/loom/src/loom/rewrite/rewriter.c
+++ b/loom/src/loom/rewrite/rewriter.c
@@ -184,6 +184,11 @@ iree_status_t loom_rewriter_seed_function(loom_rewriter_t* rewriter,
   return loom_rewriter_seed_region(rewriter, loom_func_like_body(function));
 }
 
+void loom_rewriter_attach_value_facts(loom_rewriter_t* rewriter,
+                                      loom_value_fact_table_t* facts) {
+  rewriter->fact_table = facts;
+}
+
 iree_status_t loom_rewriter_enable_region_analysis(
     loom_rewriter_t* rewriter, loom_func_like_t function, loom_region_t* region,
     loom_op_t* parent_op, loom_value_fact_table_t* facts) {

--- a/loom/src/loom/rewrite/rewriter.h
+++ b/loom/src/loom/rewrite/rewriter.h
@@ -134,6 +134,12 @@ iree_status_t loom_rewriter_seed_region(loom_rewriter_t* rewriter,
 iree_status_t loom_rewriter_seed_function(loom_rewriter_t* rewriter,
                                           loom_func_like_t function);
 
+// Attaches caller-computed value facts to the rewriter for incremental
+// maintenance. The table must already cover every value the rewrite policy may
+// query and remains owned by the caller. NULL disables value-fact maintenance.
+void loom_rewriter_attach_value_facts(loom_rewriter_t* rewriter,
+                                      loom_value_fact_table_t* facts);
+
 // Enables value analysis on this rewriter using caller-owned fact storage and
 // runs the initial forward pass over |region| and its nested regions, seeding
 // facts from fact inference functions. |function| supplies the logical

--- a/loom/src/loom/transforms/cfg/cfg_simplify.c
+++ b/loom/src/loom/transforms/cfg/cfg_simplify.c
@@ -1907,14 +1907,14 @@ static bool loom_cfg_simplify_pred_branches_to_block(
 
 static bool loom_cfg_simplify_incoming_slots_match(
     loom_op_t* const* pred_branches, iree_host_size_t predecessor_count,
-    uint16_t lhs_index, uint16_t rhs_index) {
+    uint16_t lhs_slot, uint16_t rhs_slot) {
   for (iree_host_size_t i = 0; i < predecessor_count; ++i) {
     loom_block_t* dest = NULL;
     loom_value_slice_t args = {0};
     if (!loom_cfg_simplify_direct_branch(pred_branches[i], &dest, &args)) {
       return false;
     }
-    if (args.values[lhs_index] != args.values[rhs_index]) return false;
+    if (args.values[lhs_slot] != args.values[rhs_slot]) return false;
   }
   return true;
 }
@@ -1922,13 +1922,15 @@ static bool loom_cfg_simplify_incoming_slots_match(
 static bool loom_cfg_simplify_find_duplicate_arg_replacement(
     const loom_cfg_simplify_state_t* state, const loom_block_t* block,
     loom_op_t* const* pred_branches, iree_host_size_t predecessor_count,
-    uint16_t arg_index, loom_value_id_t* out_replacement) {
+    const uint16_t* incoming_slot_by_arg, uint16_t arg_index,
+    loom_value_id_t* out_replacement) {
   loom_value_id_t old_arg = loom_block_arg_id(block, arg_index);
   for (uint16_t candidate_index = 0; candidate_index < arg_index;
        ++candidate_index) {
     loom_value_id_t candidate = loom_block_arg_id(block, candidate_index);
     if (!loom_cfg_simplify_incoming_slots_match(
-            pred_branches, predecessor_count, arg_index, candidate_index)) {
+            pred_branches, predecessor_count, incoming_slot_by_arg[arg_index],
+            incoming_slot_by_arg[candidate_index])) {
       continue;
     }
     if (!loom_cfg_simplify_type_allows_replacement(state->module, old_arg,
@@ -1944,7 +1946,8 @@ static bool loom_cfg_simplify_find_duplicate_arg_replacement(
 static bool loom_cfg_simplify_find_forwarded_arg_replacement(
     const loom_cfg_simplify_state_t* state, const loom_block_t* block,
     loom_op_t* const* pred_branches, iree_host_size_t predecessor_count,
-    uint16_t arg_index, loom_value_id_t* out_replacement) {
+    const uint16_t* incoming_slot_by_arg, uint16_t arg_index,
+    loom_value_id_t* out_replacement) {
   if (predecessor_count == 0) return false;
   loom_value_id_t old_arg = loom_block_arg_id(block, arg_index);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
@@ -1954,7 +1957,7 @@ static bool loom_cfg_simplify_find_forwarded_arg_replacement(
     if (!loom_cfg_simplify_direct_branch(pred_branches[i], &dest, &args)) {
       return false;
     }
-    loom_value_id_t incoming = args.values[arg_index];
+    loom_value_id_t incoming = args.values[incoming_slot_by_arg[arg_index]];
     if (incoming == old_arg) continue;
     if (replacement == LOOM_VALUE_ID_INVALID) {
       replacement = incoming;
@@ -1982,8 +1985,10 @@ static bool loom_cfg_simplify_find_forwarded_arg_replacement(
   return true;
 }
 
-static iree_status_t loom_cfg_simplify_rebuild_br_without_arg(
-    loom_cfg_simplify_state_t* state, loom_op_t* br, uint16_t removed_index) {
+static iree_status_t loom_cfg_simplify_rebuild_br_for_block_args(
+    loom_cfg_simplify_state_t* state, loom_op_t* br,
+    const uint16_t* incoming_slot_by_arg, uint16_t arg_count,
+    loom_value_id_t* rebuilt_args) {
   loom_block_t* dest = NULL;
   loom_value_slice_t args = {0};
   if (!loom_cfg_simplify_direct_branch(br, &dest, &args)) {
@@ -1991,33 +1996,19 @@ static iree_status_t loom_cfg_simplify_rebuild_br_without_arg(
                             "cfg-simplify block argument removal expected a "
                             "cfg.br or low.br predecessor");
   }
-  loom_value_id_t* kept_args = NULL;
-  iree_host_size_t kept_count = args.count - 1;
-  if (kept_count > 0) {
-    IREE_RETURN_IF_ERROR(
-        iree_arena_allocate_array(state->analysis_arena, kept_count,
-                                  sizeof(*kept_args), (void**)&kept_args));
+  for (uint16_t arg_index = 0; arg_index < arg_count; ++arg_index) {
+    rebuilt_args[arg_index] = args.values[incoming_slot_by_arg[arg_index]];
   }
-  iree_host_size_t kept_index = 0;
-  for (uint16_t i = 0; i < args.count; ++i) {
-    if (i == removed_index) continue;
-    kept_args[kept_index++] = args.values[i];
-  }
-  return loom_cfg_simplify_replace_direct_br(state, br, dest, kept_args,
-                                             kept_count);
+  return loom_cfg_simplify_replace_direct_br(state, br, dest, rebuilt_args,
+                                             arg_count);
 }
 
 static iree_status_t loom_cfg_simplify_remove_block_arg(
-    loom_cfg_simplify_state_t* state, loom_block_t* block,
-    loom_op_t** pred_branches, iree_host_size_t predecessor_count,
-    uint16_t arg_index, loom_value_id_t replacement) {
+    loom_cfg_simplify_state_t* state, loom_block_t* block, uint16_t arg_index,
+    loom_value_id_t replacement) {
   loom_value_id_t old_arg = loom_block_arg_id(block, arg_index);
   IREE_RETURN_IF_ERROR(loom_rewriter_replace_all_uses_with(
       state->rewriter, old_arg, replacement));
-  for (iree_host_size_t i = 0; i < predecessor_count; ++i) {
-    IREE_RETURN_IF_ERROR(loom_cfg_simplify_rebuild_br_without_arg(
-        state, pred_branches[i], arg_index));
-  }
   IREE_RETURN_IF_ERROR(loom_block_remove_arg(state->module, block, arg_index));
   ++state->statistics->block_args_removed;
   state->rewriter->flags |= LOOM_REWRITER_FLAG_CHANGED;
@@ -2038,17 +2029,20 @@ static bool loom_cfg_simplify_block_arg_unused(
 }
 
 static iree_status_t loom_cfg_simplify_remove_unused_block_arg(
-    loom_cfg_simplify_state_t* state, loom_block_t* block,
-    loom_op_t** pred_branches, iree_host_size_t predecessor_count,
-    uint16_t arg_index) {
-  for (iree_host_size_t i = 0; i < predecessor_count; ++i) {
-    IREE_RETURN_IF_ERROR(loom_cfg_simplify_rebuild_br_without_arg(
-        state, pred_branches[i], arg_index));
-  }
+    loom_cfg_simplify_state_t* state, loom_block_t* block, uint16_t arg_index) {
   IREE_RETURN_IF_ERROR(loom_block_remove_arg(state->module, block, arg_index));
   ++state->statistics->block_args_removed;
   state->rewriter->flags |= LOOM_REWRITER_FLAG_CHANGED;
   return iree_ok_status();
+}
+
+static void loom_cfg_simplify_remove_incoming_slot_for_arg(
+    uint16_t* incoming_slot_by_arg, uint16_t arg_count,
+    uint16_t removed_arg_index) {
+  for (uint16_t arg_index = (uint16_t)(removed_arg_index + 1);
+       arg_index < arg_count; ++arg_index) {
+    incoming_slot_by_arg[arg_index - 1] = incoming_slot_by_arg[arg_index];
+  }
 }
 
 static iree_status_t loom_cfg_simplify_remove_redundant_block_args(
@@ -2073,29 +2067,76 @@ static iree_status_t loom_cfg_simplify_remove_redundant_block_args(
       continue;
     }
 
-    for (uint16_t arg_index = 0; arg_index < block->arg_count; ++arg_index) {
+    const uint16_t initial_arg_count = block->arg_count;
+    uint16_t* incoming_slot_by_arg = NULL;
+    loom_value_id_t* rebuilt_args = NULL;
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        state->analysis_arena, initial_arg_count, sizeof(*incoming_slot_by_arg),
+        (void**)&incoming_slot_by_arg));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        state->analysis_arena, initial_arg_count, sizeof(*rebuilt_args),
+        (void**)&rebuilt_args));
+    for (uint16_t arg_index = 0; arg_index < initial_arg_count; ++arg_index) {
+      incoming_slot_by_arg[arg_index] = arg_index;
+    }
+
+    bool block_changed = false;
+    uint16_t arg_index = 0;
+    while (arg_index < block->arg_count) {
       if (loom_cfg_simplify_block_arg_unused(state, block, arg_index)) {
-        IREE_RETURN_IF_ERROR(loom_cfg_simplify_remove_unused_block_arg(
-            state, block, pred_branches, predecessors.count, arg_index));
-        *out_changed = true;
-        return iree_ok_status();
+        const uint16_t previous_arg_count = block->arg_count;
+        IREE_RETURN_IF_ERROR(
+            loom_cfg_simplify_remove_unused_block_arg(state, block, arg_index));
+        loom_cfg_simplify_remove_incoming_slot_for_arg(
+            incoming_slot_by_arg, previous_arg_count, arg_index);
+        block_changed = true;
+        continue;
       }
 
       loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
       bool found_replacement =
           loom_cfg_simplify_find_duplicate_arg_replacement(
-              state, block, pred_branches, predecessors.count, arg_index,
-              &replacement) ||
+              state, block, pred_branches, predecessors.count,
+              incoming_slot_by_arg, arg_index, &replacement) ||
           loom_cfg_simplify_find_forwarded_arg_replacement(
-              state, block, pred_branches, predecessors.count, arg_index,
-              &replacement);
-      if (!found_replacement) continue;
+              state, block, pred_branches, predecessors.count,
+              incoming_slot_by_arg, arg_index, &replacement);
+      if (!found_replacement) {
+        ++arg_index;
+        continue;
+      }
+      const uint16_t previous_arg_count = block->arg_count;
       IREE_RETURN_IF_ERROR(loom_cfg_simplify_remove_block_arg(
-          state, block, pred_branches, predecessors.count, arg_index,
-          replacement));
-      *out_changed = true;
-      return iree_ok_status();
+          state, block, arg_index, replacement));
+      loom_cfg_simplify_remove_incoming_slot_for_arg(
+          incoming_slot_by_arg, previous_arg_count, arg_index);
+      block_changed = true;
     }
+
+    // Removing a later argument may release the final type use of an earlier
+    // argument. References between block argument types can only point to
+    // earlier arguments, so one reverse sweep removes the newly unused
+    // dependency chain without rebuilding function-scoped facts.
+    for (arg_index = block->arg_count; arg_index > 0;) {
+      --arg_index;
+      if (!loom_cfg_simplify_block_arg_unused(state, block, arg_index)) {
+        continue;
+      }
+      const uint16_t previous_arg_count = block->arg_count;
+      IREE_RETURN_IF_ERROR(
+          loom_cfg_simplify_remove_unused_block_arg(state, block, arg_index));
+      loom_cfg_simplify_remove_incoming_slot_for_arg(
+          incoming_slot_by_arg, previous_arg_count, arg_index);
+      block_changed = true;
+    }
+
+    if (!block_changed) continue;
+    for (iree_host_size_t i = 0; i < predecessors.count; ++i) {
+      IREE_RETURN_IF_ERROR(loom_cfg_simplify_rebuild_br_for_block_args(
+          state, pred_branches[i], incoming_slot_by_arg, block->arg_count,
+          rebuilt_args));
+    }
+    *out_changed = true;
   }
   return iree_ok_status();
 }

--- a/loom/src/loom/transforms/cfg/test/cfg_simplify.loom-test
+++ b/loom/src/loom/transforms/cfg/test/cfg_simplify.loom-test
@@ -161,6 +161,43 @@ func.def @deduplicates_block_args(%cond: i1, %a: i32, %b: i32) -> (i32) {
 
 // ====
 
+func.def @deduplicates_block_arg_batch(%cond: i1, %a: i32, %b: i32) -> (i32) {
+  cfg.cond_br %cond, ^left, ^right
+^left:
+  cfg.br ^join(%a: i32, %a: i32, %a: i32, %a: i32, %a: i32, %a: i32, %a: i32, %a: i32)
+^right:
+  cfg.br ^join(%b: i32, %b: i32, %b: i32, %b: i32, %b: i32, %b: i32, %b: i32, %b: i32)
+^join(%x0: i32, %x1: i32, %x2: i32, %x3: i32, %x4: i32, %x5: i32, %x6: i32, %x7: i32):
+  %s01 = test.addi %x0, %x1 : i32
+  %s23 = test.addi %x2, %x3 : i32
+  %s45 = test.addi %x4, %x5 : i32
+  %s67 = test.addi %x6, %x7 : i32
+  %s03 = test.addi %s01, %s23 : i32
+  %s47 = test.addi %s45, %s67 : i32
+  %sum = test.addi %s03, %s47 : i32
+  func.return %sum : i32
+}
+
+// ----
+func.def @deduplicates_block_arg_batch(%cond: i1, %a: i32, %b: i32) -> (i32) {
+  cfg.cond_br %cond, ^left, ^right
+^left:
+  cfg.br ^join(%a: i32)
+^right:
+  cfg.br ^join(%b: i32)
+^join(%x0: i32):
+  %s01 = test.addi %x0, %x0 : i32
+  %s23 = test.addi %x0, %x0 : i32
+  %s45 = test.addi %x0, %x0 : i32
+  %s67 = test.addi %x0, %x0 : i32
+  %s03 = test.addi %s01, %s23 : i32
+  %s47 = test.addi %s45, %s67 : i32
+  %sum = test.addi %s03, %s47 : i32
+  func.return %sum : i32
+}
+
+// ====
+
 func.def @merges_duplicate_return_blocks(%cond: i1, %value: i32) -> (i32) {
   cfg.cond_br %cond, ^then, ^else
 ^then:

--- a/loom/src/loom/transforms/cleanup/canonicalize.c
+++ b/loom/src/loom/transforms/cleanup/canonicalize.c
@@ -1742,6 +1742,8 @@ static void loom_canonicalizer_reset_run_state(
     loom_canonicalizer_t* canonicalizer) {
   if (canonicalizer->state) {
     loom_greedy_rewrite_driver_reset(&canonicalizer->state->rewrite_driver);
+    loom_greedy_rewrite_driver_set_fact_table(
+        &canonicalizer->state->rewrite_driver, NULL);
   } else if (canonicalizer->scratch_arena_initialized) {
     iree_arena_reset(&canonicalizer->scratch_arena);
   }
@@ -1774,9 +1776,9 @@ iree_status_t loom_canonicalizer_initialize(
   iree_arena_initialize(parent_arena->block_pool,
                         &out_canonicalizer->scratch_arena);
   out_canonicalizer->scratch_arena_initialized = true;
-  loom_greedy_rewrite_driver_initialize(module,
-                                        &out_canonicalizer->scratch_arena,
-                                        value_facts, &state->rewrite_driver);
+  loom_greedy_rewrite_driver_initialize(
+      module, &out_canonicalizer->scratch_arena,
+      /*fact_table=*/NULL, &state->rewrite_driver);
   return iree_ok_status();
 }
 
@@ -1987,7 +1989,7 @@ static void loom_canonicalizer_import_greedy_result(
   };
 }
 
-iree_status_t loom_canonicalizer_run_region(
+static iree_status_t loom_canonicalizer_run_precomputed_region(
     loom_canonicalizer_t* canonicalizer, loom_func_like_t function,
     loom_region_t* region, loom_op_t* parent_op,
     const loom_canonicalizer_options_t* options,
@@ -1999,8 +2001,6 @@ iree_status_t loom_canonicalizer_run_region(
                                 : LOOM_CANONICALIZER_DEFAULT_MAX_ITERATIONS;
   loom_greedy_rewrite_options_t rewrite_options = {
       .max_iterations = max_iterations,
-      .target_facts = options ? options->target_facts : NULL,
-      .seed_facts = options ? options->seed_facts : NULL,
       .materialize_constant = loom_constant_build,
   };
   loom_greedy_rewrite_callbacks_t callbacks = {
@@ -2021,84 +2021,116 @@ iree_status_t loom_canonicalizer_run_region(
   return status;
 }
 
+static iree_status_t loom_canonicalizer_prepare_region_facts(
+    loom_canonicalizer_t* canonicalizer, loom_func_like_t function,
+    loom_region_t* region, loom_op_t* parent_op,
+    const loom_canonicalizer_options_t* options) {
+  loom_value_fact_table_t* facts = NULL;
+  IREE_RETURN_IF_ERROR(loom_pass_value_fact_owner_prepare(
+      canonicalizer->value_facts, canonicalizer->module,
+      loom_pass_value_fact_scope_region_for_target(
+          function, region, parent_op, options ? options->target_facts : NULL),
+      &facts));
+  if (options && options->seed_facts) {
+    IREE_RETURN_IF_ERROR(loom_value_fact_table_clone_defined_facts(
+        facts, options->seed_facts, canonicalizer->module));
+  }
+  IREE_RETURN_IF_ERROR(loom_value_fact_table_compute_region(
+      facts, canonicalizer->module, function, region, parent_op));
+  loom_greedy_rewrite_driver_set_fact_table(
+      &canonicalizer->state->rewrite_driver, facts);
+  return iree_ok_status();
+}
+
+static iree_status_t loom_canonicalizer_prepare_function_facts(
+    loom_canonicalizer_t* canonicalizer, loom_func_like_t function,
+    const loom_canonicalizer_options_t* options) {
+  const loom_pass_value_fact_scope_t scope =
+      loom_pass_value_fact_scope_function_for_target(
+          function, options ? options->target_facts : NULL);
+  loom_value_fact_table_t* facts = NULL;
+  if (options && options->seed_facts) {
+    IREE_RETURN_IF_ERROR(loom_pass_value_fact_owner_prepare(
+        canonicalizer->value_facts, canonicalizer->module, scope, &facts));
+    IREE_RETURN_IF_ERROR(loom_value_fact_table_clone_defined_facts(
+        facts, options->seed_facts, canonicalizer->module));
+    IREE_RETURN_IF_ERROR(
+        loom_value_fact_table_compute(facts, canonicalizer->module, function));
+  } else {
+    IREE_RETURN_IF_ERROR(loom_pass_value_fact_owner_acquire(
+        canonicalizer->value_facts, canonicalizer->module, scope, &facts));
+  }
+  loom_greedy_rewrite_driver_set_fact_table(
+      &canonicalizer->state->rewrite_driver, facts);
+  return iree_ok_status();
+}
+
+iree_status_t loom_canonicalizer_run_region(
+    loom_canonicalizer_t* canonicalizer, loom_func_like_t function,
+    loom_region_t* region, loom_op_t* parent_op,
+    const loom_canonicalizer_options_t* options,
+    loom_canonicalizer_result_t* out_result) {
+  if (out_result) memset(out_result, 0, sizeof(*out_result));
+  loom_canonicalizer_reset_run_state(canonicalizer);
+  if (!region) return iree_ok_status();
+  iree_status_t status = loom_canonicalizer_prepare_region_facts(
+      canonicalizer, function, region, parent_op, options);
+  if (iree_status_is_ok(status)) {
+    status = loom_canonicalizer_run_precomputed_region(
+        canonicalizer, function, region, parent_op, options, out_result);
+  }
+  if (!iree_status_is_ok(status)) {
+    loom_pass_value_fact_owner_invalidate(canonicalizer->value_facts);
+    loom_greedy_rewrite_driver_set_fact_table(
+        &canonicalizer->state->rewrite_driver, NULL);
+  }
+  return status;
+}
+
 iree_status_t loom_canonicalizer_run_function(
     loom_canonicalizer_t* canonicalizer, loom_func_like_t function,
     const loom_canonicalizer_options_t* options,
     loom_canonicalizer_result_t* out_result) {
   if (out_result) memset(out_result, 0, sizeof(*out_result));
+  loom_canonicalizer_reset_run_state(canonicalizer);
   loom_region_t* body = loom_func_like_body(function);
-  if (!body) {
-    loom_canonicalizer_reset_run_state(canonicalizer);
-    return iree_ok_status();
+  if (!body) return iree_ok_status();
+
+  iree_status_t status = loom_canonicalizer_prepare_function_facts(
+      canonicalizer, function, options);
+  if (!iree_status_is_ok(status)) {
+    loom_pass_value_fact_owner_invalidate(canonicalizer->value_facts);
+    loom_greedy_rewrite_driver_set_fact_table(
+        &canonicalizer->state->rewrite_driver, NULL);
+    return status;
   }
 
   const uint8_t body_region_index = loom_func_like_body_region_index(function);
-  bool has_non_body_regions = false;
   loom_canonicalizer_result_t aggregate_result = {0};
-  iree_status_t status = iree_ok_status();
   for (uint8_t i = 0; i < loom_func_like_region_count(function); ++i) {
     if (i == body_region_index) continue;
     loom_region_t* region = loom_func_like_region(function, i);
     if (!region) continue;
-    has_non_body_regions = true;
     loom_canonicalizer_result_t region_result = {0};
-    status = loom_canonicalizer_run_region(
+    status = loom_canonicalizer_run_precomputed_region(
         canonicalizer, function, region, function.op, options, &region_result);
     if (!iree_status_is_ok(status)) break;
     loom_canonicalizer_merge_result(&aggregate_result, &region_result);
   }
-  if (!iree_status_is_ok(status)) {
-    if (out_result) *out_result = aggregate_result;
-    return status;
-  }
-
-  iree_arena_allocator_t seed_arena;
-  loom_value_fact_table_t seed_facts;
-  const loom_value_fact_table_t* body_seed_facts =
-      options ? options->seed_facts : NULL;
-  bool seed_facts_initialized = false;
-  if (has_non_body_regions) {
-    iree_arena_initialize(canonicalizer->parent_arena->block_pool, &seed_arena);
-    seed_facts_initialized = true;
-    status = loom_value_fact_table_initialize(
-        &seed_facts, &seed_arena,
-        loom_value_table_capacity(&canonicalizer->module->values));
-    if (iree_status_is_ok(status)) {
-      loom_type_registry_configure_fact_context(&seed_facts.context);
-      seed_facts.context.target_facts = options ? options->target_facts : NULL;
-    }
-    if (iree_status_is_ok(status) && options && options->seed_facts) {
-      status = loom_value_fact_table_clone_defined_facts(
-          &seed_facts, options->seed_facts, canonicalizer->module);
-    }
-    for (uint8_t i = 0;
-         i < loom_func_like_region_count(function) && iree_status_is_ok(status);
-         ++i) {
-      if (i == body_region_index) continue;
-      status = loom_value_fact_table_compute_region(
-          &seed_facts, canonicalizer->module, function,
-          loom_func_like_region(function, i), function.op);
-    }
-    if (iree_status_is_ok(status)) {
-      body_seed_facts = &seed_facts;
-    }
-  }
 
   if (iree_status_is_ok(status)) {
-    loom_canonicalizer_options_t body_options = {0};
-    if (options) body_options = *options;
-    body_options.seed_facts = body_seed_facts;
     loom_canonicalizer_result_t body_result = {0};
-    status =
-        loom_canonicalizer_run_region(canonicalizer, function, body,
-                                      function.op, &body_options, &body_result);
+    status = loom_canonicalizer_run_precomputed_region(
+        canonicalizer, function, body, function.op, options, &body_result);
     if (iree_status_is_ok(status)) {
       loom_canonicalizer_merge_result(&aggregate_result, &body_result);
     }
   }
 
-  if (seed_facts_initialized) {
-    iree_arena_deinitialize(&seed_arena);
+  if (!iree_status_is_ok(status)) {
+    loom_pass_value_fact_owner_invalidate(canonicalizer->value_facts);
+    loom_greedy_rewrite_driver_set_fact_table(
+        &canonicalizer->state->rewrite_driver, NULL);
   }
   if (out_result) *out_result = aggregate_result;
   return status;

--- a/loom/src/loom/transforms/cleanup/canonicalize.h
+++ b/loom/src/loom/transforms/cleanup/canonicalize.h
@@ -31,7 +31,7 @@ typedef struct loom_canonicalizer_options_t {
   // Optional immutable target facts used by target-sensitive fact inference.
   const loom_target_facts_t* target_facts;
 
-  // Optional seed facts cloned into the driver-owned fact table before the
+  // Optional seed facts cloned into the prepared fact table before the
   // initial function analysis. Extension payloads are re-interned, so the seed
   // table may come from a different fact context. The target scope is supplied
   // independently by target_facts.
@@ -66,14 +66,14 @@ typedef struct loom_canonicalizer_t {
   // Module being transformed.
   loom_module_t* module;
 
-  // Caller-owned reusable value-fact storage used for region analysis.
+  // Caller-owned reusable value-fact storage used for function/region analysis.
   loom_pass_value_fact_owner_t* value_facts;
 
   // Parent arena whose block pool backs the resettable scratch arena.
   iree_arena_allocator_t* parent_arena;
 
-  // Reset before each region run; owns the rewriter worklist and
-  // symbolic-expression scratch state for the most recent run.
+  // Reset before each public run; owns the rewriter worklist and
+  // symbolic-expression scratch state for that run.
   iree_arena_allocator_t scratch_arena;
 
   // True after scratch_arena has been initialized and before deinitialize.
@@ -107,15 +107,17 @@ iree_status_t loom_canonicalizer_run_region(
     const loom_canonicalizer_options_t* options,
     loom_canonicalizer_result_t* out_result);
 
-// Runs canonicalization on a function-like op's root regions. Non-body regions
-// run first, then their facts seed body-region canonicalization.
+// Runs canonicalization on a function-like op's root regions. Facts are
+// computed once across the function; non-body regions canonicalize before the
+// body so their incremental updates are visible to body canonicalization.
 iree_status_t loom_canonicalizer_run_function(
     loom_canonicalizer_t* canonicalizer, loom_func_like_t function,
     const loom_canonicalizer_options_t* options,
     loom_canonicalizer_result_t* out_result);
 
-// Returns the fact table from the most recent run. The table is invalidated by
-// the next run and by loom_canonicalizer_deinitialize.
+// Returns the caller-owned fact table incrementally maintained by the most
+// recent run. A later run may replace the table. Deinitializing the
+// canonicalizer detaches the table without changing its owner-managed scope.
 const loom_value_fact_table_t* loom_canonicalizer_fact_table(
     const loom_canonicalizer_t* canonicalizer);
 

--- a/loom/src/loom/transforms/cleanup/canonicalize_test.cc
+++ b/loom/src/loom/transforms/cleanup/canonicalize_test.cc
@@ -547,6 +547,121 @@ TEST_F(CanonicalizeTest, FixedPointConvergence) {
   EXPECT_EQ(constant_value(loom_op_operands(use)[0]), 42);
 }
 
+TEST_F(CanonicalizeTest, DriverReusesFactsAcrossNoopRuns) {
+  loom_type_t i32 = loom_type_scalar(LOOM_SCALAR_TYPE_I32);
+  loom_op_t* constant = NULL;
+  IREE_ASSERT_OK(loom_test_constant_build(&builder_, loom_attr_i64(42), i32,
+                                          LOOM_LOCATION_UNKNOWN, &constant));
+  loom_value_id_t value = loom_test_constant_result(constant);
+  loom_op_t* use = NULL;
+  IREE_ASSERT_OK(
+      loom_test_use_build(&builder_, &value, 1, LOOM_LOCATION_UNKNOWN, &use));
+
+  iree_arena_allocator_t pass_arena;
+  iree_arena_initialize(&block_pool_, &pass_arena);
+  loom_pass_value_fact_owner_t value_facts = {};
+  loom_pass_value_fact_owner_initialize(&block_pool_, &value_facts);
+  loom_pass_value_fact_lifecycle_counts_t counts = {};
+  value_facts.lifecycle_counts = &counts;
+  loom_canonicalizer_t canonicalizer;
+  IREE_ASSERT_OK(loom_canonicalizer_initialize(module_, &pass_arena,
+                                               &value_facts, &canonicalizer));
+
+  loom_canonicalizer_result_t result;
+  IREE_ASSERT_OK(loom_canonicalizer_run_function(&canonicalizer, func_like_,
+                                                 NULL, &result));
+  EXPECT_FALSE(result.changed);
+  IREE_ASSERT_OK(loom_canonicalizer_run_function(&canonicalizer, func_like_,
+                                                 NULL, &result));
+  EXPECT_FALSE(result.changed);
+
+  EXPECT_EQ(counts.acquisition_count, 2u);
+  EXPECT_EQ(counts.cache_hit_count, 1u);
+  EXPECT_EQ(counts.recomputation_count, 1u);
+  EXPECT_EQ(counts.preparation_count, 0u);
+  EXPECT_EQ(counts.invalidation_count, 0u);
+  EXPECT_EQ(counts.scope_clear_count, 0u);
+  EXPECT_GT(counts.computed_value_count, 0u);
+  EXPECT_EQ(value_facts.active_scope.kind, LOOM_PASS_VALUE_FACT_SCOPE_FUNCTION);
+
+  loom_canonicalizer_deinitialize(&canonicalizer);
+  EXPECT_EQ(value_facts.active_scope.kind, LOOM_PASS_VALUE_FACT_SCOPE_FUNCTION);
+  value_facts.lifecycle_counts = nullptr;
+  loom_pass_value_fact_owner_deinitialize(&value_facts);
+  iree_arena_deinitialize(&pass_arena);
+}
+
+TEST_F(CanonicalizeTest, DriverFactsMatchFreshRecomputationAfterChanges) {
+  loom_type_t i32 = loom_type_scalar(LOOM_SCALAR_TYPE_I32);
+
+  loom_op_t* const_forty = NULL;
+  IREE_ASSERT_OK(loom_test_constant_build(&builder_, loom_attr_i64(40), i32,
+                                          LOOM_LOCATION_UNKNOWN, &const_forty));
+  loom_value_id_t forty = loom_test_constant_result(const_forty);
+  loom_op_t* keep_forty = NULL;
+  IREE_ASSERT_OK(loom_test_use_build(&builder_, &forty, 1,
+                                     LOOM_LOCATION_UNKNOWN, &keep_forty));
+
+  loom_op_t* const_two = NULL;
+  IREE_ASSERT_OK(loom_test_constant_build(&builder_, loom_attr_i64(2), i32,
+                                          LOOM_LOCATION_UNKNOWN, &const_two));
+  loom_value_id_t two = loom_test_constant_result(const_two);
+  loom_op_t* keep_two = NULL;
+  IREE_ASSERT_OK(loom_test_use_build(&builder_, &two, 1, LOOM_LOCATION_UNKNOWN,
+                                     &keep_two));
+
+  loom_op_t* addi = NULL;
+  IREE_ASSERT_OK(loom_test_addi_build(&builder_, forty, two, i32,
+                                      LOOM_LOCATION_UNKNOWN, &addi));
+  loom_value_id_t sum = loom_test_addi_result(addi);
+  loom_op_t* use_sum = NULL;
+  IREE_ASSERT_OK(
+      loom_test_use_build(&builder_, &sum, 1, LOOM_LOCATION_UNKNOWN, &use_sum));
+
+  iree_arena_allocator_t pass_arena;
+  iree_arena_initialize(&block_pool_, &pass_arena);
+  loom_pass_value_fact_owner_t value_facts = {};
+  loom_pass_value_fact_owner_initialize(&block_pool_, &value_facts);
+  loom_canonicalizer_t canonicalizer;
+  IREE_ASSERT_OK(loom_canonicalizer_initialize(module_, &pass_arena,
+                                               &value_facts, &canonicalizer));
+  loom_canonicalizer_result_t result;
+  IREE_ASSERT_OK(loom_canonicalizer_run_function(&canonicalizer, func_like_,
+                                                 NULL, &result));
+  EXPECT_TRUE(result.changed);
+
+  const loom_value_fact_table_t* incremental_facts =
+      loom_canonicalizer_fact_table(&canonicalizer);
+  ASSERT_NE(incremental_facts, nullptr);
+  loom_value_id_t folded_sum = loom_op_operands(use_sum)[0];
+  EXPECT_NE(folded_sum, sum);
+  loom_value_facts_t incremental_sum_facts =
+      loom_value_fact_table_lookup(incremental_facts, folded_sum);
+  EXPECT_TRUE(loom_value_facts_is_exact(incremental_sum_facts));
+  EXPECT_EQ(incremental_sum_facts.range_lo, 42);
+
+  loom_pass_value_fact_owner_t fresh_owner = {};
+  loom_pass_value_fact_owner_initialize(&block_pool_, &fresh_owner);
+  loom_value_fact_table_t* fresh_facts = nullptr;
+  IREE_ASSERT_OK(loom_pass_value_fact_owner_acquire(
+      &fresh_owner, module_, loom_pass_value_fact_scope_function(func_like_),
+      &fresh_facts));
+  ASSERT_NE(fresh_facts, nullptr);
+  const loom_value_id_t live_values[] = {forty, two, folded_sum};
+  for (loom_value_id_t live_value : live_values) {
+    loom_type_t type = loom_module_value_type(module_, live_value);
+    EXPECT_TRUE(loom_value_fact_table_facts_equal_for_type(
+        module_, type, incremental_facts,
+        loom_value_fact_table_lookup(incremental_facts, live_value),
+        fresh_facts, loom_value_fact_table_lookup(fresh_facts, live_value)));
+  }
+
+  loom_pass_value_fact_owner_deinitialize(&fresh_owner);
+  loom_canonicalizer_deinitialize(&canonicalizer);
+  loom_pass_value_fact_owner_deinitialize(&value_facts);
+  iree_arena_deinitialize(&pass_arena);
+}
+
 TEST_F(CanonicalizeTest, DriverAcceptsSeedFacts) {
   loom_type_t i32 = loom_type_scalar(LOOM_SCALAR_TYPE_I32);
 
@@ -663,6 +778,8 @@ TEST_F(CanonicalizeTest, DriverPreservesExplicitTargetFactsAcrossSideRegions) {
   iree_arena_initialize(&block_pool_, &pass_arena);
   loom_pass_value_fact_owner_t value_facts = {};
   loom_pass_value_fact_owner_initialize(&block_pool_, &value_facts);
+  loom_pass_value_fact_lifecycle_counts_t counts = {};
+  value_facts.lifecycle_counts = &counts;
   loom_canonicalizer_t canonicalizer;
   IREE_ASSERT_OK(loom_canonicalizer_initialize(module_, &pass_arena,
                                                &value_facts, &canonicalizer));
@@ -679,8 +796,14 @@ TEST_F(CanonicalizeTest, DriverPreservesExplicitTargetFactsAcrossSideRegions) {
       loom_canonicalizer_fact_table(&canonicalizer);
   ASSERT_NE(final_facts, nullptr);
   EXPECT_EQ(final_facts->context.target_facts, &target_facts);
+  EXPECT_EQ(counts.acquisition_count, 0u);
+  EXPECT_EQ(counts.recomputation_count, 0u);
+  EXPECT_EQ(counts.preparation_count, 1u);
+  EXPECT_EQ(counts.invalidation_count, 0u);
+  EXPECT_EQ(counts.scope_clear_count, 0u);
 
   loom_canonicalizer_deinitialize(&canonicalizer);
+  value_facts.lifecycle_counts = nullptr;
   loom_pass_value_fact_owner_deinitialize(&value_facts);
   iree_arena_deinitialize(&pass_arena);
   iree_arena_deinitialize(&seed_arena);

--- a/loom/src/loom/transforms/math/BUILD.bazel
+++ b/loom/src/loom/transforms/math/BUILD.bazel
@@ -32,6 +32,7 @@ loom_cc_library(
         "//loom/src/loom/pass:pipeline",
         "//loom/src/loom/pass:registry",
         "//loom/src/loom/pass:types",
+        "//loom/src/loom/pass:value_facts",
         "//loom/src/loom/rewrite:greedy",
         "//loom/src/loom/rewrite:rewriter",
         "//loom/src/loom/target:math_policy",

--- a/loom/src/loom/transforms/math/CMakeLists.txt
+++ b/loom/src/loom/transforms/math/CMakeLists.txt
@@ -32,6 +32,7 @@ loom_cc_library(
     loom::pass::pipeline
     loom::pass::registry
     loom::pass::types
+    loom::pass::value_facts
     loom::rewrite::greedy
     loom::rewrite::rewriter
     loom::target::math_policy

--- a/loom/src/loom/transforms/math/legalize.c
+++ b/loom/src/loom/transforms/math/legalize.c
@@ -17,6 +17,7 @@
 #include "loom/ops/vector/ops.h"
 #include "loom/pass/pipeline.h"
 #include "loom/pass/registry.h"
+#include "loom/pass/value_facts.h"
 #include "loom/rewrite/greedy.h"
 #include "loom/target/math_policy.h"
 #include "loom/target/pass_environment.h"
@@ -591,12 +592,16 @@ iree_status_t loom_math_legalize_run(loom_pass_t* pass, loom_module_t* module,
       .policy = policy,
       .compile_report = compile_report,
   };
+  loom_value_fact_table_t* fact_table = NULL;
+  IREE_RETURN_IF_ERROR(loom_pass_value_facts_acquire(
+      pass, module,
+      loom_pass_value_fact_scope_function_for_target(function, target_facts),
+      &fact_table));
   loom_greedy_rewrite_driver_t driver;
-  loom_greedy_rewrite_driver_initialize(module, pass->arena, pass->value_facts,
+  loom_greedy_rewrite_driver_initialize(module, pass->arena, fact_table,
                                         &driver);
   loom_greedy_rewrite_options_t rewrite_options = {
       .max_iterations = options ? options->max_iterations : 0,
-      .target_facts = target_facts,
   };
   loom_greedy_rewrite_callbacks_t callbacks = {
       .user_data = &state,
@@ -608,6 +613,7 @@ iree_status_t loom_math_legalize_run(loom_pass_t* pass, loom_module_t* module,
       &rewrite_options, &callbacks, &result);
   loom_greedy_rewrite_driver_deinitialize(&driver);
   if (!iree_status_is_ok(status)) {
+    loom_pass_value_fact_owner_invalidate(pass->value_facts);
     return status;
   }
 

--- a/loom/src/loom/transforms/vector/BUILD.bazel
+++ b/loom/src/loom/transforms/vector/BUILD.bazel
@@ -52,6 +52,23 @@ loom_cc_library(
     ],
 )
 
+loom_cc_test(
+    name = "memory_footprint_test",
+    srcs = ["memory_footprint_test.cc"],
+    deps = [
+        ":memory_footprint",
+        "//loom/src/loom/format/text:parser",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/ops:op_defs",
+        "//loom/src/loom/ops/test",
+        "//loom/src/loom/pass:types",
+        "//loom/src/loom/pass:value_facts",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
 loom_cc_library(
     name = "sink_single_use_reads",
     srcs = ["sink_single_use_reads.c"],

--- a/loom/src/loom/transforms/vector/CMakeLists.txt
+++ b/loom/src/loom/transforms/vector/CMakeLists.txt
@@ -51,6 +51,24 @@ loom_cc_library(
   PUBLIC
 )
 
+loom_cc_test(
+  NAME
+    memory_footprint_test
+  SRCS
+    "memory_footprint_test.cc"
+  DEPS
+    ::memory_footprint
+    iree::base::internal::arena
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::format::text::parser
+    loom::ir
+    loom::ops::op_defs
+    loom::ops::test
+    loom::pass::types
+    loom::pass::value_facts
+)
+
 loom_cc_library(
   NAME
     sink_single_use_reads

--- a/loom/src/loom/transforms/vector/memory_footprint.c
+++ b/loom/src/loom/transforms/vector/memory_footprint.c
@@ -71,9 +71,6 @@ iree_status_t loom_vector_memory_footprint_run(loom_pass_t* pass,
   };
   iree_status_t status = loom_vector_memory_footprint_verify_function(
       module, function, &options, &result);
-  if (pass->value_facts != NULL) {
-    loom_pass_value_fact_owner_invalidate(pass->value_facts);
-  }
   IREE_RETURN_IF_ERROR(status);
   loom_vector_memory_footprint_statistics(pass)->ops_checked +=
       result.checked_op_count;

--- a/loom/src/loom/transforms/vector/memory_footprint_test.cc
+++ b/loom/src/loom/transforms/vector/memory_footprint_test.cc
@@ -1,0 +1,108 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/transforms/vector/memory_footprint.h"
+
+#include <cstring>
+
+#include "iree/base/internal/arena.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "loom/format/text/parser.h"
+#include "loom/ir/context.h"
+#include "loom/ir/module.h"
+#include "loom/ops/op_defs.h"
+#include "loom/ops/test/registry.h"
+#include "loom/pass/value_facts.h"
+
+namespace loom {
+namespace {
+
+class VectorMemoryFootprintPassTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_arena_block_pool_initialize(4096, iree_allocator_system(),
+                                     &block_pool_);
+    iree_arena_initialize(&block_pool_, &pass_arena_);
+    loom_context_initialize(iree_allocator_system(), &context_);
+    IREE_ASSERT_OK(loom_test_dialect_register(&context_));
+    IREE_ASSERT_OK(loom_context_finalize(&context_));
+    loom_pass_value_fact_owner_initialize(&block_pool_, &value_facts_);
+  }
+
+  void TearDown() override {
+    loom_pass_value_fact_owner_deinitialize(&value_facts_);
+    if (module_) loom_module_free(module_);
+    loom_context_deinitialize(&context_);
+    iree_arena_deinitialize(&pass_arena_);
+    iree_arena_block_pool_deinitialize(&block_pool_);
+  }
+
+  loom_module_t* Parse(iree_string_view_t source) {
+    const loom_text_parse_options_t options = {
+        /*.diagnostic_sink=*/{loom_diagnostic_stderr_sink, nullptr},
+        /*.max_errors=*/20,
+    };
+    IREE_EXPECT_OK(
+        loom_text_parse(source, IREE_SV("memory_footprint_test.loom"),
+                        &context_, &block_pool_, &options, &module_));
+    EXPECT_NE(module_, nullptr);
+    return module_;
+  }
+
+  iree_arena_block_pool_t block_pool_ = {};
+  iree_arena_allocator_t pass_arena_ = {};
+  loom_context_t context_ = {};
+  loom_module_t* module_ = nullptr;
+  loom_pass_value_fact_owner_t value_facts_ = {};
+};
+
+TEST_F(VectorMemoryFootprintPassTest, PreservesReadOnlyFunctionFacts) {
+  loom_module_t* module =
+      Parse(IREE_SV("test.func @main() {\n"
+                    "  %value = test.constant 42 : i32\n"
+                    "  test.yield\n"
+                    "}\n"));
+  ASSERT_NE(module, nullptr);
+  loom_op_t* function_op = loom_block_op(loom_module_block(module), 0);
+  ASSERT_NE(function_op, nullptr);
+  loom_func_like_t function = loom_func_like_cast(module, function_op);
+  ASSERT_TRUE(loom_func_like_isa(function));
+
+  loom_pass_value_fact_lifecycle_counts_t counts = {};
+  value_facts_.lifecycle_counts = &counts;
+
+  loom_pass_t pass = {};
+  pass.info = loom_vector_memory_footprint_pass_info();
+  pass.instance_arena = &pass_arena_;
+  pass.arena = &pass_arena_;
+  pass.value_facts = &value_facts_;
+  ASSERT_NE(pass.info->statistic_layout, nullptr);
+  void* statistic_storage = nullptr;
+  IREE_ASSERT_OK(iree_arena_allocate(&pass_arena_,
+                                     pass.info->statistic_layout->storage_size,
+                                     &statistic_storage));
+  pass.statistic_storage = statistic_storage;
+  memset(pass.statistic_storage, 0, pass.info->statistic_layout->storage_size);
+
+  IREE_ASSERT_OK(loom_vector_memory_footprint_run(&pass, module, function));
+
+  loom_value_fact_table_t* reused_facts = nullptr;
+  IREE_ASSERT_OK(loom_pass_value_facts_acquire(
+      &pass, module, loom_pass_value_fact_scope_function(function),
+      &reused_facts));
+  ASSERT_NE(reused_facts, nullptr);
+  EXPECT_EQ(counts.acquisition_count, 2u);
+  EXPECT_EQ(counts.recomputation_count, 1u);
+  EXPECT_EQ(counts.cache_hit_count, 1u);
+  EXPECT_EQ(counts.invalidation_count, 0u);
+  EXPECT_EQ(counts.scope_clear_count, 0u);
+
+  value_facts_.lifecycle_counts = nullptr;
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/transforms/view/linearize_view_accesses.c
+++ b/loom/src/loom/transforms/view/linearize_view_accesses.c
@@ -125,22 +125,19 @@ typedef struct loom_linearize_view_accesses_vector_tile_t {
   loom_type_t flat_vector_type;
 } loom_linearize_view_accesses_vector_tile_t;
 
-static iree_status_t loom_linearize_view_accesses_op_list_initialize(
-    iree_arena_allocator_t* arena,
-    loom_linearize_view_accesses_op_list_t* list) {
-  list->count = 0;
-  list->capacity = 32;
-  return iree_arena_allocate_array(arena, list->capacity, sizeof(loom_op_t*),
-                                   (void**)&list->ops);
-}
-
 static iree_status_t loom_linearize_view_accesses_op_list_push(
     iree_arena_allocator_t* arena, loom_linearize_view_accesses_op_list_t* list,
     loom_op_t* op) {
   if (list->count >= list->capacity) {
-    IREE_RETURN_IF_ERROR(iree_arena_grow_array(
-        arena, list->count, list->count + 1, sizeof(loom_op_t*),
-        &list->capacity, (void**)&list->ops));
+    if (list->capacity == 0) {
+      list->capacity = 32;
+      IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+          arena, list->capacity, sizeof(loom_op_t*), (void**)&list->ops));
+    } else {
+      IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+          arena, list->count, list->count + 1, sizeof(loom_op_t*),
+          &list->capacity, (void**)&list->ops));
+    }
   }
   list->ops[list->count++] = op;
   return iree_ok_status();
@@ -1308,14 +1305,7 @@ iree_status_t loom_linearize_view_accesses_run(loom_pass_t* pass,
                                                loom_func_like_t function) {
   if (!loom_func_like_body(function)) return iree_ok_status();
 
-  loom_value_fact_table_t* fact_table = NULL;
-  IREE_RETURN_IF_ERROR(loom_pass_value_facts_acquire(
-      pass, module, loom_pass_value_fact_scope_function(function),
-      &fact_table));
-
   loom_linearize_view_accesses_op_list_t accesses = {0};
-  IREE_RETURN_IF_ERROR(
-      loom_linearize_view_accesses_op_list_initialize(pass->arena, &accesses));
   loom_walk_result_t walk_result = LOOM_WALK_CONTINUE;
   loom_linearize_view_accesses_collect_context_t collect_context = {
       .arena = pass->arena,
@@ -1328,6 +1318,12 @@ iree_status_t loom_linearize_view_accesses_run(loom_pass_t* pass,
                              .user_data = &collect_context,
                          },
                          pass->arena, &walk_result));
+  if (accesses.count == 0) return iree_ok_status();
+
+  loom_value_fact_table_t* fact_table = NULL;
+  IREE_RETURN_IF_ERROR(loom_pass_value_facts_acquire(
+      pass, module, loom_pass_value_fact_scope_function(function),
+      &fact_table));
 
   loom_linearize_view_accesses_view_map_t view_map = {0};
   IREE_RETURN_IF_ERROR(


### PR DESCRIPTION
Loom now keeps value facts alive when compiler work proves that the IR has not changed, and pass reports can show exactly when facts were reused, recomputed, or discarded. This removes several full-function rediscovery paths from the JIT while making the remaining lifecycle deterministic and attributable to the pass that caused it.

## Value facts become caller-owned compiler state

The greedy rewrite driver previously acquired facts internally and invalidated them whenever its run state was reset. A no-op canonicalizer therefore discarded a valid function analysis even though it had changed nothing, and canonicalizing multiple projected regions prepared and cleared independent tables for each region.

Greedy rewriting now borrows a precomputed table from its caller and incrementally maintains that table as rewrites succeed. Canonicalization owns one function-scoped table across every root region, so projected regions and the function body share one coherent analysis generation. Math and target legalization prepare the exact private scopes they maintain, and failure paths remain responsible for invalidating partially updated state.

This does not introduce a generic “facts preserved” side channel for mutating passes. Value facts can contain SSA identities through origins, storage roots, alias scopes, and contextual queries; arbitrary transforms remain conservatively invalidating until they explicitly maintain every affected domain.

## Pass reports expose lifecycle costs

When pass reporting is enabled, each invocation can now carry a `value-facts` detail with acquisitions, cache hits, recomputations, caller-maintained preparations, invalidations, populated scope clears, and the number of values computed or discarded. Ordinary compilation installs no counters and performs no per-value reporting work.

```json
{
  "category": "value-facts",
  "acquisition_count": 1,
  "cache_hit_count": 1,
  "recomputation_count": 0,
  "invalidation_count": 0,
  "scope_clear_count": 0
}
```

This turns a slow cleanup pass from “canonicalize took time” into a concrete distinction between useful rewriting, a cache hit over unchanged IR, and a full analysis that was immediately thrown away.

## Proven redundant work is removed

CFG simplification now reduces all redundant block arguments under one fact and dominance generation, tracks surviving arguments back to their original incoming slots, and rebuilds each predecessor once with the final block signature. The outer fixed point remains responsible for topology-changing simplifications, while one block with many removable arguments no longer rebuilds the same branch and analysis state after every argument.

View-access linearization collects candidate memory operations before acquiring facts. Functions without view or vector accesses return after that existing discovery walk without allocating a candidate list or computing an analysis that cannot be consumed.

Vector memory-footprint verification is read-only and now leaves its function scope reusable. A following fact consumer receives a cache hit instead of recomputing facts solely because a proof pass ran.

## Lifecycle result

On the same Qwen kernel compilation, the ten canonicalizer invocations retained the same seven changing and three no-op outcomes while their ownership churn fell substantially:

| Canonicalizer lifecycle | Before | After |
| --- | ---: | ---: |
| Owner acquisitions | 0 | 10 |
| Owner preparations | 18 | 0 |
| Invalidations | 34 | 7 |
| Populated scope clears | 18 | 7 |
| Cleared values | 9,761 | 7,915 |

Each changing invocation now reaches the conservative interpreter boundary with one invalidation. All three no-op invocations perform zero invalidations and zero scope clears, and a repeated no-op invocation with no intervening mutation is served by a cache hit. Broad end-to-end Qwen compilation remained neutral within roughly 0.5%, so the result claimed here is the deterministic removal of redundant analysis work and the instrumentation needed to find the next pathological cases—not an inflated whole-workload speedup.
