### PR TITLE
[CI] Bound GPU hardware qualification

### DIFF
--- a/.github/scripts/check_rocm_environment.sh
+++ b/.github/scripts/check_rocm_environment.sh
@@ -12,8 +12,40 @@ if ! command -v rocminfo >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "rocminfo path: $(command -v rocminfo)"
-if ! rocminfo; then
-  echo "::error::ROCm environment on this runner is broken; rocminfo failed before GPU tests."
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "::error::Required process supervisor timeout was not found."
   exit 1
 fi
+
+readonly probe_timeout_seconds=30
+readonly probe_kill_after_seconds=5
+readonly runner_name="${RUNNER_NAME:-unknown}"
+
+echo "rocminfo path: $(command -v rocminfo)"
+printf 'Checking ROCm hardware on runner %s (timeout: %ss).\n' \
+  "${runner_name}" "${probe_timeout_seconds}"
+
+probe_status=0
+timeout --kill-after="${probe_kill_after_seconds}s" \
+  "${probe_timeout_seconds}s" rocminfo || probe_status=$?
+
+case "${probe_status}" in
+  0)
+    ;;
+  124)
+    printf '::error::ROCm hardware probe exceeded %ss on runner %s; '\
+'rocminfo or the HSA driver is wedged.\n' \
+      "${probe_timeout_seconds}" "${runner_name}"
+    exit 124
+    ;;
+  137)
+    printf '::error::ROCm hardware probe on runner %s required SIGKILL '\
+'after exceeding %ss.\n' "${runner_name}" "${probe_timeout_seconds}"
+    exit 137
+    ;;
+  *)
+    printf '::error::ROCm hardware probe failed with exit code %s on '\
+'runner %s before GPU tests.\n' "${probe_status}" "${runner_name}"
+    exit "${probe_status}"
+    ;;
+esac

--- a/.github/scripts/check_vulkan_hardware_environment.sh
+++ b/.github/scripts/check_vulkan_hardware_environment.sh
@@ -12,7 +12,21 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-python3 - <<'PY'
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "Required process supervisor timeout was not found." >&2
+  exit 1
+fi
+
+readonly probe_timeout_seconds=30
+readonly probe_kill_after_seconds=5
+readonly runner_name="${RUNNER_NAME:-unknown}"
+
+printf 'Checking Vulkan hardware on runner %s (timeout: %ss).\n' \
+  "${runner_name}" "${probe_timeout_seconds}"
+
+probe_status=0
+timeout --kill-after="${probe_kill_after_seconds}s" \
+  "${probe_timeout_seconds}s" python3 -u - <<'PY' || probe_status=$?
 import ctypes
 import os
 import sys
@@ -103,6 +117,7 @@ def vk_result_name(result):
 def main():
     check_software_forcing_environment()
 
+    print("Loading the Vulkan loader...", flush=True)
     try:
         vulkan = ctypes.CDLL("libvulkan.so.1")
     except OSError as error:
@@ -142,6 +157,7 @@ def main():
         ppEnabledExtensionNames=None,
     )
     instance = ctypes.c_void_p()
+    print("Creating a Vulkan instance...", flush=True)
     result = vulkan.vkCreateInstance(
         ctypes.byref(create_info), None, ctypes.byref(instance)
     )
@@ -150,6 +166,7 @@ def main():
 
     try:
         device_count = ctypes.c_uint32()
+        print("Enumerating Vulkan physical devices...", flush=True)
         result = vulkan.vkEnumeratePhysicalDevices(
             instance, ctypes.byref(device_count), None
         )
@@ -171,6 +188,7 @@ def main():
 
         first_device_is_hardware = False
         found_hardware = False
+        print("Reading Vulkan physical device properties...", flush=True)
         print(f"Vulkan physical devices: {device_count.value}")
         for index in range(device_count.value):
             properties = VkPhysicalDeviceProperties()
@@ -217,9 +235,29 @@ def main():
             )
     finally:
         if instance.value:
+            print("Destroying the Vulkan instance...", flush=True)
             vulkan.vkDestroyInstance(instance, None)
 
 
 if __name__ == "__main__":
     sys.exit(main())
 PY
+
+case "${probe_status}" in
+  0)
+    ;;
+  124)
+    printf 'Vulkan hardware probe exceeded %ss on runner %s; the last phase '\
+'above identifies the loader or driver operation that wedged.\n' \
+      "${probe_timeout_seconds}" "${runner_name}" >&2
+    exit 124
+    ;;
+  137)
+    printf 'Vulkan hardware probe on runner %s required SIGKILL after '\
+'exceeding %ss.\n' "${runner_name}" "${probe_timeout_seconds}" >&2
+    exit 137
+    ;;
+  *)
+    exit "${probe_status}"
+    ;;
+esac

--- a/.github/workflows/ci_iree_bazel.yml
+++ b/.github/workflows/ci_iree_bazel.yml
@@ -427,6 +427,7 @@ jobs:
           test -d "${HRX_ROCM_ROOT}/include"
 
       - name: Report ROCm environment
+        timeout-minutes: 1
         run: bash .github/scripts/check_rocm_environment.sh
 
       - name: Run IREE Bazel CI

--- a/.github/workflows/ci_iree_bazel.yml
+++ b/.github/workflows/ci_iree_bazel.yml
@@ -285,6 +285,7 @@ jobs:
         run: bash .github/scripts/fetch_rocm_toolchain.sh
 
       - name: Check Vulkan hardware environment
+        timeout-minutes: 1
         run: bash .github/scripts/check_vulkan_hardware_environment.sh
 
       - name: Install Bazel host tools

--- a/.github/workflows/ci_iree_cmake.yml
+++ b/.github/workflows/ci_iree_cmake.yml
@@ -219,6 +219,7 @@ jobs:
         run: bash .github/scripts/fetch_rocm_toolchain.sh
 
       - name: Check Vulkan hardware environment
+        timeout-minutes: 1
         run: bash .github/scripts/check_vulkan_hardware_environment.sh
 
       - name: Install CMake host tools

--- a/.github/workflows/ci_iree_cmake.yml
+++ b/.github/workflows/ci_iree_cmake.yml
@@ -313,6 +313,7 @@ jobs:
           test -d "${HRX_ROCM_ROOT}/include"
 
       - name: Report ROCm environment
+        timeout-minutes: 1
         run: bash .github/scripts/check_rocm_environment.sh
 
       - name: Run IREE CMake CI

--- a/.github/workflows/test_core_linux_gpu.yml
+++ b/.github/workflows/test_core_linux_gpu.yml
@@ -153,6 +153,7 @@ jobs:
 
       - name: Report ROCm environment
         id: rocm_environment
+        timeout-minutes: 1
         continue-on-error: ${{ inputs.experimental }}
         run: |
           export PATH="${HRX_PUBLIC_DEPS_DIR}/bin:${PATH}"

--- a/.github/workflows/test_core_linux_gpu_source.yml
+++ b/.github/workflows/test_core_linux_gpu_source.yml
@@ -182,6 +182,7 @@ jobs:
 
       - name: Report ROCm environment
         id: rocm_environment
+        timeout-minutes: 1
         continue-on-error: ${{ inputs.experimental }}
         run: bash .github/scripts/check_rocm_environment.sh
 


### PR DESCRIPTION
GPU hardware qualification now fails within 30 seconds when the Vulkan loader, a device driver, or the ROCm/HSA environment wedges, instead of consuming an entire job before any build or test begins.

The shared hardware probe runs its existing ctypes validation under the Linux `timeout` supervisor, escalates to SIGKILL after five additional seconds, and preserves ordinary probe exit codes. It reports the self-hosted runner and flushes each loader, instance, enumeration, property, and teardown phase so infrastructure owners can identify both the host and the blocking Vulkan operation.

The shared ROCm environment probe applies the same process boundary to `rocminfo`, reports the runner and preserves ordinary command failures. Every AMDGPU and packaged-GPU workflow caller carries a one-minute GitHub Actions timeout as an outer boundary if the local supervisor cannot reap the process, matching the Bazel and CMake Vulkan preflights.

The observed bad DT83 jobs and successful DT143, DT145, DT147, and DT149 jobs all received the same requested Navi 4x labels, while the repository cannot inspect DT83's full organization-managed label set. This fixes the bounded-failure invariant without guessing at capacity-affecting scheduler changes; DT83 still needs to be repaired or removed from the pool.
