### PR TITLE
[Runtime/IOCP] Recover failed completion posts

### DIFF
--- a/runtime/src/iree/async/platform/iocp/BUILD.bazel
+++ b/runtime/src/iree/async/platform/iocp/BUILD.bazel
@@ -10,6 +10,7 @@
 # performs I/O and posts completion packets, so no worker threads are needed.
 
 load("//runtime/build_tools/bazel:cc.bzl", "iree_runtime_cc_library")
+load("//runtime/build_tools/bazel:cc_test.bzl", "iree_runtime_cc_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -20,6 +21,17 @@ package(
 #===------------------------------------------------------------------------===#
 # IOCP Proactor (Public API)
 #===------------------------------------------------------------------------===#
+
+iree_runtime_cc_library(
+    name = "completion_port",
+    srcs = ["completion_port.c"],
+    hdrs = ["completion_port.h"],
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
+    ],
+)
 
 iree_runtime_cc_library(
     name = "iocp",
@@ -35,6 +47,7 @@ iree_runtime_cc_library(
     hdrs = ["api.h"],
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
+        ":completion_port",
         "//runtime/src/iree/async",
         "//runtime/src/iree/async:types",
         "//runtime/src/iree/async/util:continuation",
@@ -48,5 +61,18 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base/internal:atomic_slist",
         "//runtime/src/iree/base/internal:memory",
         "//runtime/src/iree/base/internal:path",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "proactor_test",
+    srcs = ["proactor_test.cc"],
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        ":completion_port",
+        ":iocp",
+        "//runtime/src/iree/async",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )

--- a/runtime/src/iree/async/platform/iocp/CMakeLists.txt
+++ b/runtime/src/iree/async/platform/iocp/CMakeLists.txt
@@ -12,6 +12,21 @@ iree_add_all_subdirs()
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
 iree_cc_library(
   NAME
+    completion_port
+  HDRS
+    "completion_port.h"
+  SRCS
+    "completion_port.c"
+  DEPS
+    iree::base
+    iree::base::internal
+  PUBLIC
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+iree_cc_library(
+  NAME
     iocp
   HDRS
     "api.h"
@@ -24,6 +39,7 @@ iree_cc_library(
     "timer_list.c"
     "timer_list.h"
   DEPS
+    ::completion_port
     iree::async
     iree::async::types
     iree::async::util::continuation
@@ -38,6 +54,21 @@ iree_cc_library(
     iree::base::internal::memory
     iree::base::internal::path
   PUBLIC
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+iree_cc_test(
+  NAME
+    proactor_test
+  SRCS
+    "proactor_test.cc"
+  DEPS
+    ::completion_port
+    ::iocp
+    iree::async
+    iree::testing::gtest
+    iree::testing::gtest_main
 )
 endif()
 

--- a/runtime/src/iree/async/platform/iocp/completion_port.c
+++ b/runtime/src/iree/async/platform/iocp/completion_port.c
@@ -1,0 +1,139 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/async/platform/iocp/completion_port.h"
+
+#if defined(IREE_PLATFORM_WINDOWS)
+
+static VOID CALLBACK
+iree_async_iocp_completion_port_fallback_apc(ULONG_PTR data) {
+  (void)data;
+}
+
+void iree_async_iocp_completion_port_initialize(
+    HANDLE handle, iree_async_iocp_completion_port_t* out_completion_port) {
+  out_completion_port->handle = (uintptr_t)handle;
+  iree_atomic_store(&out_completion_port->poll_thread_handle, 0,
+                    iree_memory_order_relaxed);
+  iree_atomic_store(&out_completion_port->fallback_wake_pending, 0,
+                    iree_memory_order_relaxed);
+}
+
+void iree_async_iocp_completion_port_deinitialize(
+    iree_async_iocp_completion_port_t* completion_port) {
+  HANDLE poll_thread_handle = (HANDLE)iree_atomic_exchange(
+      &completion_port->poll_thread_handle, 0, iree_memory_order_acq_rel);
+  if (poll_thread_handle != NULL) {
+    if (!CloseHandle(poll_thread_handle)) iree_abort();
+  }
+  if (completion_port->handle != 0) {
+    if (!CloseHandle((HANDLE)completion_port->handle)) iree_abort();
+    completion_port->handle = 0;
+  }
+}
+
+iree_status_t iree_async_iocp_completion_port_bind_poll_thread(
+    iree_async_iocp_completion_port_t* completion_port) {
+  if (iree_atomic_load(&completion_port->poll_thread_handle,
+                       iree_memory_order_acquire) != 0) {
+    return iree_ok_status();
+  }
+
+  HANDLE poll_thread_handle = NULL;
+  if (!DuplicateHandle(GetCurrentProcess(), GetCurrentThread(),
+                       GetCurrentProcess(), &poll_thread_handle, 0, FALSE,
+                       DUPLICATE_SAME_ACCESS)) {
+    DWORD error_code = GetLastError();
+    return iree_make_status(iree_status_code_from_win32_error(error_code),
+                            "DuplicateHandle for IOCP poll owner failed "
+                            "(error %lu)",
+                            (unsigned long)error_code);
+  }
+
+  intptr_t expected_handle = 0;
+  if (!iree_atomic_compare_exchange_strong(
+          &completion_port->poll_thread_handle, &expected_handle,
+          (intptr_t)poll_thread_handle, iree_memory_order_release,
+          iree_memory_order_acquire)) {
+    if (!CloseHandle(poll_thread_handle)) iree_abort();
+  }
+  return iree_ok_status();
+}
+
+bool iree_async_iocp_completion_port_try_post(
+    iree_async_iocp_completion_port_t* completion_port, DWORD bytes_transferred,
+    ULONG_PTR completion_key, LPOVERLAPPED overlapped, DWORD* out_error_code) {
+  if (PostQueuedCompletionStatus((HANDLE)completion_port->handle,
+                                 bytes_transferred, completion_key,
+                                 overlapped)) {
+    *out_error_code = ERROR_SUCCESS;
+    return true;
+  }
+  *out_error_code = GetLastError();
+  return false;
+}
+
+iree_status_t iree_async_iocp_completion_port_post(
+    iree_async_iocp_completion_port_t* completion_port, DWORD bytes_transferred,
+    ULONG_PTR completion_key, LPOVERLAPPED overlapped) {
+  DWORD error_code = ERROR_SUCCESS;
+  if (iree_async_iocp_completion_port_try_post(
+          completion_port, bytes_transferred, completion_key, overlapped,
+          &error_code)) {
+    return iree_ok_status();
+  }
+  return iree_make_status(iree_status_code_from_win32_error(error_code),
+                          "PostQueuedCompletionStatus failed (error %lu)",
+                          (unsigned long)error_code);
+}
+
+void iree_async_iocp_completion_port_request_fallback_wake(
+    iree_async_iocp_completion_port_t* completion_port) {
+  if (iree_atomic_exchange(&completion_port->fallback_wake_pending, 1,
+                           iree_memory_order_acq_rel) != 0) {
+    return;
+  }
+
+  HANDLE poll_thread_handle = (HANDLE)iree_atomic_load(
+      &completion_port->poll_thread_handle, iree_memory_order_acquire);
+  if (poll_thread_handle == NULL) {
+    // No poll can be blocked before its owner publishes a thread handle. Its
+    // first poll consumes fallback_wake_pending before waiting.
+    return;
+  }
+
+  if (QueueUserAPC(iree_async_iocp_completion_port_fallback_apc,
+                   poll_thread_handle, 0) != 0) {
+    return;
+  }
+
+  // A duplicated live thread handle has THREAD_SET_CONTEXT access. Failure to
+  // queue its APC therefore means the poll-interrupt invariant was violated.
+  // An exited poll owner needs no wake; a live owner cannot be left blocked
+  // after the state it must observe has already committed.
+  DWORD wait_result = WaitForSingleObject(poll_thread_handle, 0);
+  if (wait_result != WAIT_OBJECT_0) {
+    iree_abort();
+  }
+}
+
+void iree_async_iocp_completion_port_wake(
+    iree_async_iocp_completion_port_t* completion_port) {
+  DWORD error_code = ERROR_SUCCESS;
+  if (iree_async_iocp_completion_port_try_post(completion_port, 0, 0, NULL,
+                                               &error_code)) {
+    return;
+  }
+  iree_async_iocp_completion_port_request_fallback_wake(completion_port);
+}
+
+bool iree_async_iocp_completion_port_consume_fallback_wake(
+    iree_async_iocp_completion_port_t* completion_port) {
+  return iree_atomic_exchange(&completion_port->fallback_wake_pending, 0,
+                              iree_memory_order_acq_rel) != 0;
+}
+
+#endif  // IREE_PLATFORM_WINDOWS

--- a/runtime/src/iree/async/platform/iocp/completion_port.h
+++ b/runtime/src/iree/async/platform/iocp/completion_port.h
@@ -1,0 +1,83 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_ASYNC_PLATFORM_IOCP_COMPLETION_PORT_H_
+#define IREE_ASYNC_PLATFORM_IOCP_COMPLETION_PORT_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/atomics.h"
+
+#if defined(IREE_PLATFORM_WINDOWS)
+// clang-format off
+#include <winsock2.h>
+#include <windows.h>
+// clang-format on
+#endif  // IREE_PLATFORM_WINDOWS
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Owns an IOCP handle and the cross-thread mechanism used to wake its poll
+// owner if a synthetic completion cannot be posted.
+typedef struct iree_async_iocp_completion_port_t {
+  // Native IOCP handle owned by this state object.
+  uintptr_t handle;
+
+  // Duplicated handle to the lifetime poll-owner thread. Published by its
+  // first poll call and closed during deinitialization.
+  iree_atomic_intptr_t poll_thread_handle;
+
+  // Coalesced indication that a failed post requested an APC fallback wake.
+  iree_atomic_int32_t fallback_wake_pending;
+} iree_async_iocp_completion_port_t;
+
+#if defined(IREE_PLATFORM_WINDOWS)
+
+// Initializes |out_completion_port| to own |handle|.
+void iree_async_iocp_completion_port_initialize(
+    HANDLE handle, iree_async_iocp_completion_port_t* out_completion_port);
+
+// Closes the poll-owner and completion-port handles.
+void iree_async_iocp_completion_port_deinitialize(
+    iree_async_iocp_completion_port_t* completion_port);
+
+// Publishes a durable handle to the calling thread as the poll owner.
+// Repeated calls from the same owner are no-ops.
+iree_status_t iree_async_iocp_completion_port_bind_poll_thread(
+    iree_async_iocp_completion_port_t* completion_port);
+
+// Attempts to post one packet and captures GetLastError immediately on
+// failure. Does not allocate and is safe for Windows-managed callbacks.
+bool iree_async_iocp_completion_port_try_post(
+    iree_async_iocp_completion_port_t* completion_port, DWORD bytes_transferred,
+    ULONG_PTR completion_key, LPOVERLAPPED overlapped, DWORD* out_error_code);
+
+// Posts one packet or returns an owned status describing the transport error.
+iree_status_t iree_async_iocp_completion_port_post(
+    iree_async_iocp_completion_port_t* completion_port, DWORD bytes_transferred,
+    ULONG_PTR completion_key, LPOVERLAPPED overlapped);
+
+// Requests an alertable-wait APC after state representing a failed post has
+// been made visible to the poll thread. Multiple requests coalesce.
+void iree_async_iocp_completion_port_request_fallback_wake(
+    iree_async_iocp_completion_port_t* completion_port);
+
+// Posts the normal wake sentinel, falling back to an APC if posting fails.
+void iree_async_iocp_completion_port_wake(
+    iree_async_iocp_completion_port_t* completion_port);
+
+// Consumes a pending fallback wake request.
+bool iree_async_iocp_completion_port_consume_fallback_wake(
+    iree_async_iocp_completion_port_t* completion_port);
+
+#endif  // IREE_PLATFORM_WINDOWS
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_ASYNC_PLATFORM_IOCP_COMPLETION_PORT_H_

--- a/runtime/src/iree/async/platform/iocp/proactor.c
+++ b/runtime/src/iree/async/platform/iocp/proactor.c
@@ -91,11 +91,17 @@ typedef NTSTATUS(NTAPI* iree_pfn_NtAssociateWaitCompletionPacket_t)(
 typedef NTSTATUS(NTAPI* iree_pfn_NtCancelWaitCompletionPacket_t)(
     HANDLE WaitCompletionPacketHandle, BOOLEAN RemoveSignaledPacket);
 
-// IOCP port handle for the proactor that owns signal handling. The console ctrl
-// handler fires on an OS thread pool thread with no user_data parameter, so we
-// store the completion port globally. Only one proactor may own signals
-// (enforced by iree_async_signal_claim_ownership).
-static HANDLE g_iocp_signal_completion_port = NULL;
+// Proactor that owns signal handling. The console ctrl handler fires on an OS
+// thread pool thread with no user_data parameter, so it reaches the checked
+// completion-post boundary through this singleton. Only one proactor may own
+// signals (enforced by iree_async_signal_claim_ownership).
+static iree_atomic_intptr_t g_iocp_signal_proactor = IREE_ATOMIC_VAR_INIT(0);
+
+// Number of console ctrl handlers that may still access the signal proactor.
+// Deinitialization clears the singleton and waits for this rundown count before
+// releasing any state a handler could observe.
+static iree_atomic_int32_t g_iocp_active_signal_handler_count =
+    IREE_ATOMIC_VAR_INIT(0);
 
 // Atomic bitmask of pending console control events. The handler ORs in
 // (1 << ctrl_type) for each event; the poll thread atomically exchanges the
@@ -105,8 +111,8 @@ static HANDLE g_iocp_signal_completion_port = NULL;
 static iree_atomic_int32_t g_iocp_pending_ctrl_events = IREE_ATOMIC_VAR_INIT(0);
 
 // Console ctrl handler registered via SetConsoleCtrlHandler. Fires on an OS
-// thread pool thread — no proactor state access, only atomic bitmask update
-// and IOCP post.
+// thread pool thread and only touches the global signal state plus the
+// proactor's completion-port wake component.
 static BOOL WINAPI
 iree_async_proactor_iocp_console_ctrl_handler(DWORD ctrl_type) {
   switch (ctrl_type) {
@@ -114,16 +120,38 @@ iree_async_proactor_iocp_console_ctrl_handler(DWORD ctrl_type) {
     case CTRL_BREAK_EVENT:
     case CTRL_CLOSE_EVENT:
     case CTRL_LOGOFF_EVENT:
-    case CTRL_SHUTDOWN_EVENT:
+    case CTRL_SHUTDOWN_EVENT: {
+      // Increment before loading the proactor so deinitialization can prove
+      // that no handler retaining the old pointer remains. Sequentially
+      // consistent ordering closes the late-handler race around the rundown
+      // count and singleton exchange.
+      iree_atomic_fetch_add(&g_iocp_active_signal_handler_count, 1,
+                            iree_memory_order_seq_cst);
+      iree_async_proactor_iocp_t* proactor =
+          (iree_async_proactor_iocp_t*)iree_atomic_load(
+              &g_iocp_signal_proactor, iree_memory_order_seq_cst);
+      if (!proactor) {
+        iree_atomic_fetch_sub(&g_iocp_active_signal_handler_count, 1,
+                              iree_memory_order_seq_cst);
+        return TRUE;
+      }
+
       iree_atomic_fetch_or(&g_iocp_pending_ctrl_events,
                            (int32_t)(1u << ctrl_type),
                            iree_memory_order_release);
-      // Wake the poll thread. The completion port handle is guaranteed non-NULL
-      // while the handler is registered (set before SetConsoleCtrlHandler,
-      // cleared after RemoveConsoleCtrlHandler).
-      PostQueuedCompletionStatus(g_iocp_signal_completion_port, 0,
-                                 IREE_ASYNC_IOCP_SIGNAL_COMPLETION_KEY, NULL);
+      DWORD error_code = ERROR_SUCCESS;
+      if (!iree_async_iocp_completion_port_try_post(
+              &proactor->completion_port, 0,
+              IREE_ASYNC_IOCP_SIGNAL_COMPLETION_KEY, NULL, &error_code)) {
+        // The pending bitmask is the durable signal state. An APC makes the
+        // alertable poll observe it without requiring another IOCP packet.
+        iree_async_iocp_completion_port_request_fallback_wake(
+            &proactor->completion_port);
+      }
+      iree_atomic_fetch_sub(&g_iocp_active_signal_handler_count, 1,
+                            iree_memory_order_seq_cst);
       return TRUE;
+    }
     default:
       return FALSE;
   }
@@ -136,9 +164,7 @@ iree_async_proactor_iocp_console_ctrl_handler(DWORD ctrl_type) {
 void iree_async_proactor_iocp_wake(iree_async_proactor_t* base_proactor) {
   iree_async_proactor_iocp_t* proactor =
       iree_async_proactor_iocp_cast(base_proactor);
-  // Post a sentinel completion with NULL overlapped to wake the poll thread.
-  // CompletionKey = 0 and lpOverlapped = NULL distinguish this from real I/O.
-  PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0, 0, NULL);
+  iree_async_iocp_completion_port_wake(&proactor->completion_port);
 }
 
 //===----------------------------------------------------------------------===//
@@ -339,7 +365,8 @@ iree_status_t iree_async_proactor_create_iocp(
                             "CreateIoCompletionPort failed (error %lu)",
                             (unsigned long)error);
   }
-  proactor->completion_port = (uintptr_t)completion_port;
+  iree_async_iocp_completion_port_initialize(completion_port,
+                                             &proactor->completion_port);
 
   // Probe for NT wait completion packet APIs (Windows 8.1+). ntdll.dll is
   // always loaded in every Windows process; GetModuleHandleW does not increment
@@ -448,13 +475,14 @@ static iree_status_t iree_async_proactor_iocp_signal_initialize(
         "signal handling requires a console application on Windows");
   }
 
-  // Store completion port for the global console ctrl handler.
-  g_iocp_signal_completion_port = (HANDLE)proactor->completion_port;
+  // Store the proactor before registering the global console ctrl handler.
+  iree_atomic_store(&g_iocp_signal_proactor, (intptr_t)proactor,
+                    iree_memory_order_seq_cst);
 
   if (!SetConsoleCtrlHandler(iree_async_proactor_iocp_console_ctrl_handler,
                              TRUE)) {
     DWORD error = GetLastError();
-    g_iocp_signal_completion_port = NULL;
+    iree_atomic_store(&g_iocp_signal_proactor, 0, iree_memory_order_seq_cst);
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(IREE_STATUS_INTERNAL,
                             "SetConsoleCtrlHandler failed (error %lu)",
@@ -473,11 +501,18 @@ static void iree_async_proactor_iocp_signal_deinitialize(
     iree_async_proactor_iocp_t* proactor) {
   iree_allocator_t allocator = proactor->base.allocator;
 
-  // Remove console ctrl handler before clearing the completion port pointer.
-  // SetConsoleCtrlHandler(handler, FALSE) synchronously removes the handler,
-  // so after this returns no new completions will be posted.
-  SetConsoleCtrlHandler(iree_async_proactor_iocp_console_ctrl_handler, FALSE);
-  g_iocp_signal_completion_port = NULL;
+  // Remove the handler and clear the singleton to prevent any late handler
+  // from acquiring the proactor. Windows may already have launched a handler
+  // thread, so wait for every thread that observed the old pointer to finish.
+  if (!SetConsoleCtrlHandler(iree_async_proactor_iocp_console_ctrl_handler,
+                             FALSE)) {
+    iree_abort();
+  }
+  iree_atomic_store(&g_iocp_signal_proactor, 0, iree_memory_order_seq_cst);
+  while (iree_atomic_load(&g_iocp_active_signal_handler_count,
+                          iree_memory_order_seq_cst) != 0) {
+    YieldProcessor();
+  }
 
   // Drain any pending events that arrived before the handler was removed.
   iree_atomic_exchange(&g_iocp_pending_ctrl_events, 0,
@@ -617,13 +652,16 @@ static void iree_async_proactor_iocp_destroy(
         // WaitCompletionPacket path: cancel and close. Always non-blocking.
         proactor->nt_wait_api.NtCancelWaitCompletionPacket(
             carrier->data.event_wait.wait_handle, TRUE);
-        CloseHandle(carrier->data.event_wait.wait_handle);
+        if (!CloseHandle(carrier->data.event_wait.wait_handle)) iree_abort();
       } else {
         // RegisterWaitForSingleObject path: INVALID_HANDLE_VALUE blocks until
         // the threadpool callback has completed, ensuring no dangling refs.
-        UnregisterWaitEx(carrier->data.event_wait.wait_handle,
-                         INVALID_HANDLE_VALUE);
+        if (!UnregisterWaitEx(carrier->data.event_wait.wait_handle,
+                              INVALID_HANDLE_VALUE)) {
+          iree_abort();
+        }
       }
+      carrier->data.event_wait.wait_handle = NULL;
     }
     iree_async_proactor_iocp_release_carrier(proactor, carrier);
   }
@@ -662,11 +700,7 @@ static void iree_async_proactor_iocp_destroy(
     iree_async_proactor_iocp_relay_release_resources(relay);
   }
 
-  // Close the completion port.
-  if (proactor->completion_port != 0) {
-    CloseHandle((HANDLE)proactor->completion_port);
-    proactor->completion_port = 0;
-  }
+  iree_async_iocp_completion_port_deinitialize(&proactor->completion_port);
 
   // Clean up Winsock (ref-counted, matches WSAStartup in create).
   WSACleanup();
@@ -703,15 +737,32 @@ iree_async_proactor_iocp_query_capabilities(
 
 // Callback invoked by the OS thread pool when a RegisterWaitForSingleObject
 // wait is satisfied. Posts a completion to the IOCP port for the poll thread
-// to dispatch. This is the ONLY work done on the thread pool thread — no
-// proactor state mutation.
+// to dispatch. If posting fails, publishes that completion fact atomically and
+// interrupts the poll owner's alertable wait.
 static VOID CALLBACK
 iree_async_proactor_iocp_event_wait_callback(PVOID context, BOOLEAN timed_out) {
   iree_async_iocp_carrier_t* carrier = (iree_async_iocp_carrier_t*)context;
   // timed_out is always FALSE because we register with INFINITE timeout.
   (void)timed_out;
-  PostQueuedCompletionStatus((HANDLE)carrier->completion_port, 0, 0,
-                             &carrier->overlapped);
+  // Publish callback ownership before posting. A successful post is the final
+  // carrier access; synchronized unregistration then distinguishes that
+  // stable ACTIVE state from a callback that never ran.
+  iree_atomic_store(&carrier->fallback_completion_state,
+                    IREE_ASYNC_IOCP_FALLBACK_COMPLETION_CALLBACK_ACTIVE,
+                    iree_memory_order_release);
+  DWORD error_code = ERROR_SUCCESS;
+  if (!iree_async_iocp_completion_port_try_post(
+          &carrier->proactor->completion_port, 0, 0, &carrier->overlapped,
+          &error_code)) {
+    // Publish the durable completion fact before interrupting the poll owner.
+    // READY authorizes fallback dispatch, which synchronizes wait
+    // unregistration before recycling anything the callback can still access.
+    iree_atomic_store(&carrier->fallback_completion_state,
+                      IREE_ASYNC_IOCP_FALLBACK_COMPLETION_READY,
+                      iree_memory_order_release);
+    iree_async_iocp_completion_port_request_fallback_wake(
+        &carrier->proactor->completion_port);
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -739,7 +790,7 @@ static void iree_async_proactor_iocp_submit_handle_wait(
   }
   memset(carrier, 0, sizeof(*carrier));
   carrier->type = IREE_ASYNC_IOCP_CARRIER_EVENT_WAIT;
-  carrier->completion_port = proactor->completion_port;
+  carrier->proactor = proactor;
   carrier->operation = operation;
   iree_atomic_fetch_add(&proactor->outstanding_carrier_count, 1,
                         iree_memory_order_relaxed);
@@ -768,8 +819,8 @@ static void iree_async_proactor_iocp_submit_handle_wait(
     // function pointer declaration in proactor.h.
     LONG already_signaled = FALSE;
     nt_status = proactor->nt_wait_api.NtAssociateWaitCompletionPacket(
-        wcp_handle, (HANDLE)proactor->completion_port, wait_target, (PVOID)0,
-        &carrier->overlapped, 0, 0, &already_signaled);
+        wcp_handle, (HANDLE)proactor->completion_port.handle, wait_target,
+        (PVOID)0, &carrier->overlapped, 0, 0, &already_signaled);
     if (!NT_SUCCESS(nt_status)) {
       CloseHandle(wcp_handle);
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
@@ -789,9 +840,10 @@ static void iree_async_proactor_iocp_submit_handle_wait(
     // completion, causing use-after-free when Phase 6 processes the same
     // carrier twice.
   } else {
-    // RegisterWaitForSingleObject path: the OS threadpool monitors the
-    // handle and fires a callback that posts to our IOCP port.
-    // WT_EXECUTEONLYONCE auto-unregisters after the callback fires once.
+    // RegisterWaitForSingleObject path: the OS threadpool monitors the handle
+    // and fires a callback that posts to our IOCP port. WT_EXECUTEONLYONCE
+    // limits callback count; the carrier still owns and must unregister the
+    // wait before it can be recycled.
     BOOL registered = RegisterWaitForSingleObject(
         &carrier->data.event_wait.wait_handle, wait_target,
         iree_async_proactor_iocp_event_wait_callback, carrier, INFINITE,
@@ -993,11 +1045,11 @@ static iree_host_size_t iree_async_proactor_iocp_drain_timer_cancellations(
 //   WaitCompletionPacket path: NtCancelWaitCompletionPacket + CloseHandle.
 //     NT_SUCCESS means the WCP was pending or its queued completion was removed
 //     from the IOCP. Failure means the completion was already dequeued.
-//   RegisterWaitForSingleObject path: UnregisterWaitEx(wait_handle, NULL).
-//     TRUE means successfully unregistered. FALSE with ERROR_IO_PENDING means
-//     the callback is executing or already posted to IOCP.
-// In both failure cases, the carrier dispatch (Phase 6) will check the
-// CANCELLED flag and handle it.
+//   RegisterWaitForSingleObject path: blocking UnregisterWaitEx ensures no
+//     callback can still access the carrier. Its published state then tells us
+//     whether a completion was delivered.
+// When either path observes an already-delivered completion, carrier dispatch
+// checks the CANCELLED flag and reports cancellation.
 static iree_host_size_t iree_async_proactor_iocp_drain_event_wait_cancellations(
     iree_async_proactor_iocp_t* proactor) {
   int32_t cancellation_count =
@@ -1029,12 +1081,22 @@ static iree_host_size_t iree_async_proactor_iocp_drain_event_wait_cancellations(
       NTSTATUS cancel_status =
           proactor->nt_wait_api.NtCancelWaitCompletionPacket(
               carrier->data.event_wait.wait_handle, TRUE);
-      CloseHandle(carrier->data.event_wait.wait_handle);
+      if (!CloseHandle(carrier->data.event_wait.wait_handle)) iree_abort();
+      carrier->data.event_wait.wait_handle = NULL;
       cancel_succeeded = NT_SUCCESS(cancel_status);
     } else {
-      // NULL = non-blocking: don't wait for an in-progress callback.
+      // The callback posts or publishes fallback state without depending on
+      // poll progress, so blocking here cannot form a callback/poll deadlock.
+      // Recycling before this synchronization would race a queued callback.
+      if (!UnregisterWaitEx(carrier->data.event_wait.wait_handle,
+                            INVALID_HANDLE_VALUE)) {
+        iree_abort();
+      }
+      carrier->data.event_wait.wait_handle = NULL;
+      int32_t callback_state = iree_atomic_load(
+          &carrier->fallback_completion_state, iree_memory_order_acquire);
       cancel_succeeded =
-          UnregisterWaitEx(carrier->data.event_wait.wait_handle, NULL) == TRUE;
+          callback_state == IREE_ASYNC_IOCP_FALLBACK_COMPLETION_NONE;
     }
 
     if (cancel_succeeded) {
@@ -1360,14 +1422,16 @@ static DWORD iree_async_proactor_iocp_calculate_timeout_ms(
 // completed_count accumulator. The carrier is released (returned to the
 // freelist) and the completion dispatched before returning.
 
-// Completes an event wait or handle poll carrier. Unlinks the carrier from the
-// active list, closes the WaitCompletionPacket handle (NtWait path only), and
-// dispatches the completion. For HANDLE_POLL operations, populates
-// result_events with POLLIN since RegisterWaitForSingleObject /
-// NtAssociateWaitCompletionPacket only fires on signal.
+// Completes an event wait or handle poll carrier. Unlinks the carrier, releases
+// its wait registration, and dispatches the completion. For HANDLE_POLL
+// operations, populates result_events with POLLIN since
+// RegisterWaitForSingleObject / NtAssociateWaitCompletionPacket only fires on
+// signal.
 static void iree_async_proactor_iocp_complete_event_wait(
     iree_async_proactor_iocp_t* proactor, iree_async_iocp_carrier_t* carrier,
     iree_async_operation_t* operation, iree_host_size_t* completed_count) {
+  iree_status_t cleanup_status = iree_ok_status();
+
   // Unlink carrier from active list (O(1) via prev/next).
   if (carrier->prev) {
     carrier->prev->next = carrier->next;
@@ -1377,12 +1441,26 @@ static void iree_async_proactor_iocp_complete_event_wait(
   if (carrier->next) {
     carrier->next->prev = carrier->prev;
   }
-  // WaitCompletionPacket path: close the WCP handle now that the one-shot
-  // association has fired. RegisterWaitForSingleObject path:
-  // WT_EXECUTEONLYONCE auto-unregistered when the callback fired; the
-  // wait_handle is no longer valid and must not be closed.
-  if (proactor->nt_wait_api.available) {
-    CloseHandle(carrier->data.event_wait.wait_handle);
+  // Release the registration before recycling the carrier. The legacy path
+  // synchronizes with the callback even for WT_EXECUTEONLYONCE waits.
+  if (carrier->data.event_wait.wait_handle != NULL) {
+    if (proactor->nt_wait_api.available) {
+      if (!CloseHandle(carrier->data.event_wait.wait_handle)) {
+        DWORD error_code = GetLastError();
+        cleanup_status = iree_make_status(
+            iree_status_code_from_win32_error(error_code),
+            "CloseHandle failed for wait completion packet (error %lu)",
+            (unsigned long)error_code);
+      }
+    } else if (!UnregisterWaitEx(carrier->data.event_wait.wait_handle,
+                                 INVALID_HANDLE_VALUE)) {
+      DWORD error_code = GetLastError();
+      cleanup_status = iree_make_status(
+          iree_status_code_from_win32_error(error_code),
+          "UnregisterWaitEx failed for completed event wait (error %lu)",
+          (unsigned long)error_code);
+    }
+    carrier->data.event_wait.wait_handle = NULL;
   }
   operation->next = NULL;
   iree_async_proactor_iocp_release_carrier(proactor, carrier);
@@ -1390,10 +1468,11 @@ static void iree_async_proactor_iocp_complete_event_wait(
   // Check CANCELLED flag — cancel() may have been called between the
   // completion being posted to IOCP and this dispatch. The cancellation drain
   // decremented the counter for this case, so we don't touch it here.
-  iree_status_t status = iree_ok_status();
+  iree_status_t status = cleanup_status;
   if (iree_any_bit_set(iree_async_operation_load_internal_flags(operation),
                        IREE_ASYNC_IOCP_INTERNAL_FLAG_CANCELLED)) {
-    status = iree_status_from_code(IREE_STATUS_CANCELLED);
+    status =
+        iree_status_join(iree_status_from_code(IREE_STATUS_CANCELLED), status);
   }
   // Populate result_events for HANDLE_POLL operations.
   // RegisterWaitForSingleObject / NtAssociateWaitCompletionPacket fires when
@@ -1407,6 +1486,32 @@ static void iree_async_proactor_iocp_complete_event_wait(
   iree_async_proactor_iocp_dispatch_completion(proactor, operation, status,
                                                IREE_ASYNC_COMPLETION_FLAG_NONE,
                                                completed_count);
+}
+
+// Dispatches legacy event-wait callbacks whose completion packet could not be
+// posted. The Windows callback publishes the flag before requesting its APC,
+// so this poll-thread scan observes the same completion exactly once without
+// requiring a second carrier queue.
+static iree_host_size_t
+iree_async_proactor_iocp_drain_event_wait_fallback_completions(
+    iree_async_proactor_iocp_t* proactor) {
+  iree_host_size_t completed_count = 0;
+  iree_async_iocp_carrier_t* carrier = proactor->active_carriers;
+  while (carrier) {
+    iree_async_iocp_carrier_t* next = carrier->next;
+    int32_t fallback_state = iree_atomic_load(
+        &carrier->fallback_completion_state, iree_memory_order_acquire);
+    if (carrier->type == IREE_ASYNC_IOCP_CARRIER_EVENT_WAIT &&
+        fallback_state == IREE_ASYNC_IOCP_FALLBACK_COMPLETION_READY) {
+      iree_atomic_store(&carrier->fallback_completion_state,
+                        IREE_ASYNC_IOCP_FALLBACK_COMPLETION_NONE,
+                        iree_memory_order_relaxed);
+      iree_async_proactor_iocp_complete_event_wait(
+          proactor, carrier, carrier->operation, &completed_count);
+    }
+    carrier = next;
+  }
+  return completed_count;
 }
 
 // Retrieves the overlapped I/O result for a socket carrier and checks for
@@ -1438,8 +1543,8 @@ static iree_status_t iree_async_proactor_iocp_get_socket_io_result(
   // Check for cancellation (may race with natural completion).
   if (iree_any_bit_set(iree_async_operation_load_internal_flags(operation),
                        IREE_ASYNC_IOCP_INTERNAL_FLAG_CANCELLED)) {
-    iree_status_ignore(io_status);
-    io_status = iree_status_from_code(IREE_STATUS_CANCELLED);
+    io_status = iree_status_join(iree_status_from_code(IREE_STATUS_CANCELLED),
+                                 io_status);
   }
 
   return io_status;
@@ -1657,7 +1762,8 @@ static void iree_async_proactor_iocp_complete_accept(
           wsa_error);
     } else {
       HANDLE assoc_result = CreateIoCompletionPort(
-          (HANDLE)new_accept_sock, (HANDLE)proactor->completion_port, 0, 0);
+          (HANDLE)new_accept_sock, (HANDLE)proactor->completion_port.handle, 0,
+          0);
       if (assoc_result == NULL) {
         DWORD error = GetLastError();
         closesocket(new_accept_sock);
@@ -1824,8 +1930,8 @@ static void iree_async_proactor_iocp_complete_file_io(
 
   if (iree_any_bit_set(iree_async_operation_load_internal_flags(operation),
                        IREE_ASYNC_IOCP_INTERNAL_FLAG_CANCELLED)) {
-    iree_status_ignore(io_status);
-    io_status = iree_status_from_code(IREE_STATUS_CANCELLED);
+    io_status = iree_status_join(iree_status_from_code(IREE_STATUS_CANCELLED),
+                                 io_status);
   }
 
   // Write results to the operation.
@@ -1860,6 +1966,11 @@ static iree_status_t iree_async_proactor_iocp_poll(
   iree_async_proactor_iocp_t* proactor =
       iree_async_proactor_iocp_cast(base_proactor);
   iree_host_size_t completed_count = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_async_iocp_completion_port_bind_poll_thread(
+              &proactor->completion_port));
+  bool observed_wake = iree_async_iocp_completion_port_consume_fallback_wake(
+      &proactor->completion_port);
 
   // Phase 1: Drain pending queue (register new operations).
   completed_count += iree_async_proactor_iocp_drain_pending_queue(proactor);
@@ -1903,24 +2014,38 @@ static iree_status_t iree_async_proactor_iocp_poll(
   iree_status_t gqcs_status = iree_ok_status();
   bool retry_wait = false;
   do {
+    // Recheck immediately before the alertable wait. A user callback executed
+    // during an earlier phase may itself have entered an alertable wait and
+    // consumed the APC, but the durable fallback flag must still prevent this
+    // poll from blocking after the represented work was published.
+    observed_wake |= iree_async_iocp_completion_port_consume_fallback_wake(
+        &proactor->completion_port);
+
     // Phase 3: Calculate the effective timeout considering timer deadlines.
     DWORD timeout_ms =
         iree_async_proactor_iocp_calculate_timeout_ms(proactor, timeout);
     const bool force_nonblocking =
-        completed_count > 0 || base_proactor->progress_list;
+        completed_count > 0 || base_proactor->progress_list || observed_wake;
     if (force_nonblocking) timeout_ms = 0;
 
     // Phase 4: Dequeue completions from the IOCP port.
     entry_count = 0;
-    BOOL success =
-        GetQueuedCompletionStatusEx((HANDLE)proactor->completion_port, entries,
-                                    IREE_ASYNC_IOCP_MAX_COMPLETIONS_PER_POLL,
-                                    &entry_count, timeout_ms, FALSE);
+    BOOL success = GetQueuedCompletionStatusEx(
+        (HANDLE)proactor->completion_port.handle, entries,
+        IREE_ASYNC_IOCP_MAX_COMPLETIONS_PER_POLL, &entry_count, timeout_ms,
+        TRUE);
     bool wait_timed_out = false;
     if (!success) {
       DWORD error = GetLastError();
       wait_timed_out = error == WAIT_TIMEOUT;
-      if (!wait_timed_out) {
+      if (error == WAIT_IO_COMPLETION) {
+        // APC delivery is the non-destructive fallback when a synthetic
+        // completion cannot be posted. APCs from other subsystems are also
+        // real poll-owner work and therefore count as explicit wakes.
+        observed_wake = true;
+        iree_async_iocp_completion_port_consume_fallback_wake(
+            &proactor->completion_port);
+      } else if (!wait_timed_out) {
         // Stash the error but continue through remaining phases so that timer
         // expirations, notification waits, and re-drains still run. The error
         // is returned after all phases complete.
@@ -1937,10 +2062,17 @@ static iree_status_t iree_async_proactor_iocp_poll(
         iree_async_proactor_iocp_process_expired_timers(proactor);
 
     retry_wait = wait_timed_out && entry_count == 0 && completed_count == 0 &&
-                 !force_nonblocking &&
+                 !force_nonblocking && !observed_wake &&
                  (iree_timeout_is_infinite(timeout) ||
                   iree_time_now() < iree_timeout_as_deadline_ns(timeout));
   } while (retry_wait);
+
+  // A failed signal post leaves its bit in the durable process-global mask.
+  // Dispatching unconditionally also coalesces normal signal packets.
+  iree_async_proactor_iocp_dispatch_pending_signals(proactor);
+
+  completed_count +=
+      iree_async_proactor_iocp_drain_event_wait_fallback_completions(proactor);
 
   // Phase 6: Process GQCS completions.
   for (ULONG i = 0; i < entry_count; ++i) {
@@ -1974,7 +2106,7 @@ static iree_status_t iree_async_proactor_iocp_poll(
       // completion. No manual post needed — the kernel handles it.
       LONG already_signaled = FALSE;
       proactor->nt_wait_api.NtAssociateWaitCompletionPacket(
-          wcp_handle, (HANDLE)proactor->completion_port, wake_event,
+          wcp_handle, (HANDLE)proactor->completion_port.handle, wake_event,
           (PVOID)IREE_ASYNC_IOCP_SHARED_NOTIFICATION_COMPLETION_KEY,
           (PVOID)notification, 0, 0, &already_signaled);
       // AlreadySignaled convergence: if TRUE, the kernel queued a completion
@@ -2103,7 +2235,7 @@ static iree_status_t iree_async_proactor_iocp_poll(
   if (out_completed_count) *out_completed_count = completed_count;
   IREE_TRACE_ZONE_END(z0);
   if (!iree_status_is_ok(gqcs_status)) return gqcs_status;
-  return completed_count > 0 || entry_count > 0
+  return completed_count > 0 || entry_count > 0 || observed_wake
              ? iree_ok_status()
              : iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
 }
@@ -2287,7 +2419,8 @@ static iree_status_t iree_async_proactor_iocp_import_file(
   // Associate the file handle with the IOCP port. This is required for
   // overlapped ReadFile/WriteFile completions to flow to this port.
   HANDLE result = CreateIoCompletionPort(
-      (HANDLE)handle, (HANDLE)proactor->completion_port, /*CompletionKey=*/0,
+      (HANDLE)handle, (HANDLE)proactor->completion_port.handle,
+      /*CompletionKey=*/0,
       /*NumberOfConcurrentThreads=*/0);
   if (result == NULL) {
     DWORD error = GetLastError();
@@ -2474,7 +2607,7 @@ static VOID CALLBACK iree_async_proactor_iocp_shared_notification_callback(
   iree_async_notification_t* notification = (iree_async_notification_t*)context;
   iree_async_proactor_iocp_t* proactor =
       iree_async_proactor_iocp_cast(notification->proactor);
-  PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0, 0, NULL);
+  iree_async_iocp_completion_port_wake(&proactor->completion_port);
 }
 
 static void iree_async_proactor_iocp_destroy_notification(
@@ -2548,7 +2681,7 @@ static iree_status_t iree_async_proactor_iocp_create_notification_shared(
             options->wake_primitive.value.win32_handle;
         LONG already_signaled = FALSE;
         nt_status = proactor->nt_wait_api.NtAssociateWaitCompletionPacket(
-            wcp_handle, (HANDLE)proactor->completion_port, wake_event,
+            wcp_handle, (HANDLE)proactor->completion_port.handle, wake_event,
             (PVOID)IREE_ASYNC_IOCP_SHARED_NOTIFICATION_COMPLETION_KEY,
             (PVOID)notification, 0, 0, &already_signaled);
         if (!NT_SUCCESS(nt_status)) {
@@ -2617,8 +2750,11 @@ static void iree_async_proactor_iocp_destroy_notification(
       } else {
         // RegisterWaitForSingleObject path: INVALID_HANDLE_VALUE blocks until
         // any in-flight threadpool callbacks complete.
-        UnregisterWaitEx((HANDLE)notification->platform.iocp.wait_registration,
-                         INVALID_HANDLE_VALUE);
+        if (!UnregisterWaitEx(
+                (HANDLE)notification->platform.iocp.wait_registration,
+                INVALID_HANDLE_VALUE)) {
+          iree_abort();
+        }
       }
     }
     // Do not close the wake/signal Events — caller owns them.

--- a/runtime/src/iree/async/platform/iocp/proactor.h
+++ b/runtime/src/iree/async/platform/iocp/proactor.h
@@ -13,6 +13,7 @@
 #define IREE_ASYNC_PLATFORM_IOCP_PROACTOR_H_
 
 #include "iree/async/platform/iocp/api.h"
+#include "iree/async/platform/iocp/completion_port.h"
 #include "iree/async/platform/iocp/timer_list.h"
 #include "iree/async/proactor.h"
 #include "iree/async/semaphore.h"
@@ -44,6 +45,7 @@ extern "C" {
 
 typedef struct iree_async_semaphore_wait_operation_t
     iree_async_semaphore_wait_operation_t;
+typedef struct iree_async_proactor_iocp_t iree_async_proactor_iocp_t;
 
 //===----------------------------------------------------------------------===//
 // Internal flags for IOCP proactor operations
@@ -90,6 +92,20 @@ enum iree_async_iocp_carrier_type_e {
 };
 typedef uint8_t iree_async_iocp_carrier_type_t;
 
+// Legacy event-wait callback handoff after a completion post fails.
+enum iree_async_iocp_fallback_completion_state_e {
+  // The Windows callback has not started.
+  IREE_ASYNC_IOCP_FALLBACK_COMPLETION_NONE = 0,
+
+  // The callback started and may still be posting. After synchronized wait
+  // unregistration this state means the IOCP packet was posted successfully.
+  IREE_ASYNC_IOCP_FALLBACK_COMPLETION_CALLBACK_ACTIVE,
+
+  // Posting failed and the callback published fallback completion. The poll
+  // owner must synchronize wait unregistration before recycling the carrier.
+  IREE_ASYNC_IOCP_FALLBACK_COMPLETION_READY,
+};
+
 // Carrier wrapping an operation for delivery through the IOCP port.
 //
 // For event waits: the RegisterWaitForSingleObject callback fires on an OS
@@ -118,9 +134,13 @@ typedef struct iree_async_iocp_carrier_t {
   // Discriminator for the data union.
   iree_async_iocp_carrier_type_t type;
 
-  // Completion port handle for PostQueuedCompletionStatus in callbacks.
-  // Stored here because callbacks have no access to the proactor struct.
-  uintptr_t completion_port;
+  // Owning proactor used by Windows-managed callbacks to post or request the
+  // fallback poll wake. The proactor outlives every outstanding carrier.
+  iree_async_proactor_iocp_t* proactor;
+
+  // State published by a legacy event-wait callback when its completion
+  // packet could not be posted. The poll owner dispatches only READY state.
+  iree_atomic_int32_t fallback_completion_state;
 
   // The operation this carrier delivers. Set during submit/registration,
   // consumed during poll dispatch.
@@ -236,15 +256,13 @@ struct iree_async_event_source_t {
 //   - poll() calls GetQueuedCompletionStatusEx to dequeue completions
 //   - wake() uses PostQueuedCompletionStatus with a sentinel
 //   - MPSC pending_queue only for non-I/O operations (timers, events, etc.)
-typedef struct iree_async_proactor_iocp_t {
+struct iree_async_proactor_iocp_t {
   // Must be first for safe casting.
   iree_async_proactor_t base;
   iree_atomic_int32_t shutdown_requested;
 
-  // IOCP completion port handle. All overlapped I/O completions and
-  // cross-thread wakeups are delivered through this single handle.
-  // Stored as uintptr_t to avoid requiring windows.h in headers.
-  uintptr_t completion_port;
+  // IOCP handle, checked synthetic-post boundary, and fallback poll wake.
+  iree_async_iocp_completion_port_t completion_port;
 
   // MPSC queue for operations that cannot be submitted directly as overlapped
   // I/O (timers, event waits, notification waits, relay management). Submit()
@@ -374,7 +392,7 @@ typedef struct iree_async_proactor_iocp_t {
   // allocation, decremented at carrier release. Asserted zero at destroy to
   // catch callers that destroy the proactor with pending overlapped I/O.
   iree_atomic_int32_t outstanding_carrier_count;
-} iree_async_proactor_iocp_t;
+};
 
 static inline iree_async_proactor_iocp_t* iree_async_proactor_iocp_cast(
     iree_async_proactor_t* proactor) {

--- a/runtime/src/iree/async/platform/iocp/proactor_submit.c
+++ b/runtime/src/iree/async/platform/iocp/proactor_submit.c
@@ -79,7 +79,7 @@ static iree_status_t iree_async_proactor_iocp_allocate_carrier(
   }
   memset(carrier, 0, sizeof(*carrier));
   carrier->type = carrier_type;
-  carrier->completion_port = proactor->completion_port;
+  carrier->proactor = proactor;
   carrier->operation = operation;
   carrier->io_handle = io_handle;
   iree_atomic_fetch_add(&proactor->outstanding_carrier_count, 1,
@@ -112,29 +112,58 @@ static DWORD iree_async_proactor_iocp_build_wsabuf(
   return count;
 }
 
+// Posts a direct completion after ownership of the operation's resource
+// release has transferred to the completion path. If posting fails, performs
+// that release locally and returns the transport error to submit(). This also
+// covers consuming operations such as close: their caller reference is the
+// release owned by the completion rather than a matching submit-time retain.
+static iree_status_t iree_async_proactor_iocp_post_owned_completion(
+    iree_async_proactor_iocp_t* proactor, iree_async_operation_t* operation,
+    DWORD bytes_transferred) {
+  iree_status_t post_status = iree_async_iocp_completion_port_post(
+      &proactor->completion_port, bytes_transferred, (ULONG_PTR)operation,
+      NULL);
+  if (!iree_status_is_ok(post_status)) {
+    iree_async_operation_release_resources(operation);
+    if (bytes_transferred != 0) {
+      iree_status_t operation_status = iree_make_status(
+          iree_status_code_from_win32_error(bytes_transferred),
+          "operation completed with Win32 error %lu before its IOCP "
+          "completion could be posted",
+          (unsigned long)bytes_transferred);
+      return iree_status_join(post_status, operation_status);
+    }
+  }
+  return post_status;
+}
+
 // Posts a synthetic failure completion for an operation whose overlapped I/O
 // call failed synchronously (error != ERROR_IO_PENDING / WSA_IO_PENDING). The
-// proactor API contract requires submit() to succeed and deliver errors through
-// the completion callback on the poll thread. This posts the operation as a
-// "direct completion" with the Win32 error code encoded in
-// dwNumberOfBytesTransferred for the poll thread to convert to iree_status_t.
-static void iree_async_proactor_iocp_post_submit_failure(
+// Win32 error code is encoded in dwNumberOfBytesTransferred for conversion by
+// the poll thread.
+static iree_status_t iree_async_proactor_iocp_post_submit_failure(
     iree_async_proactor_iocp_t* proactor, iree_async_operation_t* operation,
     int error_code) {
-  PostQueuedCompletionStatus((HANDLE)proactor->completion_port,
-                             (DWORD)error_code, (ULONG_PTR)operation, NULL);
+  return iree_async_proactor_iocp_post_owned_completion(proactor, operation,
+                                                        (DWORD)error_code);
 }
 
 // Posts a direct completion with a pre-computed iree_status_t. The status is
 // stashed in operation->next (available as scratch for non-carrier operations)
 // and retrieved by the poll thread via the sentinel in bytes_transferred.
-static void iree_async_proactor_iocp_post_stashed_status(
+static iree_status_t iree_async_proactor_iocp_post_stashed_status(
     iree_async_proactor_iocp_t* proactor, iree_async_operation_t* operation,
     iree_status_t op_status) {
   operation->next = (iree_async_operation_t*)(uintptr_t)op_status;
-  PostQueuedCompletionStatus((HANDLE)proactor->completion_port,
-                             IREE_ASYNC_IOCP_STASHED_STATUS_SENTINEL,
-                             (ULONG_PTR)operation, NULL);
+  iree_status_t post_status = iree_async_iocp_completion_port_post(
+      &proactor->completion_port, IREE_ASYNC_IOCP_STASHED_STATUS_SENTINEL,
+      (ULONG_PTR)operation, NULL);
+  if (!iree_status_is_ok(post_status)) {
+    operation->next = NULL;
+    iree_async_operation_release_resources(operation);
+    return iree_status_join(post_status, op_status);
+  }
+  return iree_ok_status();
 }
 
 //===----------------------------------------------------------------------===//
@@ -217,7 +246,7 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_accept(
 
   // Associate accept socket with IOCP port.
   HANDLE result = CreateIoCompletionPort(
-      (HANDLE)accept_sock, (HANDLE)proactor->completion_port, 0, 0);
+      (HANDLE)accept_sock, (HANDLE)proactor->completion_port.handle, 0, 0);
   if (result == NULL) {
     DWORD error = GetLastError();
     closesocket(accept_sock);
@@ -263,9 +292,8 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_accept(
     if (wsa_error != WSA_IO_PENDING) {
       closesocket(accept_sock);
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
-      iree_async_proactor_iocp_post_submit_failure(proactor, &accept_op->base,
-                                                   wsa_error);
-      return iree_ok_status();
+      return iree_async_proactor_iocp_post_submit_failure(
+          proactor, &accept_op->base, wsa_error);
     }
     // WSA_IO_PENDING: I/O is pending, completion will arrive via GQCS.
   }
@@ -360,18 +388,16 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_connect(
     int result = connect(sock, target_addr, addr_length);
     if (result == SOCKET_ERROR) {
       int wsa_error = WSAGetLastError();
-      iree_async_proactor_iocp_post_submit_failure(proactor, &connect_op->base,
-                                                   wsa_error);
-      return iree_ok_status();
+      return iree_async_proactor_iocp_post_submit_failure(
+          proactor, &connect_op->base, wsa_error);
     }
 
     socket->state = IREE_ASYNC_SOCKET_STATE_CONNECTED;
 
     // Post a direct completion (NULL overlapped, operation as CompletionKey,
     // bytes=0 for success).
-    PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0,
-                               (ULONG_PTR)&connect_op->base, NULL);
-    return iree_ok_status();
+    return iree_async_proactor_iocp_post_owned_completion(proactor,
+                                                          &connect_op->base, 0);
   }
 
   // TCP: use ConnectEx for overlapped (asynchronous) connection.
@@ -402,9 +428,8 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_connect(
     int wsa_error = WSAGetLastError();
     if (wsa_error != WSA_IO_PENDING) {
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
-      iree_async_proactor_iocp_post_submit_failure(proactor, &connect_op->base,
-                                                   wsa_error);
-      return iree_ok_status();
+      return iree_async_proactor_iocp_post_submit_failure(
+          proactor, &connect_op->base, wsa_error);
     }
   }
 
@@ -442,9 +467,8 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_recv(
     int wsa_error = WSAGetLastError();
     if (wsa_error != WSA_IO_PENDING) {
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
-      iree_async_proactor_iocp_post_submit_failure(proactor, &recv_op->base,
-                                                   wsa_error);
-      return iree_ok_status();
+      return iree_async_proactor_iocp_post_submit_failure(
+          proactor, &recv_op->base, wsa_error);
     }
   }
 
@@ -482,9 +506,8 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_send(
     int wsa_error = WSAGetLastError();
     if (wsa_error != WSA_IO_PENDING) {
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
-      iree_async_proactor_iocp_post_submit_failure(proactor, &send_op->base,
-                                                   wsa_error);
-      return iree_ok_status();
+      return iree_async_proactor_iocp_post_submit_failure(
+          proactor, &send_op->base, wsa_error);
     }
   }
 
@@ -523,9 +546,8 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_sendto(
     int wsa_error = WSAGetLastError();
     if (wsa_error != WSA_IO_PENDING) {
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
-      iree_async_proactor_iocp_post_submit_failure(proactor, &sendto_op->base,
-                                                   wsa_error);
-      return iree_ok_status();
+      return iree_async_proactor_iocp_post_submit_failure(
+          proactor, &sendto_op->base, wsa_error);
     }
   }
 
@@ -570,9 +592,8 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_recvfrom(
     int wsa_error = WSAGetLastError();
     if (wsa_error != WSA_IO_PENDING) {
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
-      iree_async_proactor_iocp_post_submit_failure(proactor, &recvfrom_op->base,
-                                                   wsa_error);
-      return iree_ok_status();
+      return iree_async_proactor_iocp_post_submit_failure(
+          proactor, &recvfrom_op->base, wsa_error);
     }
   }
 
@@ -641,9 +662,8 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_recv_pool(
       // carrier-type-specific handling to do it.
       iree_async_buffer_lease_release(&recv_pool_op->lease);
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
-      iree_async_proactor_iocp_post_submit_failure(
+      return iree_async_proactor_iocp_post_submit_failure(
           proactor, &recv_pool_op->base, wsa_error);
-      return iree_ok_status();
     }
   }
 
@@ -657,20 +677,22 @@ static iree_status_t iree_async_proactor_iocp_submit_socket_close(
   iree_async_socket_t* socket = close_op->socket;
   SOCKET sock = (SOCKET)socket->primitive.value.win32_handle;
 
-  // Close is synchronous, no carrier needed. Close the underlying socket,
-  // then post an immediate completion.
+  // Close is synchronous, no carrier needed. Preserve the socket handle on
+  // failure so its eventual destroy can retry instead of leaking it.
+  int close_error = 0;
   if (sock != INVALID_SOCKET) {
-    closesocket(sock);
+    if (closesocket(sock) == SOCKET_ERROR) {
+      close_error = WSAGetLastError();
+    }
   }
-  // Invalidate the socket primitive so destroy doesn't double-close.
-  socket->primitive = iree_async_primitive_none();
-  socket->state = IREE_ASYNC_SOCKET_STATE_CLOSED;
+  if (close_error == 0) {
+    socket->primitive = iree_async_primitive_none();
+    socket->state = IREE_ASYNC_SOCKET_STATE_CLOSED;
+  }
 
-  // Post immediate completion. Resources are not retained (close consumes
-  // the caller's reference via release_operation_resources).
-  PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0,
-                             (ULONG_PTR)&close_op->base, NULL);
-  return iree_ok_status();
+  // Close consumes the caller's reference when the completion is accepted.
+  return iree_async_proactor_iocp_post_owned_completion(
+      proactor, &close_op->base, (DWORD)close_error);
 }
 
 //===----------------------------------------------------------------------===//
@@ -703,16 +725,14 @@ static iree_status_t iree_async_proactor_iocp_submit_semaphore_signal(
   iree_async_operation_retain_resources(&signal_op->base);
 
   if (iree_status_is_ok(op_status)) {
-    PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0,
-                               (ULONG_PTR)&signal_op->base, NULL);
-  } else {
-    // Stash the error status for the poll thread. Cannot use bytes_transferred
-    // encoding (WSA error code) because the status from semaphore_signal
-    // carries a rich message that would be lost in the conversion.
-    iree_async_proactor_iocp_post_stashed_status(proactor, &signal_op->base,
-                                                 op_status);
+    return iree_async_proactor_iocp_post_owned_completion(proactor,
+                                                          &signal_op->base, 0);
   }
-  return iree_ok_status();
+  // Stash the error status for the poll thread. Cannot use bytes_transferred
+  // encoding (WSA error code) because the status from semaphore_signal carries
+  // a rich message that would be lost in the conversion.
+  return iree_async_proactor_iocp_post_stashed_status(
+      proactor, &signal_op->base, op_status);
 }
 
 // Submits a SEMAPHORE_WAIT by checking for immediate satisfaction, then
@@ -747,9 +767,8 @@ static iree_status_t iree_async_proactor_iocp_submit_semaphore_wait(
     IREE_TRACE_ZONE_END(z0);
     // Retain, post direct completion for poll-thread dispatch.
     iree_async_operation_retain_resources(&wait_op->base);
-    PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0,
-                               (ULONG_PTR)&wait_op->base, NULL);
-    return iree_ok_status();
+    return iree_async_proactor_iocp_post_owned_completion(proactor,
+                                                          &wait_op->base, 0);
   }
 
   iree_async_semaphore_wait_enqueue_callback_t enqueue_callback = {
@@ -802,9 +821,8 @@ static iree_status_t iree_async_proactor_iocp_submit_notification_signal(
 
   // Retain and post direct completion for poll-thread dispatch.
   iree_async_operation_retain_resources(&signal_op->base);
-  PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0,
-                             (ULONG_PTR)&signal_op->base, NULL);
-  return iree_ok_status();
+  return iree_async_proactor_iocp_post_owned_completion(proactor,
+                                                        &signal_op->base, 0);
 }
 
 //===----------------------------------------------------------------------===//
@@ -846,13 +864,11 @@ static iree_status_t iree_async_proactor_iocp_submit_message(
   // dispatch (consistent with all other operation types).
   iree_async_operation_retain_resources(&message->base);
   if (iree_status_is_ok(send_status)) {
-    PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0,
-                               (ULONG_PTR)&message->base, NULL);
-  } else {
-    iree_async_proactor_iocp_post_stashed_status(proactor, &message->base,
-                                                 send_status);
+    return iree_async_proactor_iocp_post_owned_completion(proactor,
+                                                          &message->base, 0);
   }
-  return iree_ok_status();
+  return iree_async_proactor_iocp_post_stashed_status(proactor, &message->base,
+                                                      send_status);
 }
 
 //===----------------------------------------------------------------------===//
@@ -917,9 +933,8 @@ static iree_status_t iree_async_proactor_iocp_submit_file_open(
   if (file_handle == INVALID_HANDLE_VALUE) {
     IREE_TRACE_ZONE_END(z0);
     // Post failure as direct completion for poll-thread delivery.
-    iree_async_proactor_iocp_post_submit_failure(proactor, &open_op->base,
-                                                 (int)open_error);
-    return iree_ok_status();
+    return iree_async_proactor_iocp_post_submit_failure(
+        proactor, &open_op->base, (int)open_error);
   }
 
   // Import the file handle (associates with IOCP port).
@@ -933,11 +948,17 @@ static iree_status_t iree_async_proactor_iocp_submit_file_open(
     return status;
   }
 
-  // Post immediate completion (open is synchronous).
-  PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0,
-                             (ULONG_PTR)&open_op->base, NULL);
+  // Post immediate completion (open is synchronous). If the packet cannot be
+  // accepted, the result reference never transfers to a callback and must be
+  // released here.
+  status = iree_async_iocp_completion_port_post(
+      &proactor->completion_port, 0, (ULONG_PTR)&open_op->base, NULL);
+  if (!iree_status_is_ok(status)) {
+    iree_async_file_release(open_op->opened_file);
+    open_op->opened_file = NULL;
+  }
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 static iree_status_t iree_async_proactor_iocp_submit_file_read(
@@ -970,9 +991,8 @@ static iree_status_t iree_async_proactor_iocp_submit_file_read(
     DWORD error = GetLastError();
     if (error != ERROR_IO_PENDING) {
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
-      iree_async_proactor_iocp_post_submit_failure(proactor, &read_op->base,
-                                                   (int)error);
-      return iree_ok_status();
+      return iree_async_proactor_iocp_post_submit_failure(
+          proactor, &read_op->base, (int)error);
     }
   }
 
@@ -1013,9 +1033,8 @@ static iree_status_t iree_async_proactor_iocp_submit_file_write(
     DWORD error = GetLastError();
     if (error != ERROR_IO_PENDING) {
       iree_async_proactor_iocp_release_carrier(proactor, carrier);
-      iree_async_proactor_iocp_post_submit_failure(proactor, &write_op->base,
-                                                   (int)error);
-      return iree_ok_status();
+      return iree_async_proactor_iocp_post_submit_failure(
+          proactor, &write_op->base, (int)error);
     }
   }
 
@@ -1029,26 +1048,21 @@ static iree_status_t iree_async_proactor_iocp_submit_file_close(
   iree_async_file_t* file = close_op->file;
   HANDLE file_handle = (HANDLE)file->primitive.value.win32_handle;
 
-  // Close is synchronous, no carrier needed.
-  BOOL close_ok = TRUE;
+  // Close is synchronous, no carrier needed. Preserve a handle that failed to
+  // close so the resource destructor can retry instead of losing ownership.
+  DWORD close_error = ERROR_SUCCESS;
   if (file_handle != NULL && file_handle != INVALID_HANDLE_VALUE) {
-    close_ok = CloseHandle(file_handle);
+    if (!CloseHandle(file_handle)) {
+      close_error = GetLastError();
+    }
   }
-  // Invalidate the handle to prevent double-close in destroy.
-  file->primitive.value.win32_handle = 0;
-
-  // Post completion. The caller's file reference is consumed by
-  // release_operation_resources during completion dispatch (no prior retain).
-  if (!close_ok) {
-    DWORD error = GetLastError();
-    iree_async_proactor_iocp_post_submit_failure(proactor, &close_op->base,
-                                                 (int)error);
-    return iree_ok_status();
+  if (close_error == ERROR_SUCCESS) {
+    file->primitive.value.win32_handle = 0;
   }
 
-  PostQueuedCompletionStatus((HANDLE)proactor->completion_port, 0,
-                             (ULONG_PTR)&close_op->base, NULL);
-  return iree_ok_status();
+  // The completion owns consumption of the caller's file reference.
+  return iree_async_proactor_iocp_post_owned_completion(
+      proactor, &close_op->base, close_error);
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/async/platform/iocp/proactor_test.cc
+++ b/runtime/src/iree/async/platform/iocp/proactor_test.cc
@@ -1,0 +1,362 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/async/platform/iocp/proactor.h"
+
+#include <atomic>
+#include <cstring>
+#include <thread>
+
+#include "iree/async/event.h"
+#include "iree/async/notification.h"
+#include "iree/async/operations/semaphore.h"
+#include "iree/async/semaphore.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+struct CompletionState {
+  int call_count = 0;
+  iree_status_code_t status_code = IREE_STATUS_UNKNOWN;
+};
+
+static void RecordCompletion(void* user_data, iree_async_operation_t* operation,
+                             iree_status_t status,
+                             iree_async_completion_flags_t flags) {
+  (void)operation;
+  (void)flags;
+  auto* state = static_cast<CompletionState*>(user_data);
+  ++state->call_count;
+  state->status_code = iree_status_code(status);
+  iree_status_free(status);
+}
+
+// Replaces the component's owned handle with NULL while preserving the same
+// completion-port object through a duplicate. Synthetic posts then fail
+// through the real PostQueuedCompletionStatus call. Restoring the duplicate
+// returns ownership of a valid handle to the component.
+static iree_status_t DisableCompletionPosting(
+    iree_async_proactor_iocp_t* proactor, HANDLE* out_preserved_port) {
+  *out_preserved_port = NULL;
+  HANDLE completion_port = (HANDLE)proactor->completion_port.handle;
+  HANDLE preserved_port = NULL;
+  if (!DuplicateHandle(GetCurrentProcess(), completion_port,
+                       GetCurrentProcess(), &preserved_port, 0, FALSE,
+                       DUPLICATE_SAME_ACCESS)) {
+    DWORD error_code = GetLastError();
+    return iree_make_status(iree_status_code_from_win32_error(error_code),
+                            "DuplicateHandle failed (error %lu)",
+                            (unsigned long)error_code);
+  }
+  if (!CloseHandle(completion_port)) {
+    DWORD error_code = GetLastError();
+    iree_status_t status = iree_make_status(
+        iree_status_code_from_win32_error(error_code),
+        "CloseHandle failed while disabling completion posts (error %lu)",
+        (unsigned long)error_code);
+    if (!CloseHandle(preserved_port)) {
+      DWORD close_error_code = GetLastError();
+      status = iree_status_join(
+          status,
+          iree_make_status(iree_status_code_from_win32_error(close_error_code),
+                           "CloseHandle failed while unwinding duplicate "
+                           "completion port (error %lu)",
+                           (unsigned long)close_error_code));
+    }
+    return status;
+  }
+  proactor->completion_port.handle = 0;
+  *out_preserved_port = preserved_port;
+  return iree_ok_status();
+}
+
+static void RestoreCompletionPosting(iree_async_proactor_iocp_t* proactor,
+                                     HANDLE preserved_port) {
+  proactor->completion_port.handle = (uintptr_t)preserved_port;
+}
+
+static void WaitForFallbackCompletionReady(iree_async_iocp_carrier_t* carrier) {
+  while (iree_atomic_load(&carrier->fallback_completion_state,
+                          iree_memory_order_acquire) !=
+         IREE_ASYNC_IOCP_FALLBACK_COMPLETION_READY) {
+    std::this_thread::yield();
+  }
+}
+
+class IocpProactorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_async_proactor_options_t options =
+        iree_async_proactor_options_default();
+    IREE_ASSERT_OK(iree_async_proactor_create_iocp(
+        options, iree_allocator_system(), &proactor_));
+  }
+
+  void TearDown() override { iree_async_proactor_release(proactor_); }
+
+  iree_async_proactor_iocp_t* iocp() {
+    return iree_async_proactor_iocp_cast(proactor_);
+  }
+
+  iree_async_proactor_t* proactor_ = nullptr;
+};
+
+TEST_F(IocpProactorTest, DirectPostFailureReleasesRetainedResources) {
+  iree_async_notification_t* notification = nullptr;
+  IREE_ASSERT_OK(iree_async_notification_create(
+      proactor_, IREE_ASYNC_NOTIFICATION_FLAG_NONE, &notification));
+  ASSERT_EQ(iree_atomic_ref_count_load(&notification->ref_count), 1);
+
+  CompletionState completion;
+  iree_async_notification_signal_operation_t signal_operation;
+  std::memset(&signal_operation, 0, sizeof(signal_operation));
+  signal_operation.base.type = IREE_ASYNC_OPERATION_TYPE_NOTIFICATION_SIGNAL;
+  signal_operation.base.completion_fn = RecordCompletion;
+  signal_operation.base.user_data = &completion;
+  signal_operation.notification = notification;
+  signal_operation.wake_count = 1;
+
+  uint32_t initial_epoch = iree_async_notification_query_epoch(notification);
+  HANDLE preserved_port = NULL;
+  IREE_ASSERT_OK(DisableCompletionPosting(iocp(), &preserved_port));
+  iree_status_t submit_status =
+      iree_async_proactor_submit_one(proactor_, &signal_operation.base);
+  RestoreCompletionPosting(iocp(), preserved_port);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, submit_status);
+
+  EXPECT_NE(iree_async_notification_query_epoch(notification), initial_epoch);
+  EXPECT_EQ(iree_atomic_ref_count_load(&notification->ref_count), 1);
+  EXPECT_EQ(completion.call_count, 0);
+  EXPECT_EQ(signal_operation.base.next, nullptr);
+
+  iree_async_notification_release(notification);
+}
+
+TEST_F(IocpProactorTest, RichStatusPostFailureConsumesStashedStatus) {
+  iree_async_semaphore_t* semaphore = nullptr;
+  IREE_ASSERT_OK(iree_async_semaphore_create(
+      proactor_, /*initial_value=*/10,
+      IREE_ASYNC_SEMAPHORE_DEFAULT_FRONTIER_CAPACITY, iree_allocator_system(),
+      &semaphore));
+  iree_async_semaphore_t* semaphore_storage = semaphore;
+  uint64_t non_monotonic_value = 10;
+
+  CompletionState completion;
+  iree_async_semaphore_signal_operation_t signal_operation;
+  std::memset(&signal_operation, 0, sizeof(signal_operation));
+  signal_operation.base.type = IREE_ASYNC_OPERATION_TYPE_SEMAPHORE_SIGNAL;
+  signal_operation.base.completion_fn = RecordCompletion;
+  signal_operation.base.user_data = &completion;
+  signal_operation.semaphores = &semaphore_storage;
+  signal_operation.values = &non_monotonic_value;
+  signal_operation.count = 1;
+
+  HANDLE preserved_port = NULL;
+  IREE_ASSERT_OK(DisableCompletionPosting(iocp(), &preserved_port));
+  iree_status_t submit_status =
+      iree_async_proactor_submit_one(proactor_, &signal_operation.base);
+  RestoreCompletionPosting(iocp(), preserved_port);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT, submit_status);
+
+  EXPECT_EQ(iree_async_semaphore_query(semaphore), 10u);
+  EXPECT_EQ(completion.call_count, 0);
+  EXPECT_EQ(signal_operation.base.next, nullptr);
+
+  iree_async_semaphore_release(semaphore);
+}
+
+TEST_F(IocpProactorTest, FailedWakePersistsUntilPoll) {
+  HANDLE preserved_port = NULL;
+  IREE_ASSERT_OK(DisableCompletionPosting(iocp(), &preserved_port));
+  iree_async_proactor_wake(proactor_);
+
+  EXPECT_EQ(iree_atomic_load(&iocp()->completion_port.fallback_wake_pending,
+                             iree_memory_order_acquire),
+            1);
+  RestoreCompletionPosting(iocp(), preserved_port);
+  IREE_ASSERT_OK(iree_async_proactor_poll(proactor_, iree_immediate_timeout(),
+                                          /*out_completed_count=*/nullptr));
+  EXPECT_EQ(iree_atomic_load(&iocp()->completion_port.fallback_wake_pending,
+                             iree_memory_order_acquire),
+            0);
+}
+
+TEST_F(IocpProactorTest, FallbackApcInterruptsBlockedPoll) {
+  std::atomic<iree_status_code_t> poll_status{IREE_STATUS_UNKNOWN};
+  std::thread poll_thread([&]() {
+    iree_status_t status = iree_async_proactor_poll(
+        proactor_, iree_infinite_timeout(), /*out_completed_count=*/nullptr);
+    poll_status.store(iree_status_code(status), std::memory_order_release);
+    iree_status_free(status);
+  });
+
+  // Waiting for the durable owner handle ensures wake() must use the APC path
+  // instead of relying on a pre-poll pending flag.
+  while (iree_atomic_load(&iocp()->completion_port.poll_thread_handle,
+                          iree_memory_order_acquire) == 0) {
+    std::this_thread::yield();
+  }
+  iree_async_iocp_completion_port_request_fallback_wake(
+      &iocp()->completion_port);
+  poll_thread.join();
+
+  EXPECT_EQ(poll_status.load(std::memory_order_acquire), IREE_STATUS_OK);
+  EXPECT_EQ(iree_atomic_load(&iocp()->completion_port.fallback_wake_pending,
+                             iree_memory_order_acquire),
+            0);
+}
+
+TEST(IocpLegacyEventWaitTest, FailedCallbackPostDispatchesFromPoll) {
+  iree_async_proactor_options_t options = iree_async_proactor_options_default();
+  options.allowed_capabilities &=
+      ~IREE_ASYNC_PROACTOR_CAPABILITY_WAIT_COMPLETION_PACKET;
+  iree_async_proactor_t* proactor = nullptr;
+  IREE_ASSERT_OK(iree_async_proactor_create_iocp(
+      options, iree_allocator_system(), &proactor));
+  iree_async_proactor_iocp_t* iocp = iree_async_proactor_iocp_cast(proactor);
+
+  iree_async_event_t* event = nullptr;
+  IREE_ASSERT_OK(iree_async_event_create(proactor, &event));
+  CompletionState completion;
+  iree_async_event_wait_operation_t wait_operation;
+  std::memset(&wait_operation, 0, sizeof(wait_operation));
+  wait_operation.base.type = IREE_ASYNC_OPERATION_TYPE_EVENT_WAIT;
+  wait_operation.base.completion_fn = RecordCompletion;
+  wait_operation.base.user_data = &completion;
+  wait_operation.event = event;
+
+  IREE_ASSERT_OK(
+      iree_async_proactor_submit_one(proactor, &wait_operation.base));
+  IREE_ASSERT_OK(iree_async_proactor_poll(proactor, iree_immediate_timeout(),
+                                          /*out_completed_count=*/nullptr));
+  ASSERT_EQ(completion.call_count, 0);
+  ASSERT_EQ(iree_atomic_load(&iocp->outstanding_carrier_count,
+                             iree_memory_order_relaxed),
+            1);
+
+  HANDLE preserved_port = NULL;
+  IREE_ASSERT_OK(DisableCompletionPosting(iocp, &preserved_port));
+  IREE_ASSERT_OK(iree_async_event_set(event));
+  iree_async_iocp_carrier_t* carrier = iocp->active_carriers;
+  ASSERT_NE(carrier, nullptr);
+  WaitForFallbackCompletionReady(carrier);
+  RestoreCompletionPosting(iocp, preserved_port);
+
+  iree_host_size_t completed_count = 0;
+  IREE_ASSERT_OK(iree_async_proactor_poll(proactor, iree_infinite_timeout(),
+                                          &completed_count));
+
+  EXPECT_EQ(completed_count, 1);
+  EXPECT_EQ(completion.call_count, 1);
+  EXPECT_EQ(completion.status_code, IREE_STATUS_OK);
+  EXPECT_EQ(iree_atomic_load(&iocp->outstanding_carrier_count,
+                             iree_memory_order_relaxed),
+            0);
+  EXPECT_EQ(iree_atomic_ref_count_load(&event->ref_count), 1);
+
+  iree_async_event_release(event);
+  iree_async_proactor_release(proactor);
+}
+
+TEST(IocpLegacyEventWaitTest, SuccessfulCallbackPostReleasesRegistration) {
+  iree_async_proactor_options_t options = iree_async_proactor_options_default();
+  options.allowed_capabilities &=
+      ~IREE_ASYNC_PROACTOR_CAPABILITY_WAIT_COMPLETION_PACKET;
+  iree_async_proactor_t* proactor = nullptr;
+  IREE_ASSERT_OK(iree_async_proactor_create_iocp(
+      options, iree_allocator_system(), &proactor));
+  iree_async_proactor_iocp_t* iocp = iree_async_proactor_iocp_cast(proactor);
+
+  iree_async_event_t* event = nullptr;
+  IREE_ASSERT_OK(iree_async_event_create(proactor, &event));
+  CompletionState completion;
+  iree_async_event_wait_operation_t wait_operation;
+  std::memset(&wait_operation, 0, sizeof(wait_operation));
+  wait_operation.base.type = IREE_ASYNC_OPERATION_TYPE_EVENT_WAIT;
+  wait_operation.base.completion_fn = RecordCompletion;
+  wait_operation.base.user_data = &completion;
+  wait_operation.event = event;
+
+  IREE_ASSERT_OK(
+      iree_async_proactor_submit_one(proactor, &wait_operation.base));
+  IREE_ASSERT_OK(iree_async_proactor_poll(proactor, iree_immediate_timeout(),
+                                          /*out_completed_count=*/nullptr));
+  ASSERT_EQ(iree_atomic_load(&iocp->outstanding_carrier_count,
+                             iree_memory_order_relaxed),
+            1);
+
+  IREE_ASSERT_OK(iree_async_event_set(event));
+  iree_host_size_t completed_count = 0;
+  while (completion.call_count == 0) {
+    iree_host_size_t poll_completed_count = 0;
+    IREE_ASSERT_OK(iree_async_proactor_poll(proactor, iree_infinite_timeout(),
+                                            &poll_completed_count));
+    completed_count += poll_completed_count;
+  }
+
+  EXPECT_EQ(completed_count, 1);
+  EXPECT_EQ(completion.call_count, 1);
+  EXPECT_EQ(completion.status_code, IREE_STATUS_OK);
+  EXPECT_EQ(iree_atomic_load(&iocp->outstanding_carrier_count,
+                             iree_memory_order_relaxed),
+            0);
+  EXPECT_EQ(iree_atomic_ref_count_load(&event->ref_count), 1);
+
+  iree_async_event_release(event);
+  iree_async_proactor_release(proactor);
+}
+
+TEST(IocpLegacyEventWaitTest, CancelledFallbackDispatchesExactlyOnce) {
+  iree_async_proactor_options_t options = iree_async_proactor_options_default();
+  options.allowed_capabilities &=
+      ~IREE_ASYNC_PROACTOR_CAPABILITY_WAIT_COMPLETION_PACKET;
+  iree_async_proactor_t* proactor = nullptr;
+  IREE_ASSERT_OK(iree_async_proactor_create_iocp(
+      options, iree_allocator_system(), &proactor));
+  iree_async_proactor_iocp_t* iocp = iree_async_proactor_iocp_cast(proactor);
+
+  iree_async_event_t* event = nullptr;
+  IREE_ASSERT_OK(iree_async_event_create(proactor, &event));
+  CompletionState completion;
+  iree_async_event_wait_operation_t wait_operation;
+  std::memset(&wait_operation, 0, sizeof(wait_operation));
+  wait_operation.base.type = IREE_ASYNC_OPERATION_TYPE_EVENT_WAIT;
+  wait_operation.base.completion_fn = RecordCompletion;
+  wait_operation.base.user_data = &completion;
+  wait_operation.event = event;
+
+  IREE_ASSERT_OK(
+      iree_async_proactor_submit_one(proactor, &wait_operation.base));
+  IREE_ASSERT_OK(iree_async_proactor_poll(proactor, iree_immediate_timeout(),
+                                          /*out_completed_count=*/nullptr));
+
+  HANDLE preserved_port = NULL;
+  IREE_ASSERT_OK(DisableCompletionPosting(iocp, &preserved_port));
+  IREE_ASSERT_OK(iree_async_event_set(event));
+  iree_async_iocp_carrier_t* carrier = iocp->active_carriers;
+  ASSERT_NE(carrier, nullptr);
+  WaitForFallbackCompletionReady(carrier);
+  IREE_ASSERT_OK(iree_async_proactor_cancel(proactor, &wait_operation.base));
+  RestoreCompletionPosting(iocp, preserved_port);
+
+  iree_host_size_t completed_count = 0;
+  IREE_ASSERT_OK(iree_async_proactor_poll(proactor, iree_infinite_timeout(),
+                                          &completed_count));
+
+  EXPECT_EQ(completed_count, 1);
+  EXPECT_EQ(completion.call_count, 1);
+  EXPECT_EQ(completion.status_code, IREE_STATUS_CANCELLED);
+  EXPECT_EQ(iree_atomic_load(&iocp->outstanding_carrier_count,
+                             iree_memory_order_relaxed),
+            0);
+  EXPECT_EQ(iree_atomic_ref_count_load(&event->ref_count), 1);
+
+  iree_async_event_release(event);
+  iree_async_proactor_release(proactor);
+}
+
+}  // namespace

--- a/runtime/src/iree/async/platform/iocp/socket.c
+++ b/runtime/src/iree/async/platform/iocp/socket.c
@@ -187,7 +187,8 @@ static iree_async_socket_flags_t iree_async_iocp_socket_flags_from_options(
 static iree_status_t iree_async_iocp_socket_associate(
     iree_async_proactor_iocp_t* proactor, SOCKET sock) {
   HANDLE result = CreateIoCompletionPort(
-      (HANDLE)sock, (HANDLE)proactor->completion_port, /*CompletionKey=*/0,
+      (HANDLE)sock, (HANDLE)proactor->completion_port.handle,
+      /*CompletionKey=*/0,
       /*NumberOfConcurrentThreads=*/0);
   if (result == NULL) {
     DWORD error = GetLastError();
@@ -383,7 +384,7 @@ void iree_async_iocp_socket_destroy(iree_async_proactor_iocp_t* proactor,
 
   iree_status_t failure = (iree_status_t)iree_atomic_load(
       &socket->failure_status, iree_memory_order_acquire);
-  iree_status_ignore(failure);
+  iree_status_free(failure);
 
   iree_allocator_free(proactor->base.allocator, socket);
 


### PR DESCRIPTION
The IOCP backend treated every synthetic `PostQueuedCompletionStatus` call as infallible. If the completion port rejected a packet, status-returning submit paths leaked transferred ownership or silently lost an operation, Windows thread-pool callbacks could strand carriers, and void wake paths could leave the poll owner asleep.

This introduces an owned completion-port component that centralizes checked synthetic posts and the poll-owner wake contract. Status-returning submit paths unwind operation resources and propagate the transport failure. Windows-managed callbacks publish durable completion or signal state before interrupting the poll owner's alertable wait with an APC, and the poll path synchronizes wait unregistration before dispatching or recycling a carrier. Console-control and shared-notification wakes use the same boundary, with signal-handler rundown preventing teardown from racing a handler that observed the proactor.

The focused coverage invalidates only the posting handle while preserving the underlying completion-port object, forcing failures through the real Win32 API. It covers direct and stashed-status submissions, failed void wakes, blocked-poll interruption, legacy wait callback delivery, successful registration teardown, and cancellation racing fallback dispatch.
