### PR TITLE
[Loom] Make shared target cleanup change-driven

### DIFF
--- a/loom/src/loom/codegen/low/pipeline/pipeline.c
+++ b/loom/src/loom/codegen/low/pipeline/pipeline.c
@@ -9,6 +9,9 @@
 iree_status_t loom_low_pipeline_build_packetization_preparation(
     loom_builder_t* builder) {
   loom_op_t* run_op = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_pass_ir_build_run(builder, 0, IREE_SV("canonicalize"),
+                             loom_named_attr_slice_empty(), &run_op));
   IREE_RETURN_IF_ERROR(loom_pass_ir_build_run(
       builder, 0, IREE_SV("cse"), loom_named_attr_slice_empty(), &run_op));
   IREE_RETURN_IF_ERROR(

--- a/loom/src/loom/codegen/low/pipeline/pipeline_test.cc
+++ b/loom/src/loom/codegen/low/pipeline/pipeline_test.cc
@@ -69,9 +69,14 @@ TEST_F(LowPipelineTest, BuildsPacketizationPreparationFragment) {
   loom_block_t* pipeline_body =
       loom_region_entry_block(loom_pass_pipeline_body(pipeline_op));
   ASSERT_NE(pipeline_body, nullptr);
-  ASSERT_EQ(pipeline_body->op_count, 4u);
+  ASSERT_EQ(pipeline_body->op_count, 5u);
 
-  loom_op_t* cse_run = pipeline_body->first_op;
+  loom_op_t* canonicalize_run = pipeline_body->first_op;
+  ASSERT_TRUE(loom_pass_run_isa(canonicalize_run));
+  EXPECT_TRUE(iree_string_view_equal(RunKey(module.get(), canonicalize_run),
+                                     IREE_SV("canonicalize")));
+
+  loom_op_t* cse_run = canonicalize_run->next_op;
   ASSERT_TRUE(loom_pass_run_isa(cse_run));
   EXPECT_TRUE(
       iree_string_view_equal(RunKey(module.get(), cse_run), IREE_SV("cse")));

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_pipeline.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_pipeline.loom-test
@@ -47,20 +47,36 @@ pass.pipeline<module> @__loom_check_source_low pipeline {
     }
   }
   target-legalize(mode = "eager")
+  if changed {
+    for func {
+      where target {
+        canonicalize
+        cse
+      }
+    }
+  }
   for func {
     where target {
       unroll-scf-for
-      canonicalize
-      cse
+      if changed {
+        canonicalize
+        cse
+      }
       sroa-vector-banks
       if changed {
         canonicalize
         cse
       }
       sink-single-use-reads
+      if changed {
+        canonicalize
+        cse
+      }
       promote-private-fragments
-      canonicalize
-      cse
+      if changed {
+        canonicalize
+        cse
+      }
       scf-to-cfg
       cfg-simplify
       canonicalize
@@ -130,20 +146,36 @@ pass.pipeline<module> @__loom_check_source_low pipeline {
     }
   }
   target-legalize(mode = "eager")
+  if changed {
+    for func {
+      where target {
+        canonicalize
+        cse
+      }
+    }
+  }
   for func {
     where target {
       unroll-scf-for
-      canonicalize
-      cse
+      if changed {
+        canonicalize
+        cse
+      }
       sroa-vector-banks
       if changed {
         canonicalize
         cse
       }
       sink-single-use-reads
+      if changed {
+        canonicalize
+        cse
+      }
       promote-private-fragments
-      canonicalize
-      cse
+      if changed {
+        canonicalize
+        cse
+      }
       scf-to-cfg
       cfg-simplify
       canonicalize
@@ -261,20 +293,36 @@ pass.pipeline<module> @__loom_check_prepared_low pipeline {
     }
   }
   target-legalize(mode = "eager")
+  if changed {
+    for func {
+      where target {
+        canonicalize
+        cse
+      }
+    }
+  }
   for func {
     where target {
       unroll-scf-for
-      canonicalize
-      cse
+      if changed {
+        canonicalize
+        cse
+      }
       sroa-vector-banks
       if changed {
         canonicalize
         cse
       }
       sink-single-use-reads
+      if changed {
+        canonicalize
+        cse
+      }
       promote-private-fragments
-      canonicalize
-      cse
+      if changed {
+        canonicalize
+        cse
+      }
       scf-to-cfg
       cfg-simplify
       canonicalize
@@ -298,7 +346,6 @@ pass.pipeline<module> @__loom_check_prepared_low pipeline {
         amdgpu-materialize-hal-kernel-abi
       }
       canonicalize
-      cse
       cse
       low-select-operand-forms
       low-dce

--- a/loom/src/loom/target/arch/spirv/test/source_low/structured_control.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/structured_control.loom-test
@@ -47,6 +47,14 @@ pass.pipeline<module> @__loom_check_source_low pipeline {
     }
   }
   target-legalize(mode = "eager")
+  if changed {
+    for func {
+      where target {
+        canonicalize
+        cse
+      }
+    }
+  }
   source-to-low(control-flow = "structured-low")
   for func {
     where target {

--- a/loom/src/loom/target/pipeline.c
+++ b/loom/src/loom/target/pipeline.c
@@ -271,6 +271,21 @@ static iree_status_t loom_target_pipeline_build_cleanup_body(
   return loom_target_pipeline_build_cleanup(builder);
 }
 
+static iree_status_t loom_target_pipeline_build_cleanup_if_changed(
+    loom_builder_t* builder) {
+  loom_op_t* if_changed_op = NULL;
+  return loom_pass_ir_build_if_changed(
+      builder, loom_target_pipeline_build_cleanup_body, NULL, &if_changed_op);
+}
+
+static iree_status_t loom_target_pipeline_build_cleanup_target_functions(
+    loom_builder_t* builder, void* user_data) {
+  (void)user_data;
+  loom_op_t* for_op = NULL;
+  return loom_target_pipeline_build_for_target_functions(
+      builder, loom_target_pipeline_build_cleanup_body, NULL, &for_op);
+}
+
 static iree_status_t
 loom_target_pipeline_build_source_normalization_before_authoring_expansion(
     loom_builder_t* builder, void* user_data) {
@@ -318,21 +333,23 @@ loom_target_pipeline_build_cfg_source_finalization_after_legalize(
   (void)user_data;
   IREE_RETURN_IF_ERROR(
       loom_target_pipeline_build_run(builder, IREE_SV("unroll-scf-for")));
-  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_cleanup(builder));
+  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_cleanup_if_changed(builder));
   IREE_RETURN_IF_ERROR(
       loom_target_pipeline_build_run(builder, IREE_SV("sroa-vector-banks")));
-  loom_op_t* if_changed_op = NULL;
-  IREE_RETURN_IF_ERROR(loom_pass_ir_build_if_changed(
-      builder, loom_target_pipeline_build_cleanup_body, NULL, &if_changed_op));
+  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_cleanup_if_changed(builder));
   IREE_RETURN_IF_ERROR(loom_target_pipeline_build_run(
       builder, IREE_SV("sink-single-use-reads")));
+  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_cleanup_if_changed(builder));
   IREE_RETURN_IF_ERROR(loom_target_pipeline_build_run(
       builder, IREE_SV("promote-private-fragments")));
-  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_cleanup(builder));
+  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_cleanup_if_changed(builder));
   IREE_RETURN_IF_ERROR(
       loom_target_pipeline_build_run(builder, IREE_SV("scf-to-cfg")));
   IREE_RETURN_IF_ERROR(
       loom_target_pipeline_build_run(builder, IREE_SV("cfg-simplify")));
+  // This is the final source canonicalization boundary before lowering. Run it
+  // even when CFG simplification made no change because canonicalization may
+  // have independent pending work, such as propagating callee purity.
   IREE_RETURN_IF_ERROR(loom_target_pipeline_build_cleanup(builder));
   return loom_target_pipeline_build_run(builder, IREE_SV("branch-sink"));
 }
@@ -376,7 +393,6 @@ static iree_status_t loom_target_pipeline_build_low_preparation(
     IREE_RETURN_IF_ERROR(loom_target_pipeline_build_run(
         builder, IREE_SV("sanitizer-materialize-assertions")));
   }
-  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_cleanup(builder));
   IREE_RETURN_IF_ERROR(loom_target_pipeline_contribute_phase(
       builder, context, LOOM_TARGET_PIPELINE_PHASE_TARGET_LOW_PREPARATION));
   return loom_low_pipeline_build_packetization_preparation(builder);
@@ -422,6 +438,12 @@ static iree_status_t loom_target_pipeline_build_source_low_body(
       user_data, &for_op));
   IREE_RETURN_IF_ERROR(
       loom_target_pipeline_build_target_legalize(builder, IREE_SV("eager")));
+  // Module legalization may mutate any target function. Normalize the full
+  // target set only when it did so before function-local CFG finalization.
+  loom_op_t* if_changed_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_pass_ir_build_if_changed(
+      builder, loom_target_pipeline_build_cleanup_target_functions, NULL,
+      &if_changed_op));
   if (control_flow_lowering == LOOM_TARGET_CONTROL_FLOW_LOWERING_CFG) {
     IREE_RETURN_IF_ERROR(loom_target_pipeline_build_for_target_functions(
         builder,

--- a/loom/src/loom/target/provider.h
+++ b/loom/src/loom/target/provider.h
@@ -215,7 +215,8 @@ typedef enum loom_target_pipeline_phase_e {
   LOOM_TARGET_PIPELINE_PHASE_SOURCE_LOW_ARTIFACT_PREPARATION = 2,
   // Target ABI/resource materialization after source-to-low.
   LOOM_TARGET_PIPELINE_PHASE_TARGET_LOW_MATERIALIZATION = 3,
-  // Target-low cleanup and operand-form preparation before emission.
+  // Target-low preparation before the common cleanup and operand-form
+  // selection immediately preceding emission.
   LOOM_TARGET_PIPELINE_PHASE_TARGET_LOW_PREPARATION = 4,
   LOOM_TARGET_PIPELINE_PHASE_COUNT_,
 } loom_target_pipeline_phase_t;


### PR DESCRIPTION
Use pass result state to skip canonicalization and CSE after transformation stages that made no IR change. The final source cleanup before lowering remains an unconditional convergence boundary because canonicalization can observe interprocedural facts such as newly pure callees even when the immediately preceding CFG simplification was a no-op.

Move the common Low normalization sequence after target-provider preparation. Each target function now runs canonicalization, CSE, operand-form selection, and dead-code elimination once immediately before emission instead of paying for redundant generic cleanup before and after the provider slot.

The existing single-worker gfx1100 compile-throughput witness improved in all five paired runs by 2.5–5.4%, with a median paired reduction of 5.2 microseconds (3.9%). Emitted artifacts are unchanged and linked code size is effectively neutral.

## Reviewer Notes

- `loom/src/loom/target/pipeline.c` contains the changed cleanup boundaries and documents why the final source boundary remains unconditional.
- The AMDGPU and SPIR-V pipeline checks expose the resulting pass structure directly, including module legalization cleanup and the single final Low normalization sequence.
