### PR TITLE
[Loom] Compact generated target tables

### DIFF
--- a/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows.py
+++ b/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows.py
@@ -211,19 +211,19 @@ class _PacketRow:
             return self.operand_types[:1]
         raise ValueError(f"{self.descriptor_key}: packet operand types do not fit")
 
-    def render(self) -> str:
+    def render(self, value_type_refs: dict[str, int]) -> str:
         encoded_operand_types = self.encoded_operand_types()
         lines = [
             f"    [{_descriptor_ref_constant_name(self.descriptor_key)}] =",
             "        {",
             f"            .opcode = {self.opcode},",
             f"            .form = {self.form},",
-            f"            .result_type = {self.result_type or _unknown_value()},",
+            f"            .result_type_ref = {value_type_refs[self.result_type or _unknown_value()]},",
         ]
         if encoded_operand_types:
-            lines.append("            .operand_types =")
+            lines.append("            .operand_type_refs =")
             lines.append("                {")
-            lines.extend(f"                    {operand_type}," for operand_type in encoded_operand_types)
+            lines.extend(f"                    {value_type_refs[operand_type]}," for operand_type in encoded_operand_types)
             lines.append("                },")
         lines.extend(
             [
@@ -233,25 +233,25 @@ class _PacketRow:
             ]
         )
         if self.literal_word_count:
-            lines.append(f"            .literal_word_count = {self.literal_word_count},")
+            lines.append(f"            .payload.scalar_constant.literal_word_count = {self.literal_word_count},")
         if self.memory_alignment:
             lines.append(f"            .memory_alignment = {self.memory_alignment},")
         if self.builtin is not None:
-            lines.append(f"            .builtin = {self.builtin},")
+            lines.append(f"            .payload.builtin_load.builtin = {self.builtin},")
         if self.component_index is not None:
-            lines.append(f"            .component_index = {self.component_index},")
+            lines.append(f"            .payload.builtin_load.component_index = {self.component_index},")
         if self.execution_scope is not None:
-            lines.append(f"            .execution_scope = {self.execution_scope},")
+            lines.append(f"            .payload.barrier.execution_scope = {self.execution_scope},")
         if self.memory_scope is not None:
-            lines.append(f"            .memory_scope = {self.memory_scope},")
+            lines.append(f"            .payload.barrier.memory_scope = {self.memory_scope},")
         if self.memory_semantics is not None:
-            lines.append(f"            .memory_semantics = {self.memory_semantics},")
+            lines.append(f"            .payload.barrier.memory_semantics = {self.memory_semantics},")
         if self.cooperative_matrix_layout is not None:
-            lines.append(f"            .cooperative_matrix_layout = {self.cooperative_matrix_layout},")
+            lines.append(f"            .payload.cooperative_matrix.layout = {self.cooperative_matrix_layout},")
         if self.cooperative_matrix_stride:
-            lines.append(f"            .cooperative_matrix_stride = {self.cooperative_matrix_stride},")
+            lines.append(f"            .payload.cooperative_matrix.stride = {self.cooperative_matrix_stride},")
         if self.cooperative_matrix_operands is not None:
-            lines.append(f"            .cooperative_matrix_operands = {self.cooperative_matrix_operands},")
+            lines.append(f"            .payload.cooperative_matrix.operands = {self.cooperative_matrix_operands},")
         lines.append("        },")
         return "\n".join(lines)
 
@@ -925,9 +925,32 @@ def _validate_rows(rows: tuple[_PacketRow, ...]) -> None:
         raise ValueError("SPIR-V storage-buffer scalar suffixes must be unique")
 
 
+def _interned_value_types(
+    rows: tuple[_PacketRow, ...],
+) -> tuple[tuple[str, ...], dict[str, int]]:
+    value_types: list[str] = []
+    value_type_refs: dict[str, int] = {}
+
+    def intern(value_type: str) -> None:
+        if value_type in value_type_refs:
+            return
+        value_type_refs[value_type] = len(value_types)
+        value_types.append(value_type)
+
+    intern(_unknown_value())
+    for row in rows:
+        intern(row.result_type or _unknown_value())
+        for operand_type in row.encoded_operand_types():
+            intern(operand_type)
+    if len(value_types) > 0xFFFF:
+        raise ValueError("SPIR-V packet value-type refs exceed uint16_t storage")
+    return tuple(value_types), value_type_refs
+
+
 def generate_tables() -> str:
     rows = _packet_rows()
     _validate_rows(rows)
+    value_types, value_type_refs = _interned_value_types(rows)
     lines = [
         "// Copyright 2026 The IREE Authors",
         "//",
@@ -940,8 +963,12 @@ def generate_tables() -> str:
         f'static_assert(LOOM_SPIRV_PACKET_MAX_OPERAND_COUNT == {_PACKET_MAX_OPERAND_COUNT}, "generated packet operand maximum");',
         f'static_assert(LOOM_SPIRV_PACKET_OPERAND_TYPE_CAPACITY == {_PACKET_OPERAND_TYPE_CAPACITY}, "generated packet operand-type capacity");',
         "",
+        "const loom_spirv_value_type_t loom_spirv_packet_value_types[] = {",
+        *(f"    {value_type}," for value_type in value_types),
+        "};",
+        "",
         "static const loom_spirv_packet_row_t kSpirvLogicalCorePacketRows[] = {",
-        *(row.render() for row in rows),
+        *(row.render(value_type_refs) for row in rows),
         "};",
         "",
     ]

--- a/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows_test.py
+++ b/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows_test.py
@@ -14,6 +14,7 @@ import pytest
 from loom.gen.target.arch.spirv.spirv_packet_rows import (
     _PACKETLESS_DESCRIPTOR_KEYS,
     _descriptor_ref_constant_name,
+    _interned_value_types,
     _packet_rows,
     _PacketRow,
     _validate_rows,
@@ -65,6 +66,15 @@ def _row_index(rows: tuple[_PacketRow, ...], descriptor_key: str) -> int:
         if row.descriptor_key == descriptor_key:
             return index
     raise AssertionError(f"missing packet-row fixture '{descriptor_key}'")
+
+
+def _packet_row(descriptor_key: str) -> _PacketRow:
+    rows = _packet_rows()
+    return rows[_row_index(rows, descriptor_key)]
+
+
+def _packet_value_types(row: _PacketRow) -> tuple[str, ...]:
+    return ((row.result_type,) if row.result_type is not None else ()) + row.operand_types
 
 
 def test_validation_rejects_duplicate_packet_descriptor_keys() -> None:
@@ -200,41 +210,32 @@ def test_generation_emits_scalar_memory_packet_rows() -> None:
 
 def test_generation_emits_raw_storage_byte_bridge_rows() -> None:
     suffix = RAW_STORAGE_BUFFER_BYTE.suffix
-    tables = generate_tables()
-    load_row = _generated_row(
-        tables,
-        f"spirv.op_load.storage_buffer.{suffix}",
-    )
-    assert "LOOM_SPIRV_SCALAR_TYPE_U8" in load_row
-    assert ".memory_alignment = 1" in load_row
+    load_row = _packet_row(f"spirv.op_load.storage_buffer.{suffix}")
+    assert "LOOM_SPIRV_SCALAR_TYPE_U8" in load_row.result_type
+    assert load_row.memory_alignment == 1
 
-    extend_row = _generated_row(tables, f"spirv.op_uconvert.{suffix}.u32")
-    assert "LOOM_SPIRV_SCALAR_TYPE_U8" in extend_row
-    assert "LOOM_SPIRV_SCALAR_TYPE_U32" in extend_row
+    extend_row = _packet_row(f"spirv.op_uconvert.{suffix}.u32")
+    assert "LOOM_SPIRV_SCALAR_TYPE_U32" in extend_row.result_type
+    assert "LOOM_SPIRV_SCALAR_TYPE_U8" in extend_row.operand_types[0]
 
-    narrow_row = _generated_row(tables, f"spirv.op_uconvert.u32.{suffix}")
-    assert "LOOM_SPIRV_SCALAR_TYPE_U32" in narrow_row
-    assert "LOOM_SPIRV_SCALAR_TYPE_U8" in narrow_row
+    narrow_row = _packet_row(f"spirv.op_uconvert.u32.{suffix}")
+    assert "LOOM_SPIRV_SCALAR_TYPE_U8" in narrow_row.result_type
+    assert "LOOM_SPIRV_SCALAR_TYPE_U32" in narrow_row.operand_types[0]
 
 
 def test_generation_emits_complete_float_constant_packet_rows() -> None:
-    tables = generate_tables()
-
     for scalar in FLOAT_CONSTANT_TYPES:
-        row = _generated_row(tables, f"spirv.op_constant.{scalar.suffix}")
-        assert "LOOM_SPIRV_PACKET_FORM_SCALAR_CONSTANT" in row
-        assert scalar.scalar_enum in row
-        assert f".literal_word_count = {scalar.literal_word_count}" in row
+        row = _packet_row(f"spirv.op_constant.{scalar.suffix}")
+        assert row.form == "LOOM_SPIRV_PACKET_FORM_SCALAR_CONSTANT"
+        assert scalar.scalar_enum in row.result_type
+        assert row.literal_word_count == scalar.literal_word_count
 
         descriptor = _descriptor(f"spirv.op_constant.{scalar.suffix}")
         assert descriptor.feature_mask_words == ((scalar.feature_bits,) if scalar.feature_bits else ())
 
 
 def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
-    tables = generate_tables()
-
-    f16_lhs = _generated_row(
-        tables,
+    f16_lhs = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_load_khr",
             role="lhs",
@@ -244,8 +245,7 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    f16_init = _generated_row(
-        tables,
+    f16_init = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_load_khr",
             role="init",
@@ -255,8 +255,7 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    f16_store = _generated_row(
-        tables,
+    f16_store = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_store_khr",
             role="result",
@@ -266,12 +265,11 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    assert ".cooperative_matrix_stride = 32" in f16_lhs
-    assert ".cooperative_matrix_stride = 64" in f16_init
-    assert ".cooperative_matrix_stride = 64" in f16_store
+    assert f16_lhs.cooperative_matrix_stride == 32
+    assert f16_init.cooperative_matrix_stride == 64
+    assert f16_store.cooperative_matrix_stride == 64
 
-    bf16_rhs = _generated_row(
-        tables,
+    bf16_rhs = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_load_khr",
             role="rhs",
@@ -281,10 +279,9 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    assert ".cooperative_matrix_stride = 32" in bf16_rhs
+    assert bf16_rhs.cooperative_matrix_stride == 32
 
-    s8_lhs = _generated_row(
-        tables,
+    s8_lhs = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_load_khr",
             role="lhs",
@@ -294,8 +291,7 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    s8_rhs = _generated_row(
-        tables,
+    s8_rhs = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_load_khr",
             role="rhs",
@@ -305,8 +301,7 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    s8_store = _generated_row(
-        tables,
+    s8_store = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_store_khr",
             role="result",
@@ -316,12 +311,11 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    assert ".cooperative_matrix_stride = 32" in s8_lhs
-    assert ".cooperative_matrix_stride = 16" in s8_rhs
-    assert ".cooperative_matrix_stride = 64" in s8_store
+    assert s8_lhs.cooperative_matrix_stride == 32
+    assert s8_rhs.cooperative_matrix_stride == 16
+    assert s8_store.cooperative_matrix_stride == 64
 
-    u8_lhs = _generated_row(
-        tables,
+    u8_lhs = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_load_khr",
             role="lhs",
@@ -331,8 +325,7 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    u8_store = _generated_row(
-        tables,
+    u8_store = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_store_khr",
             role="result",
@@ -342,20 +335,17 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    assert "LOOM_SPIRV_SCALAR_TYPE_U8" in u8_lhs
-    assert "LOOM_SPIRV_SCALAR_TYPE_U32" in u8_store
-    assert ".cooperative_matrix_stride = 32" in u8_lhs
-    assert ".cooperative_matrix_stride = 64" in u8_store
+    assert "LOOM_SPIRV_SCALAR_TYPE_U8" in u8_lhs.result_type
+    assert "LOOM_SPIRV_SCALAR_TYPE_U32" in u8_store.operand_types[1]
+    assert u8_lhs.cooperative_matrix_stride == 32
+    assert u8_store.cooperative_matrix_stride == 64
 
 
 def test_generation_keeps_storage_buffer_address_untyped_until_access_chain() -> None:
-    tables = generate_tables()
-
-    access_row_start = tables.index("SPIRV_LOGICAL_CORE_DESCRIPTOR_REF_OP_PTR_ACCESS_CHAIN_STORAGE_BUFFER_F32_BYTE_OFFSET")
-    access_row = tables[access_row_start : access_row_start + 800]
-    assert "LOOM_SPIRV_VALUE_CLASS_STORAGE_BUFFER_ADDRESS" in access_row
-    assert "LOOM_SPIRV_VALUE_CLASS_PTR_PHYSICAL_STORAGE_BUFFER" in access_row
-    assert "LOOM_SPIRV_SCALAR_TYPE_F32" in access_row
+    access_row = _packet_row("spirv.op_ptr_access_chain.storage_buffer.f32.byte_offset")
+    assert "LOOM_SPIRV_VALUE_CLASS_PTR_PHYSICAL_STORAGE_BUFFER" in access_row.result_type
+    assert "LOOM_SPIRV_SCALAR_TYPE_F32" in access_row.result_type
+    assert "LOOM_SPIRV_VALUE_CLASS_STORAGE_BUFFER_ADDRESS" in access_row.operand_types[0]
 
 
 def test_generation_emits_coordinate_arithmetic_packet_rows() -> None:
@@ -376,7 +366,6 @@ def test_generation_emits_coordinate_arithmetic_packet_rows() -> None:
 
 
 def test_generation_emits_complete_integer_boolean_packet_matrix() -> None:
-    tables = generate_tables()
     assert tuple(
         (
             row.source_type,
@@ -431,25 +420,19 @@ def test_generation_emits_complete_integer_boolean_packet_matrix() -> None:
 
     for constant in BOOLEAN_CONSTANTS:
         descriptor_key = f"spirv.op_constant_{constant.descriptor_suffix}.bool"
-        row = _generated_row(
-            tables,
-            descriptor_key,
-        )
-        assert constant.opcode in row
-        assert "LOOM_SPIRV_PACKET_FORM_BOOLEAN_CONSTANT" in row
-        assert "LOOM_SPIRV_VALUE_CLASS_BOOL" in row
+        row = _packet_row(descriptor_key)
+        assert row.opcode == constant.opcode
+        assert row.form == "LOOM_SPIRV_PACKET_FORM_BOOLEAN_CONSTANT"
+        assert "LOOM_SPIRV_VALUE_CLASS_BOOL" in row.result_type
         descriptor = _descriptor(descriptor_key)
         assert descriptor.mnemonic == f"{constant.mnemonic}.bool"
         assert descriptor.feature_mask_words == ()
 
     for operation in BOOLEAN_BINARY_OPERATIONS:
         descriptor_key = f"spirv.op_{operation.descriptor_suffix}.bool"
-        row = _generated_row(
-            tables,
-            descriptor_key,
-        )
-        assert operation.opcode in row
-        assert row.count("LOOM_SPIRV_VALUE_CLASS_BOOL") == 3
+        row = _packet_row(descriptor_key)
+        assert row.opcode == operation.opcode
+        assert sum("LOOM_SPIRV_VALUE_CLASS_BOOL" in value_type for value_type in _packet_value_types(row)) == 3
         descriptor = _descriptor(descriptor_key)
         assert descriptor.mnemonic == f"{operation.mnemonic}.bool"
         assert descriptor.feature_mask_words == ()
@@ -458,12 +441,9 @@ def test_generation_emits_complete_integer_boolean_packet_matrix() -> None:
         signed = scalar_pair.signed
         expected_feature_mask = (signed.feature_bits,) if signed.feature_bits else ()
         constant_descriptor_key = f"spirv.op_constant.{signed.suffix}"
-        constant_row = _generated_row(
-            tables,
-            constant_descriptor_key,
-        )
-        assert signed.scalar_enum in constant_row
-        assert f".literal_word_count = {scalar_pair.literal_word_count}" in constant_row
+        constant_row = _packet_row(constant_descriptor_key)
+        assert signed.scalar_enum in constant_row.result_type
+        assert constant_row.literal_word_count == scalar_pair.literal_word_count
         constant_descriptor = _descriptor(constant_descriptor_key)
         assert constant_descriptor.mnemonic == f"OpConstant.{signed.suffix}"
         assert constant_descriptor.feature_mask_words == expected_feature_mask
@@ -476,12 +456,9 @@ def test_generation_emits_complete_integer_boolean_packet_matrix() -> None:
 
         for operation in INTEGER_BITWISE_BINARY_OPERATIONS:
             descriptor_key = f"spirv.op_{operation.descriptor_suffix}.{signed.suffix}"
-            operation_row = _generated_row(
-                tables,
-                descriptor_key,
-            )
-            assert operation.opcode in operation_row
-            assert operation_row.count(signed.scalar_enum) == 3
+            operation_row = _packet_row(descriptor_key)
+            assert operation_row.opcode == operation.opcode
+            assert sum(signed.scalar_enum in value_type for value_type in _packet_value_types(operation_row)) == 3
             descriptor = _descriptor(descriptor_key)
             expected_mnemonic = operation.mnemonic if signed.suffix == "i32" else f"{operation.mnemonic}.{signed.suffix}"
             assert descriptor.mnemonic == expected_mnemonic
@@ -489,37 +466,28 @@ def test_generation_emits_complete_integer_boolean_packet_matrix() -> None:
 
         for predicate in SIGNED_INTEGER_COMPARE_PREDICATES:
             descriptor_key = f"spirv.op_{predicate.descriptor_suffix}.{signed.suffix}"
-            compare_row = _generated_row(
-                tables,
-                descriptor_key,
-            )
-            assert predicate.opcode in compare_row
-            assert compare_row.count(signed.scalar_enum) == 2
+            compare_row = _packet_row(descriptor_key)
+            assert compare_row.opcode == predicate.opcode
+            assert sum(signed.scalar_enum in value_type for value_type in _packet_value_types(compare_row)) == 2
             descriptor = _descriptor(descriptor_key)
             assert descriptor.feature_mask_words == expected_feature_mask
 
         for predicate in UNSIGNED_ORDERED_INTEGER_COMPARE_PREDICATES:
             descriptor_key = f"spirv.op_{predicate.descriptor_suffix}.{scalar_pair.unsigned.suffix}"
-            compare_row = _generated_row(
-                tables,
-                descriptor_key,
-            )
-            assert predicate.opcode in compare_row
-            assert compare_row.count(scalar_pair.unsigned.scalar_enum) == 2
+            compare_row = _packet_row(descriptor_key)
+            assert compare_row.opcode == predicate.opcode
+            assert sum(scalar_pair.unsigned.scalar_enum in value_type for value_type in _packet_value_types(compare_row)) == 2
             descriptor = _descriptor(descriptor_key)
             assert descriptor.feature_mask_words == expected_feature_mask
 
         select_descriptor_key = f"spirv.op_select.{signed.suffix}"
-        select_row = _generated_row(
-            tables,
-            select_descriptor_key,
-        )
-        assert select_row.count(signed.scalar_enum) == 3
+        select_row = _packet_row(select_descriptor_key)
+        assert sum(signed.scalar_enum in value_type for value_type in _packet_value_types(select_row)) == 3
         select_descriptor = _descriptor(select_descriptor_key)
         assert select_descriptor.feature_mask_words == expected_feature_mask
 
-    bool_select_row = _generated_row(tables, "spirv.op_select.bool")
-    assert bool_select_row.count("LOOM_SPIRV_VALUE_CLASS_BOOL") == 4
+    bool_select_row = _packet_row("spirv.op_select.bool")
+    assert sum("LOOM_SPIRV_VALUE_CLASS_BOOL" in value_type for value_type in _packet_value_types(bool_select_row)) == 4
     assert _descriptor("spirv.op_select.bool").feature_mask_words == ()
 
 
@@ -540,19 +508,17 @@ def test_generation_emits_integer_compare_and_select_rows() -> None:
 
 
 def test_generation_emits_complete_index_numeric_primitives() -> None:
-    tables = generate_tables()
+    coordinate_copy = _packet_row("spirv.op_copy_object.i32")
+    assert coordinate_copy.opcode == "LOOM_SPIRV_OP_COPY_OBJECT"
+    assert sum("LOOM_SPIRV_SCALAR_TYPE_S32" in value_type for value_type in _packet_value_types(coordinate_copy)) == 2
 
-    coordinate_copy = _generated_row(tables, "spirv.op_copy_object.i32")
-    assert "LOOM_SPIRV_OP_COPY_OBJECT" in coordinate_copy
-    assert coordinate_copy.count("LOOM_SPIRV_SCALAR_TYPE_S32") == 2
+    offset_multiply = _packet_row("spirv.op_imul.offset64")
+    assert offset_multiply.opcode == "LOOM_SPIRV_OP_I_MUL"
+    assert sum("LOOM_SPIRV_SCALAR_TYPE_U64" in value_type for value_type in _packet_value_types(offset_multiply)) == 3
 
-    offset_multiply = _generated_row(tables, "spirv.op_imul.offset64")
-    assert "LOOM_SPIRV_OP_I_MUL" in offset_multiply
-    assert offset_multiply.count("LOOM_SPIRV_SCALAR_TYPE_U64") == 3
-
-    bit_count = _generated_row(tables, "spirv.op_bit_count.i32")
-    assert "LOOM_SPIRV_OP_BIT_COUNT" in bit_count
-    assert bit_count.count("LOOM_SPIRV_SCALAR_TYPE_S32") == 2
+    bit_count = _packet_row("spirv.op_bit_count.i32")
+    assert bit_count.opcode == "LOOM_SPIRV_OP_BIT_COUNT"
+    assert sum("LOOM_SPIRV_SCALAR_TYPE_S32" in value_type for value_type in _packet_value_types(bit_count)) == 2
 
 
 def test_generation_emits_scalar_conversion_rows() -> None:
@@ -591,13 +557,13 @@ def test_generation_emits_complete_ordinary_vector_structural_matrix() -> None:
         insert_key = f"spirv.op_composite_insert.{component_type.suffix}.{vector_type.suffix}"
         select_key = f"spirv.op_select.{vector_type.suffix}"
 
-        construct = _generated_row(tables, construct_key)
-        assert "LOOM_SPIRV_OP_COMPOSITE_CONSTRUCT" in construct
-        assert "LOOM_SPIRV_PACKET_FORM_COMPOSITE_CONSTRUCT" in construct
-        assert component_type.vector_value_class in construct
-        assert component_type.scalar_value_class in construct
-        assert f".lane_count = {vector_type.lane_count}" in construct
-        assert f".operand_count = {vector_type.lane_count}" in construct
+        construct = packet_rows_by_key[construct_key]
+        assert construct.opcode == "LOOM_SPIRV_OP_COMPOSITE_CONSTRUCT"
+        assert construct.form == "LOOM_SPIRV_PACKET_FORM_COMPOSITE_CONSTRUCT"
+        assert component_type.vector_value_class in construct.result_type
+        assert component_type.scalar_value_class in construct.operand_types[0]
+        assert f".lane_count = {vector_type.lane_count}" in construct.result_type
+        assert len(construct.operand_types) == vector_type.lane_count
 
         extract = _generated_row(tables, extract_key)
         assert "LOOM_SPIRV_OP_COMPOSITE_EXTRACT" in extract
@@ -611,11 +577,11 @@ def test_generation_emits_complete_ordinary_vector_structural_matrix() -> None:
         assert ".operand_count = 2" in insert
         assert ".immediate_index = 0" in insert
 
-        select = _generated_row(tables, select_key)
-        assert "LOOM_SPIRV_OP_SELECT" in select
-        assert "LOOM_SPIRV_PACKET_FORM_SELECT" in select
-        assert "LOOM_SPIRV_VALUE_CLASS_BOOL_VECTOR" in select
-        assert ".operand_count = 3" in select
+        select = packet_rows_by_key[select_key]
+        assert select.opcode == "LOOM_SPIRV_OP_SELECT"
+        assert select.form == "LOOM_SPIRV_PACKET_FORM_SELECT"
+        assert "LOOM_SPIRV_VALUE_CLASS_BOOL_VECTOR" in select.operand_types[0]
+        assert len(select.operand_types) == 3
 
         expected_features = (component_type.feature_bits,) if component_type.feature_bits else ()
         for descriptor_key in (construct_key, extract_key, insert_key, select_key):
@@ -706,6 +672,23 @@ def test_generation_compacts_only_repeated_four_operand_types() -> None:
             assert construct.encoded_operand_types() == construct.operand_types
 
 
+def test_generation_interns_packet_value_types() -> None:
+    rows = _packet_rows()
+    value_types, value_type_refs = _interned_value_types(rows)
+
+    assert "LOOM_SPIRV_VALUE_CLASS_UNKNOWN" in value_types[0]
+    assert len(value_types) < len(rows)
+    for row in rows:
+        assert value_type_refs[row.result_type or value_types[0]] < len(value_types)
+        for operand_type in row.encoded_operand_types():
+            assert value_type_refs[operand_type] < len(value_types)
+
+    tables = generate_tables()
+    assert "const loom_spirv_value_type_t loom_spirv_packet_value_types[]" in tables
+    assert ".result_type_ref = " in tables
+    assert ".operand_type_refs =" in tables
+
+
 def test_generation_emits_complete_address_conversion_rows() -> None:
     tables = generate_tables()
 
@@ -718,11 +701,11 @@ def test_generation_emits_complete_address_conversion_rows() -> None:
             f"spirv.op_{operation}.{scalar.suffix}.offset64",
             f"spirv.op_{operation}.offset64.{scalar.suffix}",
         ):
-            row = _generated_row(tables, descriptor_key)
-            assert opcode in row
-            assert "LOOM_SPIRV_PACKET_FORM_UNARY_TYPED" in row
-            assert scalar.scalar_enum in row
-            assert "LOOM_SPIRV_VALUE_CLASS_OFFSET64" in row
+            row = _packet_row(descriptor_key)
+            assert row.opcode == opcode
+            assert row.form == "LOOM_SPIRV_PACKET_FORM_UNARY_TYPED"
+            assert any(scalar.scalar_enum in value_type for value_type in _packet_value_types(row))
+            assert any("LOOM_SPIRV_VALUE_CLASS_OFFSET64" in value_type for value_type in _packet_value_types(row))
             assert _descriptor(descriptor_key).feature_mask_words == expected_feature_mask
 
     for query in BUILTIN_INDEX_QUERIES:
@@ -730,6 +713,6 @@ def test_generation_emits_complete_address_conversion_rows() -> None:
             suffix = f"{query.descriptor_suffix}_{dimension.source_keyword}".upper()
             assert f"SPIRV_LOGICAL_CORE_DESCRIPTOR_REF_OP_LOAD_BUILTIN_{suffix}" in tables
             assert query.builtin_enum in tables
-            assert f".component_index = {dimension.component_index}" in tables
+            assert f".payload.builtin_load.component_index = {dimension.component_index}" in tables
 
     assert "LOOM_SPIRV_PACKET_FORM_LOAD_BUILTIN" in tables

--- a/loom/py/loom/gen/target/contracts/lower_rule_rows.py
+++ b/loom/py/loom/gen/target/contracts/lower_rule_rows.py
@@ -831,8 +831,14 @@ def rule_set_row(
     source_memories_name: str,
     descriptor_ref_keys: tuple[str, ...],
     descriptor_refs_name: str,
+    diagnostic_param_rows: tuple[tuple[LowerDiagnosticParam, int], ...],
     diagnostic_params_name: str,
+    diagnostic_param_refs: tuple[int, ...],
+    diagnostic_param_refs_name: str,
+    guard_rows: tuple[LowerGuard, ...],
     guards_name: str,
+    guard_refs: tuple[int, ...],
+    guard_refs_name: str,
     attr_copies_name: str,
     tied_results_name: str,
     emits_name: str,
@@ -876,14 +882,20 @@ def rule_set_row(
         descriptor_ref_keys,
         descriptor_refs_name,
     )
-    diagnostic_param_rows = tuple(param for diagnostic in table.diagnostics for param in diagnostic_stored_params(diagnostic))
     _append_table_fields(
         fields,
         "diagnostic_params",
         diagnostic_param_rows,
         diagnostic_params_name,
     )
-    _append_table_fields(fields, "guards", table.guards, guards_name)
+    _append_table_fields(
+        fields,
+        "diagnostic_param_refs",
+        diagnostic_param_refs,
+        diagnostic_param_refs_name,
+    )
+    _append_table_fields(fields, "guards", guard_rows, guards_name)
+    _append_table_fields(fields, "guard_refs", guard_refs, guard_refs_name)
     _append_table_fields(fields, "attr_copies", table.attr_copies, attr_copies_name)
     _append_table_fields(fields, "tied_results", table.tied_results, tied_results_name)
     _append_table_fields(fields, "emits", table.emits, emits_name)
@@ -910,6 +922,10 @@ def _table_count_field_name(field_name: str) -> str:
         return "source_memory_count"
     if field_name == "diagnostic_params":
         return "diagnostic_param_count"
+    if field_name == "diagnostic_param_refs":
+        return "diagnostic_param_ref_count"
+    if field_name == "guard_refs":
+        return "guard_ref_count"
     if field_name == "report_key_string_offsets":
         return "report_key_count"
     return f"{field_name[:-1]}_count"

--- a/loom/py/loom/gen/target/contracts/lower_rules.py
+++ b/loom/py/loom/gen/target/contracts/lower_rules.py
@@ -8,7 +8,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -50,6 +50,51 @@ class GeneratedLowerRuleSet:
 
     header: str
     source: str
+
+
+def _intern_rows[RowT: Hashable](
+    rows: Sequence[RowT],
+) -> tuple[tuple[RowT, ...], tuple[int, ...]]:
+    unique_rows: list[RowT] = []
+    row_refs: list[int] = []
+    row_ordinals: dict[RowT, int] = {}
+    for row in rows:
+        ordinal = row_ordinals.get(row)
+        if ordinal is None:
+            ordinal = len(unique_rows)
+            row_ordinals[row] = ordinal
+            unique_rows.append(row)
+        row_refs.append(ordinal)
+    return tuple(unique_rows), tuple(row_refs)
+
+
+def _diagnostic_param_storage_key(row: LowerDiagnosticParam) -> tuple[object, ...]:
+    return (
+        row.kind,
+        row.string_value,
+        row.value_ref_index,
+        row.i64_value,
+        row.u32_value,
+        row.u64_value,
+        row.bool_value,
+    )
+
+
+def _intern_diagnostic_params(
+    rows: Sequence[LowerDiagnosticParam],
+) -> tuple[tuple[tuple[LowerDiagnosticParam, int], ...], tuple[int, ...]]:
+    unique_rows: list[tuple[LowerDiagnosticParam, int]] = []
+    row_refs: list[int] = []
+    row_ordinals: dict[tuple[object, ...], int] = {}
+    for source_index, row in enumerate(rows):
+        key = _diagnostic_param_storage_key(row)
+        ordinal = row_ordinals.get(key)
+        if ordinal is None:
+            ordinal = len(unique_rows)
+            row_ordinals[key] = ordinal
+            unique_rows.append((row, source_index))
+        row_refs.append(ordinal)
+    return tuple(unique_rows), tuple(row_refs)
 
 
 def generate_lower_rule_set(
@@ -263,6 +308,7 @@ def _generate_source(
             fields.append(".flags = LOOM_LOW_LOWER_DIAGNOSTIC_FLAG_IMPLICIT_TARGET_CONTEXT")
         diagnostic_rows.append(fields)
 
+    unique_diagnostic_params, diagnostic_param_refs = _intern_diagnostic_params(diagnostic_param_rows)
     diagnostic_params_name = f"k{c_table_prefix}DiagnosticParams"
     lines.extend(
         lower_rule_rows.emit_optional_array(
@@ -271,10 +317,19 @@ def _generate_source(
             [
                 lower_rule_rows.diagnostic_param_row(
                     row,
-                    string_value_offset=(string_pool.ref(_diagnostic_param_string_label(index)) if row.kind == DiagnosticParamKind.STRING_LITERAL else None),
+                    string_value_offset=(string_pool.ref(_diagnostic_param_string_label(source_index)) if row.kind == DiagnosticParamKind.STRING_LITERAL else None),
                 )
-                for index, row in enumerate(diagnostic_param_rows)
+                for row, source_index in unique_diagnostic_params
             ],
+        )
+    )
+
+    diagnostic_param_refs_name = f"k{c_table_prefix}DiagnosticParamRefs"
+    lines.extend(
+        lower_rule_rows.emit_optional_value_array(
+            diagnostic_param_refs_name,
+            "loom_low_lower_diagnostic_param_ref_t",
+            [str(ref) for ref in diagnostic_param_refs],
         )
     )
 
@@ -287,12 +342,22 @@ def _generate_source(
         )
     )
 
+    unique_guards, guard_refs = _intern_rows(table.guards)
     guards_name = f"k{c_table_prefix}Guards"
     lines.extend(
         lower_rule_rows.emit_optional_array(
             guards_name,
             "loom_low_lower_guard_t",
-            [lower_rule_rows.guard_row(descriptor_refs, row) for row in table.guards],
+            [lower_rule_rows.guard_row(descriptor_refs, row) for row in unique_guards],
+        )
+    )
+
+    guard_refs_name = f"k{c_table_prefix}GuardRefs"
+    lines.extend(
+        lower_rule_rows.emit_optional_value_array(
+            guard_refs_name,
+            "loom_low_lower_guard_ref_t",
+            [str(ref) for ref in guard_refs],
         )
     )
 
@@ -374,8 +439,14 @@ def _generate_source(
             source_memories_name=source_memories_name,
             descriptor_ref_keys=descriptor_ref_keys,
             descriptor_refs_name=descriptor_refs_name,
+            diagnostic_param_rows=unique_diagnostic_params,
             diagnostic_params_name=diagnostic_params_name,
+            diagnostic_param_refs=diagnostic_param_refs,
+            diagnostic_param_refs_name=diagnostic_param_refs_name,
+            guard_rows=unique_guards,
             guards_name=guards_name,
+            guard_refs=guard_refs,
+            guard_refs_name=guard_refs_name,
             attr_copies_name=attr_copies_name,
             tied_results_name=tied_results_name,
             emits_name=emits_name,

--- a/loom/py/loom/gen/target/contracts/lower_rules_test.py
+++ b/loom/py/loom/gen/target/contracts/lower_rules_test.py
@@ -25,6 +25,8 @@ from loom.gen.target.contracts.lower_rule_rows import (
     value_ref_row,
 )
 from loom.gen.target.contracts.lower_rules import (
+    _intern_diagnostic_params,
+    _intern_rows,
     _validate_c_table_shape,
     generate_lower_rule_set,
 )
@@ -646,6 +648,39 @@ def test_diagnostic_param_row_emits_portable_signed_i64_literal() -> None:
     )
 
     assert ".value = {.i64_value = (-INT64_C(2147483648))}" in fields
+
+
+def test_generated_tables_intern_guards_and_diagnostic_params() -> None:
+    guards = (
+        LowerGuard(kind=GuardKind.VALUE_TYPE, diagnostic_index=2),
+        LowerGuard(kind=GuardKind.VALUE_TYPE, diagnostic_index=2),
+        LowerGuard(kind=GuardKind.VALUE_TYPE, diagnostic_index=3),
+    )
+    unique_guards, guard_refs = _intern_rows(guards)
+    assert unique_guards == (guards[0], guards[2])
+    assert guard_refs == (0, 0, 1)
+
+    params = (
+        LowerDiagnosticParam(
+            "first_name",
+            DiagnosticParamKind.STRING_LITERAL,
+            string_value="same value",
+        ),
+        LowerDiagnosticParam(
+            "second_name",
+            DiagnosticParamKind.STRING_LITERAL,
+            string_value="same value",
+        ),
+        LowerDiagnosticParam(
+            "different_value",
+            DiagnosticParamKind.STRING_LITERAL,
+            string_value="different value",
+        ),
+    )
+    unique_params, param_refs = _intern_diagnostic_params(params)
+    assert tuple(row for row, _ in unique_params) == (params[0], params[2])
+    assert tuple(source_index for _, source_index in unique_params) == (0, 2)
+    assert param_refs == (0, 0, 1)
 
 
 def test_diagnostic_rows_use_recorded_target_context() -> None:

--- a/loom/py/loom/gen/target/low/c_emit.py
+++ b/loom/py/loom/gen/target/low/c_emit.py
@@ -232,7 +232,6 @@ def _descriptor_row_lines(
             f".operand_form_count = {descriptor_rows[i]['operand_form_count']},",
             f".flags = {c_spelling.flag_expr(descriptor.flags)},",
             f".op_kind = {descriptor.op_kind.c_name},",
-            ".reserved = 0,",
         ]
         for i, descriptor in enumerate(descriptors)
     ]

--- a/loom/py/loom/gen/target/low/compiler.py
+++ b/loom/py/loom/gen/target/low/compiler.py
@@ -1349,6 +1349,25 @@ def compile_descriptor_set(
     immediate_encoding_slice_starts = [row.encoding_slice_start for row in compiled_immediate_rows]
     immediate_enum_domain_ids = [row.enum_domain_id for row in compiled_immediate_rows]
 
+    compact_start_tables = (
+        ("descriptor", selected_descriptors),
+        ("asm operand index", asm_table_storage.operand_indices),
+        ("asm operand segment", asm_table_storage.operand_segments),
+        ("asm result value type", asm_table_storage.result_value_types),
+        ("asm immediate", asm_table_storage.immediates),
+        ("native asm value", asm_table_storage.native_values),
+        ("operand", operands),
+        ("immediate", immediates),
+        ("effect", effects),
+        ("constraint", constraints),
+        ("storage lease", storage_leases),
+        ("feature mask word", feature_mask_words),
+        ("encoding field value", encoding_field_values),
+        ("operand form", operand_forms),
+    )
+    for table_name, rows in compact_start_tables:
+        validation.validate_u16_table_count(len(rows), f"descriptor set '{spec.key}' {table_name}")
+
     descriptor_refs = sorted((descriptor.key, i) for i, descriptor in enumerate(selected_descriptors))
     seen_stable_ids: dict[int, str] = {}
     for descriptor in selected_descriptors:

--- a/loom/src/loom/codegen/low/descriptors.h
+++ b/loom/src/loom/codegen/low/descriptors.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 // ABI version for descriptor sets consumed by this header.
-#define LOOM_LOW_DESCRIPTOR_SET_ABI_VERSION 37u
+#define LOOM_LOW_DESCRIPTOR_SET_ABI_VERSION 38u
 
 // Sentinel for absent string-table offsets.
 #define LOOM_LOW_STRING_OFFSET_NONE LOOM_BSTRING_TABLE_OFFSET_NONE
@@ -48,7 +48,7 @@ extern "C" {
 #define LOOM_LOW_ASM_FORM_ORDINAL_NONE UINT16_MAX
 
 // Sentinel for asm forms without exact semantic result value types.
-#define LOOM_LOW_ASM_RESULT_VALUE_TYPE_START_NONE UINT32_MAX
+#define LOOM_LOW_ASM_RESULT_VALUE_TYPE_START_NONE UINT16_MAX
 
 // Sentinel used before verification; verified descriptors must name a class.
 #define LOOM_LOW_SCHEDULE_CLASS_NONE UINT16_MAX
@@ -829,12 +829,13 @@ static inline uint16_t loom_low_schedule_class_schedule_distance_cycles(
              : schedule_class->latency_cycles;
 }
 
-typedef enum loom_low_descriptor_op_kind_e {
+enum loom_low_descriptor_op_kind_e {
   // Descriptor packets use the general low.op representation.
   LOOM_LOW_DESCRIPTOR_OP_KIND_OP = 0,
   // Descriptor packets use the operandless, single-result low.const form.
   LOOM_LOW_DESCRIPTOR_OP_KIND_CONST = 1,
-} loom_low_descriptor_op_kind_t;
+};
+typedef uint8_t loom_low_descriptor_op_kind_t;
 
 typedef struct loom_low_descriptor_t {
   // Durable descriptor identity derived from the descriptor key. This is
@@ -848,21 +849,21 @@ typedef struct loom_low_descriptor_t {
   // String-table offset for the primary semantic tag.
   loom_bstring_table_offset_t semantic_tag_string_offset;
   // First feature-mask word required by this descriptor.
-  uint32_t feature_mask_word_start;
+  uint16_t feature_mask_word_start;
   // First target-owned fixed encoding field value for this descriptor.
-  uint32_t encoding_field_value_start;
+  uint16_t encoding_field_value_start;
   // First operand/result row for this descriptor.
-  uint32_t operand_start;
+  uint16_t operand_start;
   // First immediate row for this descriptor.
-  uint32_t immediate_start;
+  uint16_t immediate_start;
   // First effect row for this descriptor.
-  uint32_t effect_start;
+  uint16_t effect_start;
   // First constraint row for this descriptor.
-  uint32_t constraint_start;
+  uint16_t constraint_start;
   // First storage-lease row for this descriptor.
-  uint32_t storage_lease_start;
+  uint16_t storage_lease_start;
   // First operand-form row for descriptor-family packet selection.
-  uint32_t operand_form_start;
+  uint16_t operand_form_start;
   // Descriptor flags used by verifier, scheduler, and optimizer.
   loom_low_descriptor_flags_t flags;
   // Canonical low IR operation used to represent this descriptor packet.
@@ -893,12 +894,10 @@ typedef struct loom_low_descriptor_t {
   uint16_t storage_lease_count;
   // Number of operand-form rows for this descriptor.
   uint16_t operand_form_count;
-  // Reserved zero padding available for future structural descriptor facts.
-  uint32_t reserved;
 } loom_low_descriptor_t;
 
-static_assert(sizeof(loom_low_descriptor_t) == 88,
-              "loom_low_descriptor_t must be 88 bytes");
+static_assert(sizeof(loom_low_descriptor_t) == 64,
+              "loom_low_descriptor_t must be 64 bytes");
 
 // Descriptor facts owned by one descriptor-set view. Rows correspond exactly
 // to the structural rows in loom_low_descriptor_set_t::descriptors. Keeping
@@ -1061,19 +1060,19 @@ typedef struct loom_low_asm_form_t {
   // Optional string-table offset for the native assembly mnemonic.
   loom_bstring_table_offset_t native_assembly_mnemonic_string_offset;
   // Descriptor ordinal selected by this asm form.
-  uint32_t descriptor_ordinal;
+  uint16_t descriptor_ordinal;
   // First descriptor-local result operand index in asm_operand_indices.
-  uint32_t result_operand_index_start;
+  uint16_t result_operand_index_start;
   // First exact semantic result row, or START_NONE when none are declared.
-  uint32_t result_value_type_start;
+  uint16_t result_value_type_start;
   // First descriptor-local input operand index in asm_operand_indices.
-  uint32_t operand_index_start;
+  uint16_t operand_index_start;
   // First delimited input operand segment row.
-  uint32_t operand_segment_start;
+  uint16_t operand_segment_start;
   // First immediate spelling row for this asm form.
-  uint32_t immediate_start;
+  uint16_t immediate_start;
   // First native assembly value row for this asm form.
-  uint32_t native_assembly_value_start;
+  uint16_t native_assembly_value_start;
   // Number of result operand indices for this asm form.
   uint16_t result_operand_index_count;
   // Number of input operand indices for this asm form.
@@ -1086,8 +1085,8 @@ typedef struct loom_low_asm_form_t {
   uint16_t native_assembly_value_count;
 } loom_low_asm_form_t;
 
-static_assert(sizeof(loom_low_asm_form_t) == 48,
-              "loom_low_asm_form_t must be 48 bytes");
+static_assert(sizeof(loom_low_asm_form_t) == 32,
+              "loom_low_asm_form_t must be 32 bytes");
 
 typedef struct loom_low_descriptor_set_t {
   // Descriptor table ABI version.

--- a/loom/src/loom/codegen/low/lower/contract_query_test.cc
+++ b/loom/src/loom/codegen/low/lower/contract_query_test.cc
@@ -273,6 +273,8 @@ TEST_F(LowContractQuerySourceMemoryTest,
           /*.value=*/{/*.string_value_offset=*/kRuleStringAttrKind},
       },
   };
+  const loom_low_lower_diagnostic_param_ref_t diagnostic_param_refs[] = {0, 1,
+                                                                         2};
   const loom_low_lower_diagnostic_t diagnostic = {
       /*.error_ref=*/LOOM_ERR_TARGET_003_REF,
       /*.param_start=*/0,
@@ -283,6 +285,8 @@ TEST_F(LowContractQuerySourceMemoryTest,
   rule_set.string_table = kRuleStringTable;
   rule_set.diagnostic_params = diagnostic_params;
   rule_set.diagnostic_param_count = IREE_ARRAYSIZE(diagnostic_params);
+  rule_set.diagnostic_param_refs = diagnostic_param_refs;
+  rule_set.diagnostic_param_ref_count = IREE_ARRAYSIZE(diagnostic_param_refs);
   loom_low_lower_rule_match_context_t match_context = {};
   match_context.module = module_;
   match_context.function = function_;
@@ -427,6 +431,9 @@ TEST(LowContractQueryTest, ContractIndexDescriptorRuleReportsRejectedCase) {
           /*.value=*/{/*.string_value_offset=*/kRuleStringAttrKind},
       },
   };
+  const loom_low_lower_diagnostic_param_ref_t diagnostic_param_refs[] = {
+      0, 1, 2, 3, 4, 5, 6, 7};
+  const loom_low_lower_guard_ref_t guard_refs[] = {0};
   loom_low_lower_diagnostic_t diagnostic = {};
   diagnostic.error_ref = LOOM_ERR_TARGET_003_REF;
   diagnostic.param_count = IREE_ARRAYSIZE(diagnostic_params);
@@ -439,8 +446,12 @@ TEST(LowContractQueryTest, ContractIndexDescriptorRuleReportsRejectedCase) {
   rule_set.rule_count = 1;
   rule_set.guards = &guard;
   rule_set.guard_count = 1;
+  rule_set.guard_refs = guard_refs;
+  rule_set.guard_ref_count = IREE_ARRAYSIZE(guard_refs);
   rule_set.diagnostic_params = diagnostic_params;
   rule_set.diagnostic_param_count = IREE_ARRAYSIZE(diagnostic_params);
+  rule_set.diagnostic_param_refs = diagnostic_param_refs;
+  rule_set.diagnostic_param_ref_count = IREE_ARRAYSIZE(diagnostic_param_refs);
   rule_set.diagnostics = &diagnostic;
   rule_set.diagnostic_count = 1;
   const loom_low_lower_rule_set_t* rule_sets[] = {&rule_set};

--- a/loom/src/loom/codegen/low/lower/lower_rules.c
+++ b/loom/src/loom/codegen/low/lower/lower_rules.c
@@ -1524,7 +1524,9 @@ static iree_status_t loom_low_lower_rule_matches(
   *out_source_memory_compatible = false;
   *out_uses_source_memory_access = false;
   for (uint16_t i = 0; i < rule->guard_count; ++i) {
-    uint16_t guard_index = (uint16_t)(rule->guard_start + i);
+    const uint16_t guard_ref_index = (uint16_t)(rule->guard_start + i);
+    const loom_low_lower_guard_ref_t guard_index =
+        rule_set->guard_refs[guard_ref_index];
     const loom_low_lower_guard_t* guard = &rule_set->guards[guard_index];
     bool guard_matches = false;
     IREE_RETURN_IF_ERROR(loom_low_lower_rule_guard_matches(
@@ -1870,14 +1872,14 @@ void loom_low_lower_rule_materialize_diagnostic_params(
     param_index = LOOM_LOW_LOWER_TARGET_CONTEXT_PARAM_COUNT;
   }
   const uint8_t stored_param_count = diagnostic->param_count - param_index;
-  const loom_low_lower_diagnostic_param_t* param_rows =
-      stored_param_count == 0
-          ? NULL
-          : &rule_set->diagnostic_params[diagnostic->param_start];
   for (uint8_t stored_param_index = 0; stored_param_index < stored_param_count;
        ++stored_param_index, ++param_index) {
+    const uint16_t param_ref_index =
+        (uint16_t)(diagnostic->param_start + stored_param_index);
+    const loom_low_lower_diagnostic_param_ref_t param_ordinal =
+        rule_set->diagnostic_param_refs[param_ref_index];
     const loom_low_lower_diagnostic_param_t* row =
-        &param_rows[stored_param_index];
+        &rule_set->diagnostic_params[param_ordinal];
     switch (row->kind) {
       case LOOM_LOW_LOWER_DIAGNOSTIC_PARAM_TARGET_KEY:
         out_params[param_index] = loom_param_string(

--- a/loom/src/loom/codegen/low/lower/lower_rules.h
+++ b/loom/src/loom/codegen/low/lower/lower_rules.h
@@ -382,6 +382,9 @@ typedef struct loom_low_lower_diagnostic_param_t {
 static_assert(sizeof(loom_low_lower_diagnostic_param_t) == 16,
               "loom_low_lower_diagnostic_param_t must be 16 bytes");
 
+// Ordinal into a rule set's interned diagnostic-parameter table.
+typedef uint16_t loom_low_lower_diagnostic_param_ref_t;
+
 enum loom_low_lower_diagnostic_flag_bits_e {
   // Materialize the canonical five target-context parameters before stored
   // parameter rows.
@@ -392,7 +395,7 @@ typedef uint8_t loom_low_lower_diagnostic_flags_t;
 typedef struct loom_low_lower_diagnostic_t {
   // Stable structured diagnostic identity.
   loom_error_ref_t error_ref;
-  // First stored parameter projection row.
+  // First stored parameter projection ref.
   uint16_t param_start;
   // Total number of materialized parameters, including implicit context.
   uint8_t param_count;
@@ -713,6 +716,9 @@ typedef struct loom_low_lower_guard_t {
 static_assert(sizeof(loom_low_lower_guard_t) == 32,
               "loom_low_lower_guard_t must be 32 bytes");
 
+// Ordinal into a rule set's interned guard table.
+typedef uint16_t loom_low_lower_guard_ref_t;
+
 typedef enum loom_low_lower_emit_kind_e {
   // Invalid or uninitialized emit action.
   LOOM_LOW_LOWER_EMIT_INVALID = 0,
@@ -833,9 +839,9 @@ typedef struct loom_low_lower_rule_t {
   // Number of rule-local temporary low values available while emitting this
   // rule.
   uint16_t temporary_count;
-  // First guard table row for this rule.
+  // First guard-ref row for this rule.
   uint16_t guard_start;
-  // Number of guard rows for this rule.
+  // Number of guard refs for this rule.
   uint16_t guard_count;
   // First emit-program table row for this rule.
   uint16_t emit_start;
@@ -905,14 +911,22 @@ typedef struct loom_low_lower_rule_set_t {
   const loom_low_lower_rule_descriptor_ref_t* descriptor_refs;
   // Number of rows in descriptor_refs.
   uint16_t descriptor_ref_count;
-  // Diagnostic parameter projection rows referenced by diagnostics.
+  // Interned diagnostic parameter projection rows.
   const loom_low_lower_diagnostic_param_t* diagnostic_params;
   // Number of rows in diagnostic_params.
   uint16_t diagnostic_param_count;
-  // Guard rows referenced by rules.
+  // Diagnostic parameter refs addressed by diagnostic param spans.
+  const loom_low_lower_diagnostic_param_ref_t* diagnostic_param_refs;
+  // Number of rows in diagnostic_param_refs.
+  uint16_t diagnostic_param_ref_count;
+  // Interned guard rows referenced by guard_refs.
   const loom_low_lower_guard_t* guards;
   // Number of rows in guards.
   uint16_t guard_count;
+  // Guard refs addressed by rule guard spans.
+  const loom_low_lower_guard_ref_t* guard_refs;
+  // Number of rows in guard_refs.
+  uint16_t guard_ref_count;
   // Attribute-copy rows referenced by emits.
   const loom_low_lower_attr_copy_t* attr_copies;
   // Number of rows in attr_copies.

--- a/loom/src/loom/codegen/low/testing/descriptors_verify.c
+++ b/loom/src/loom/codegen/low/testing/descriptors_verify.c
@@ -2177,12 +2177,6 @@ static iree_status_t loom_low_verify_descriptor(
       &descriptor_set->descriptors[descriptor_index];
   const loom_low_descriptor_view_t* descriptor_view =
       &descriptor_set->descriptor_views[descriptor_index];
-  if (descriptor->reserved != 0) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "low descriptor %" PRIu32
-                            " has a non-zero reserved field",
-                            descriptor_index);
-  }
   IREE_RETURN_IF_ERROR(loom_low_verify_known_flags(
       descriptor->flags,
       LOOM_LOW_DESCRIPTOR_FLAG_SIDE_EFFECTING |

--- a/loom/src/loom/target/arch/spirv/low_verify.c
+++ b/loom/src/loom/target/arch/spirv/low_verify.c
@@ -744,8 +744,9 @@ static iree_status_t loom_spirv_low_define_packet_results(
     return iree_ok_status();
   }
   const loom_value_id_t* results = loom_op_const_results(packet->op);
-  return loom_spirv_low_value_type_table_define(&state->value_types, results[0],
-                                                row->result_type, state->arena);
+  return loom_spirv_low_value_type_table_define(
+      &state->value_types, results[0], loom_spirv_packet_row_result_type(row),
+      state->arena);
 }
 
 static iree_status_t loom_spirv_low_verify_packet(

--- a/loom/src/loom/target/arch/spirv/packet_rows.h
+++ b/loom/src/loom/target/arch/spirv/packet_rows.h
@@ -25,7 +25,7 @@ extern "C" {
 #define LOOM_SPIRV_PACKET_MAX_OPERAND_COUNT 4
 #define LOOM_SPIRV_PACKET_OPERAND_TYPE_CAPACITY 3
 
-typedef enum loom_spirv_packet_form_e {
+enum loom_spirv_packet_form_e {
   LOOM_SPIRV_PACKET_FORM_UNSUPPORTED = 0,
   LOOM_SPIRV_PACKET_FORM_SCALAR_CONSTANT = 1,
   LOOM_SPIRV_PACKET_FORM_BINARY_SAME_TYPE = 2,
@@ -46,49 +46,80 @@ typedef enum loom_spirv_packet_form_e {
   LOOM_SPIRV_PACKET_FORM_COMPOSITE_CONSTRUCT = 17,
   LOOM_SPIRV_PACKET_FORM_COMPOSITE_EXTRACT = 18,
   LOOM_SPIRV_PACKET_FORM_COMPOSITE_INSERT = 19,
-} loom_spirv_packet_form_t;
+};
+typedef uint8_t loom_spirv_packet_form_t;
+
+// Ordinal into the generated packet value-type table. Zero names UNKNOWN.
+typedef uint16_t loom_spirv_packet_value_type_ref_t;
+
+#define LOOM_SPIRV_PACKET_VALUE_TYPE_REF_UNKNOWN \
+  ((loom_spirv_packet_value_type_ref_t)0)
 
 typedef struct loom_spirv_packet_row_t {
   // SPIR-V instruction opcode.
   uint32_t opcode;
+  // Form-specific packet literals selected by form.
+  union {
+    // Scalar-constant packet literals.
+    struct {
+      // Number of literal words emitted for the constant.
+      uint8_t literal_word_count;
+    } scalar_constant;
+    // Built-in input packet literals.
+    struct {
+      // SPIR-V BuiltIn enumerant.
+      uint32_t builtin;
+      // Vector component extracted from the built-in input.
+      uint8_t component_index;
+    } builtin_load;
+    // Control-barrier packet literals.
+    struct {
+      // SPIR-V execution scope literal.
+      uint32_t execution_scope;
+      // SPIR-V memory scope literal.
+      uint32_t memory_scope;
+      // SPIR-V memory semantics mask literal.
+      uint32_t memory_semantics;
+    } barrier;
+    // Cooperative-matrix packet literals.
+    struct {
+      // Cooperative matrix layout literal for load/store rows.
+      uint32_t layout;
+      // Cooperative matrix stride literal for load/store rows.
+      uint32_t stride;
+      // Cooperative matrix operands mask literal for mul-add rows.
+      uint32_t operands;
+    } cooperative_matrix;
+  } payload;
+  // Result value-type table ref, or UNKNOWN for result-less packets.
+  loom_spirv_packet_value_type_ref_t result_type_ref;
+  // Required value-type refs for packet operands. Four-operand packets use one
+  // repeated type because the inline type-ref capacity is three.
+  loom_spirv_packet_value_type_ref_t
+      operand_type_refs[LOOM_SPIRV_PACKET_OPERAND_TYPE_CAPACITY];
   // Emission algorithm selected for this descriptor.
   loom_spirv_packet_form_t form;
-  // Result value type, or UNKNOWN for result-less packets.
-  loom_spirv_value_type_t result_type;
-  // Required value types for packet operands. Four-operand packets use one
-  // repeated type because the inline type capacity is three.
-  loom_spirv_value_type_t
-      operand_types[LOOM_SPIRV_PACKET_OPERAND_TYPE_CAPACITY];
   // Expected packet result count.
   uint8_t result_count;
   // Expected packet operand count.
   uint8_t operand_count;
   // Descriptor-local immediate index read by the row.
   uint8_t immediate_index;
-  // Number of literal words emitted for SCALAR_CONSTANT rows.
-  uint8_t literal_word_count;
   // Alignment operand for aligned memory access rows.
   uint8_t memory_alignment;
-  // SPIR-V BuiltIn enumerant for built-in load rows.
-  uint32_t builtin;
-  // Vector component extracted from built-in input rows.
-  uint8_t component_index;
-  // SPIR-V execution scope literal for barrier rows.
-  uint32_t execution_scope;
-  // SPIR-V memory scope literal for barrier rows.
-  uint32_t memory_scope;
-  // SPIR-V memory semantics mask literal for barrier rows.
-  uint32_t memory_semantics;
-  // Cooperative matrix layout literal for load/store rows.
-  uint32_t cooperative_matrix_layout;
-  // Cooperative matrix stride literal for load/store rows.
-  uint32_t cooperative_matrix_stride;
-  // Cooperative matrix operands mask literal for mul-add rows.
-  uint32_t cooperative_matrix_operands;
 } loom_spirv_packet_row_t;
 
-static_assert(sizeof(loom_spirv_packet_row_t) == 128,
+static_assert(sizeof(loom_spirv_packet_row_t) == 32,
               "SPIR-V packet rows must remain compact");
+
+// Generated value types interned across all packet rows.
+extern const loom_spirv_value_type_t loom_spirv_packet_value_types[];
+
+// Returns the result value type required by |row|.
+static inline loom_spirv_value_type_t loom_spirv_packet_row_result_type(
+    const loom_spirv_packet_row_t* row) {
+  return loom_spirv_packet_value_types[row->result_type_ref];
+}
 
 // Returns the required value type for packet operand |operand_index|.
 static inline loom_spirv_value_type_t loom_spirv_packet_row_operand_type(
@@ -97,7 +128,7 @@ static inline loom_spirv_value_type_t loom_spirv_packet_row_operand_type(
       row->operand_count > LOOM_SPIRV_PACKET_OPERAND_TYPE_CAPACITY
           ? 0
           : operand_index;
-  return row->operand_types[type_index];
+  return loom_spirv_packet_value_types[row->operand_type_refs[type_index]];
 }
 
 // Returns the packet row for |descriptor_ordinal|, or NULL when the descriptor

--- a/loom/src/loom/target/emit/spirv/function_emitter.c
+++ b/loom/src/loom/target/emit/spirv/function_emitter.c
@@ -345,10 +345,11 @@ static iree_status_t loom_spirv_emit_scalar_constant_packet(
       loom_spirv_emit_lookup_i64_immediate(state, packet, row, &value));
   uint32_t type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row), &type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, type_id, row->result_type, &result_id));
+      state, packet, type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint64_t literal = (uint64_t)value;
   uint32_t operands[] = {
       type_id,
@@ -358,9 +359,11 @@ static iree_status_t loom_spirv_emit_scalar_constant_packet(
   };
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_DECLARATION),
-      row->opcode, operands, 2 + row->literal_word_count));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id, type_id,
-                                              row->result_type);
+      row->opcode, operands,
+      2 + row->payload.scalar_constant.literal_word_count));
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_boolean_constant_packet(
@@ -368,10 +371,11 @@ static iree_status_t loom_spirv_emit_boolean_constant_packet(
     const loom_spirv_packet_row_t* row) {
   uint32_t type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row), &type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, type_id, row->result_type, &result_id));
+      state, packet, type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t operands[] = {
       type_id,
       result_id,
@@ -379,8 +383,9 @@ static iree_status_t loom_spirv_emit_boolean_constant_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_DECLARATION),
       row->opcode, operands, IREE_ARRAYSIZE(operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id, type_id,
-                                              row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_binary_same_type_packet(
@@ -392,7 +397,8 @@ static iree_status_t loom_spirv_emit_binary_same_type_packet(
   IREE_ASSERT_EQ(operands[0].type_id, operands[1].type_id);
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, operands[0].type_id, row->result_type, &result_id));
+      state, packet, operands[0].type_id,
+      loom_spirv_packet_row_result_type(row), &result_id));
   const uint32_t instruction_operands[] = {
       operands[0].type_id,
       result_id,
@@ -403,7 +409,8 @@ static iree_status_t loom_spirv_emit_binary_same_type_packet(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
   return loom_spirv_emit_define_packet_result(
-      state, packet, result_id, operands[0].type_id, row->result_type);
+      state, packet, result_id, operands[0].type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_unary_typed_packet(
@@ -414,10 +421,12 @@ static iree_status_t loom_spirv_emit_unary_typed_packet(
       loom_spirv_emit_load_packet_operands(state, packet, row, operands));
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t instruction_operands[] = {
       result_type_id,
       result_id,
@@ -426,8 +435,9 @@ static iree_status_t loom_spirv_emit_unary_typed_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_composite_construct_packet(
@@ -439,10 +449,12 @@ static iree_status_t loom_spirv_emit_composite_construct_packet(
       loom_spirv_emit_load_packet_operands(state, packet, row, operands));
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   uint32_t instruction_operands[2 + LOOM_SPIRV_PACKET_MAX_OPERAND_COUNT] = {
       result_type_id,
       result_id,
@@ -453,8 +465,9 @@ static iree_status_t loom_spirv_emit_composite_construct_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, 2 + row->operand_count));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_composite_extract_packet(
@@ -468,10 +481,12 @@ static iree_status_t loom_spirv_emit_composite_extract_packet(
                                                             &component_index));
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t instruction_operands[] = {
       result_type_id,
       result_id,
@@ -481,8 +496,9 @@ static iree_status_t loom_spirv_emit_composite_extract_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_composite_insert_packet(
@@ -496,10 +512,12 @@ static iree_status_t loom_spirv_emit_composite_insert_packet(
                                                             &component_index));
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t instruction_operands[] = {
       result_type_id,
       result_id,
@@ -510,16 +528,17 @@ static iree_status_t loom_spirv_emit_composite_insert_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_load_builtin_packet(
     loom_spirv_emit_state_t* state, const loom_low_descriptor_packet_t* packet,
     const loom_spirv_packet_row_t* row) {
   uint32_t variable_id = 0;
-  IREE_RETURN_IF_ERROR(
-      loom_spirv_emit_builtin_variable(state, row->builtin, &variable_id));
+  IREE_RETURN_IF_ERROR(loom_spirv_emit_builtin_variable(
+      state, row->payload.builtin_load.builtin, &variable_id));
   uint32_t u32_type_id = 0;
   IREE_RETURN_IF_ERROR(
       loom_spirv_emit_type_u32(state->type_context, &u32_type_id));
@@ -534,12 +553,14 @@ static iree_status_t loom_spirv_emit_load_builtin_packet(
 
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t result_id = 0;
   uint32_t component_id = 0;
   if (result_type_id == u32_type_id) {
     IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-        state, packet, result_type_id, row->result_type, &result_id));
+        state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+        &result_id));
     component_id = result_id;
   } else {
     component_id = loom_spirv_emit_allocate_id(state);
@@ -548,7 +569,7 @@ static iree_status_t loom_spirv_emit_load_builtin_packet(
       u32_type_id,
       component_id,
       vector_id,
-      row->component_index,
+      row->payload.builtin_load.component_index,
   };
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
@@ -557,7 +578,8 @@ static iree_status_t loom_spirv_emit_load_builtin_packet(
 
   if (result_type_id != u32_type_id) {
     IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-        state, packet, result_type_id, row->result_type, &result_id));
+        state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+        &result_id));
     const uint32_t bitcast_operands[] = {
         result_type_id,
         result_id,
@@ -568,8 +590,9 @@ static iree_status_t loom_spirv_emit_load_builtin_packet(
         LOOM_SPIRV_OP_BITCAST, bitcast_operands,
         IREE_ARRAYSIZE(bitcast_operands)));
   }
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_integer_mul_add_packet(
@@ -586,7 +609,8 @@ static iree_status_t loom_spirv_emit_integer_mul_add_packet(
       operands[1].id, &product_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, operands[0].type_id, row->result_type, &result_id));
+      state, packet, operands[0].type_id,
+      loom_spirv_packet_row_result_type(row), &result_id));
   const uint32_t instruction_operands[] = {
       operands[0].type_id,
       result_id,
@@ -598,7 +622,8 @@ static iree_status_t loom_spirv_emit_integer_mul_add_packet(
       LOOM_SPIRV_OP_I_ADD, instruction_operands,
       IREE_ARRAYSIZE(instruction_operands)));
   return loom_spirv_emit_define_packet_result(
-      state, packet, result_id, operands[0].type_id, row->result_type);
+      state, packet, result_id, operands[0].type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_compare_same_type_packet(
@@ -610,10 +635,12 @@ static iree_status_t loom_spirv_emit_compare_same_type_packet(
   IREE_ASSERT_EQ(operands[0].type_id, operands[1].type_id);
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t instruction_operands[] = {
       result_type_id,
       result_id,
@@ -623,8 +650,9 @@ static iree_status_t loom_spirv_emit_compare_same_type_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_select_packet(
@@ -636,19 +664,22 @@ static iree_status_t loom_spirv_emit_select_packet(
   IREE_ASSERT_EQ(operands[1].type_id, operands[2].type_id);
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   IREE_ASSERT_EQ(result_type_id, operands[1].type_id);
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t instruction_operands[] = {
       result_type_id, result_id, operands[0].id, operands[1].id, operands[2].id,
   };
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_typed_physical_storage_buffer_pointer(
@@ -684,13 +715,16 @@ static iree_status_t loom_spirv_emit_ptr_access_chain_packet(
       loom_spirv_emit_load_packet_operands(state, packet, row, operands));
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t base_pointer_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_typed_physical_storage_buffer_pointer(
-      state, operands[0], row->result_type, result_type_id, &base_pointer_id));
+      state, operands[0], loom_spirv_packet_row_result_type(row),
+      result_type_id, &base_pointer_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t instruction_operands[] = {
       result_type_id,
       result_id,
@@ -700,8 +734,9 @@ static iree_status_t loom_spirv_emit_ptr_access_chain_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_access_chain_packet(
@@ -712,10 +747,12 @@ static iree_status_t loom_spirv_emit_access_chain_packet(
       loom_spirv_emit_load_packet_operands(state, packet, row, operands));
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t instruction_operands[] = {
       result_type_id,
       result_id,
@@ -725,8 +762,9 @@ static iree_status_t loom_spirv_emit_access_chain_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_load_aligned_packet(
@@ -737,10 +775,12 @@ static iree_status_t loom_spirv_emit_load_aligned_packet(
       loom_spirv_emit_load_packet_operands(state, packet, row, operands));
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t instruction_operands[] = {
       result_type_id,        result_id,
       operands[0].id,        LOOM_SPIRV_MEMORY_ACCESS_ALIGNED_MASK,
@@ -749,8 +789,9 @@ static iree_status_t loom_spirv_emit_load_aligned_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_store_aligned_packet(
@@ -774,9 +815,11 @@ static iree_status_t loom_spirv_emit_cooperative_matrix_layout_operands(
     loom_spirv_emit_state_t* state, const loom_spirv_packet_row_t* row,
     uint32_t* out_layout_id, uint32_t* out_stride_id) {
   IREE_RETURN_IF_ERROR(loom_spirv_emit_u32_constant(
-      state->type_context, row->cooperative_matrix_layout, out_layout_id));
-  return loom_spirv_emit_u32_constant(
-      state->type_context, row->cooperative_matrix_stride, out_stride_id);
+      state->type_context, row->payload.cooperative_matrix.layout,
+      out_layout_id));
+  return loom_spirv_emit_u32_constant(state->type_context,
+                                      row->payload.cooperative_matrix.stride,
+                                      out_stride_id);
 }
 
 static iree_status_t loom_spirv_emit_cooperative_matrix_load_packet(
@@ -787,14 +830,16 @@ static iree_status_t loom_spirv_emit_cooperative_matrix_load_packet(
       loom_spirv_emit_load_packet_operands(state, packet, row, operands));
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t layout_id = 0;
   uint32_t stride_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_cooperative_matrix_layout_operands(
       state, row, &layout_id, &stride_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   const uint32_t instruction_operands[] = {
       result_type_id,
       result_id,
@@ -807,8 +852,9 @@ static iree_status_t loom_spirv_emit_cooperative_matrix_load_packet(
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, IREE_ARRAYSIZE(instruction_operands)));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_cooperative_matrix_store_packet(
@@ -842,35 +888,42 @@ static iree_status_t loom_spirv_emit_cooperative_matrix_mul_add_packet(
       loom_spirv_emit_load_packet_operands(state, packet, row, operands));
   uint32_t result_type_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_type_id_for_value_type(
-      state->type_context, row->result_type, &result_type_id));
+      state->type_context, loom_spirv_packet_row_result_type(row),
+      &result_type_id));
   uint32_t result_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_prepare_packet_result(
-      state, packet, result_type_id, row->result_type, &result_id));
+      state, packet, result_type_id, loom_spirv_packet_row_result_type(row),
+      &result_id));
   uint32_t instruction_operands[6] = {
       result_type_id, result_id, operands[0].id, operands[1].id, operands[2].id,
   };
   uint8_t operand_count = 5;
-  if (row->cooperative_matrix_operands != 0) {
-    instruction_operands[operand_count++] = row->cooperative_matrix_operands;
+  if (row->payload.cooperative_matrix.operands != 0) {
+    instruction_operands[operand_count++] =
+        row->payload.cooperative_matrix.operands;
   }
   IREE_RETURN_IF_ERROR(loom_spirv_binary_write_instruction(
       loom_spirv_emit_section(state, LOOM_SPIRV_MODULE_SECTION_FUNCTION),
       row->opcode, instruction_operands, operand_count));
-  return loom_spirv_emit_define_packet_result(state, packet, result_id,
-                                              result_type_id, row->result_type);
+  return loom_spirv_emit_define_packet_result(
+      state, packet, result_id, result_type_id,
+      loom_spirv_packet_row_result_type(row));
 }
 
 static iree_status_t loom_spirv_emit_control_barrier_packet(
     loom_spirv_emit_state_t* state, const loom_spirv_packet_row_t* row) {
   uint32_t execution_scope_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_u32_constant(
-      state->type_context, row->execution_scope, &execution_scope_id));
+      state->type_context, row->payload.barrier.execution_scope,
+      &execution_scope_id));
   uint32_t memory_scope_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_u32_constant(
-      state->type_context, row->memory_scope, &memory_scope_id));
+      state->type_context, row->payload.barrier.memory_scope,
+      &memory_scope_id));
   uint32_t memory_semantics_id = 0;
   IREE_RETURN_IF_ERROR(loom_spirv_emit_u32_constant(
-      state->type_context, row->memory_semantics, &memory_semantics_id));
+      state->type_context, row->payload.barrier.memory_semantics,
+      &memory_semantics_id));
   const uint32_t instruction_operands[] = {
       execution_scope_id,
       memory_scope_id,


### PR DESCRIPTION
Generated target tables encoded small repeated domains as full-width rows, making the complete SPIR-V compiler slice carry nearly 500 KiB across its three largest data objects. This change makes those representations compact without dropping any target coverage.

SPIR-V packet rows now intern their value types and union mutually exclusive form payloads. Generic descriptor and assembly rows use 16-bit starts backed by generator-enforced table bounds, with a descriptor ABI bump preventing mixed layouts. Generated lower-rule tables intern repeated guards and diagnostic projections behind compact reference streams.

The three dominant optimized SPIR-V objects shrink by 189,560 bytes before linking: packet rows by 87,116 bytes, descriptors by 37,240 bytes, and logical-core lower rules by 65,204 bytes. In an otherwise identical optimized build with the AMDGPU, LLVMIR, SPIR-V, and x86 targets enabled, `loom-compile.exe` shrinks from 10,434,560 bytes to 9,341,952 bytes, a 1,092,608-byte or 10.47% reduction.
