### PR TITLE
[Infra] Remove avoidable devtool feedback loops

### DIFF
--- a/build_tools/devtools/cmake.py
+++ b/build_tools/devtools/cmake.py
@@ -624,21 +624,40 @@ def build_plan(
     backend_args: list[str],
     env: dict[str, str] | None = None,
 ) -> CommandPlan:
+    requested_build_dir = build_dir(configured_build_dir)
+    cmake_args = build_args(
+        backend_args,
+        configured_build_dir=configured_build_dir,
+    )
+    target_names = [
+        cmake_args[index + 1]
+        for index, argument in enumerate(cmake_args[:-1])
+        if argument == "--target"
+    ]
+    target_description = ", ".join(target_names) if target_names else "default"
+    configured_generator = _configured_cmake_generator(requested_build_dir)
+    generator_description = (
+        configured_generator.describe()
+        if configured_generator is not None
+        else "unconfigured"
+    )
     return CommandPlan(
         [
             CommandStep(
                 [
                     tool_env.tool("cmake"),
                     "--build",
-                    str(build_dir(configured_build_dir)),
-                    *build_args(
-                        backend_args,
-                        configured_build_dir=configured_build_dir,
-                    ),
+                    str(requested_build_dir),
+                    *cmake_args,
                 ],
                 cwd=REPO_ROOT,
                 env=tool_env.path_env() if env is None else env,
-                label="cmake build",
+                label=(
+                    f"cmake build: targets={target_description}; "
+                    f"generator={generator_description}; "
+                    f"tree={requested_build_dir}"
+                ),
+                announce=True,
             )
         ]
     )

--- a/build_tools/devtools/cmake_test.py
+++ b/build_tools/devtools/cmake_test.py
@@ -12,6 +12,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from build_tools.devtools import cmake as cmake_dev
 from build_tools.devtools import (
@@ -212,6 +213,32 @@ class CMakeTest(unittest.TestCase):
         )
         self.assertIn("ctest", inspect_plan.describe())
         self.assertNotIn("cmake --build", inspect_plan.describe())
+
+    def test_build_announces_targets_generator_and_tree(self):
+        tool_env = ToolEnvironment(ToolMode.SYSTEM, None)
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            build_dir = Path(temporary_dir)
+            (build_dir / "CMakeCache.txt").write_text(
+                "CMAKE_GENERATOR:INTERNAL=NMake Makefiles\n",
+                encoding="utf-8",
+            )
+            plan = cmake_dev.build_plan(
+                tool_env,
+                configured_build_dir=build_dir,
+                backend_args=["loom-compile"],
+                env={},
+            )
+
+            output = io.StringIO()
+            with (
+                mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
+                contextlib.redirect_stdout(output),
+            ):
+                self.assertEqual(plan.run(), 0)
+
+            self.assertIn("targets=loom-compile", output.getvalue())
+            self.assertIn("generator=NMake Makefiles", output.getvalue())
+            self.assertIn(f"tree={build_dir}", output.getvalue())
 
     def test_fresh_configure_preserves_configured_generator(self):
         tool_env = ToolEnvironment(ToolMode.SYSTEM, None)

--- a/build_tools/devtools/command_plan.py
+++ b/build_tools/devtools/command_plan.py
@@ -56,6 +56,7 @@ class CommandStep:
     cwd: Path
     env: dict[str, str] | None = None
     label: str | None = None
+    announce: bool = False
 
     def describe(self) -> str:
         pieces = []
@@ -97,9 +98,11 @@ class CommandStep:
 
     def run(self, verbose: bool = False) -> int:
         argv = _resolve_subprocess_argv(self.argv, self.env)
-        if verbose:
+        if verbose or self.announce:
             print(f"dev.py: {self.label or quote_command(argv)}")
+        if verbose:
             print("  " + quote_command(argv))
+        if verbose or self.announce:
             sys.stdout.flush()
         return subprocess.run(argv, cwd=self.cwd, env=self.env).returncode
 

--- a/build_tools/devtools/command_plan_test.py
+++ b/build_tools/devtools/command_plan_test.py
@@ -96,6 +96,24 @@ class CommandPlanTest(unittest.TestCase):
         self.assertIn("dev.py: loud command", output.getvalue())
         self.assertIn(sys.executable, output.getvalue())
 
+    def test_announced_command_step_prints_label_without_command(self):
+        plan = CommandPlan(
+            [
+                CommandStep(
+                    [sys.executable, "-c", ""],
+                    cwd=Path.cwd(),
+                    label="starting long command",
+                    announce=True,
+                )
+            ]
+        )
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.assertEqual(plan.run(), 0)
+
+        self.assertEqual(output.getvalue(), "dev.py: starting long command\n")
+
     def test_windows_command_step_resolves_executable_from_child_path(self):
         child_path = "C:/source/.venv/Scripts;C:/Windows/System32"
         resolved_executable = "C:/source/.venv/Scripts/lefthook.exe"

--- a/build_tools/lefthook/README.md
+++ b/build_tools/lefthook/README.md
@@ -75,11 +75,12 @@ fragment useful commit-message prose. Long fenced code blocks, indented
 examples, Markdown tables, URLs, and final Git trailers are preserved as
 structured text.
 
-When body prose is too long, the hook writes a reflowed suggestion under
-`.tmp/commit-msg/` and prints a `git commit -F ...` retry command. The
-suggestion reflows ordinary prose paragraphs only: subject lines, trailers,
-fenced blocks, indented examples, tables, URLs, block quotes, and list items are
-left untouched. The same formatter is available directly:
+Before validation, the hook canonicalizes ordinary prose paragraphs to 72
+columns in the proposed commit message and proceeds without a retry. Inline
+code spans remain indivisible. Subject lines, trailers, fenced blocks, indented
+examples, tables, URLs, block quotes, and list items are left untouched;
+overlong structured lines still require an explicit edit. The same formatter is
+available directly:
 
 ```bash
 python build_tools/lefthook/commit_msg.py --format .git/COMMIT_EDITMSG

--- a/build_tools/lefthook/commit_msg.py
+++ b/build_tools/lefthook/commit_msg.py
@@ -5,13 +5,12 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Validates Git commit message text."""
+"""Formats and validates Git commit message text."""
 
 from __future__ import annotations
 
 import argparse
 import re
-import shlex
 import subprocess
 import sys
 import textwrap
@@ -35,6 +34,7 @@ SUBJECT_TAG_PATTERN = re.compile(
 )
 AUTOSQUASH_SUBJECT_PREFIX_PATTERN = re.compile(r"^(?P<prefix>fixup|squash|amend)!\s+")
 CODE_FENCE_PATTERN = re.compile(r"^\s*(```|~~~)")
+INLINE_CODE_SPAN_PATTERN = re.compile(r"(?P<delimiter>`+)(?P<body>.*?)(?P=delimiter)")
 INDENTED_CODE_PATTERN = re.compile(r"^(?: {4,}|\t)")
 LIST_ITEM_PATTERN = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+")
 MARKDOWN_TABLE_PATTERN = re.compile(r"^\s*\|.*\|\s*$")
@@ -133,7 +133,6 @@ class CommitMessageDiagnostic:
     text: str
     hint: str = ""
     kind: str = "policy"
-    autofixable: bool = False
 
 
 def staged_commit_paths() -> list[str]:
@@ -247,6 +246,21 @@ def is_markdown_table_line(line: str) -> bool:
     return stripped.startswith("|") and stripped.endswith("|")
 
 
+def has_overlong_inline_code_token(line: str) -> bool:
+    """Returns whether an inline code span makes a word unwrappable."""
+
+    for match in INLINE_CODE_SPAN_PATTERN.finditer(line):
+        token_start = match.start()
+        while token_start > 0 and not line[token_start - 1].isspace():
+            token_start -= 1
+        token_end = match.end()
+        while token_end < len(line) and not line[token_end].isspace():
+            token_end += 1
+        if token_end - token_start > LINE_LENGTH_LIMIT:
+            return True
+    return False
+
+
 def is_line_length_exempt(line_number: int, line: str, trailer_lines: set[int]) -> bool:
     """Returns whether line length should be preserved instead of checked."""
 
@@ -255,6 +269,7 @@ def is_line_length_exempt(line_number: int, line: str, trailer_lines: set[int]) 
         or INDENTED_CODE_PATTERN.match(line) is not None
         or is_markdown_table_line(line)
         or URL_PATTERN.search(line) is not None
+        or has_overlong_inline_code_token(line)
     )
 
 
@@ -269,11 +284,73 @@ def is_reflowable_body_line(
         return False
     if is_line_length_exempt(line_number, line, trailer_lines):
         return False
+    if line[0].isspace():
+        return False
     if LIST_ITEM_PATTERN.match(line):
         return False
     if line.lstrip().startswith(">"):
         return False
     return True
+
+
+def protect_inline_code_whitespace(text: str) -> tuple[str, dict[str, str]]:
+    """Makes whitespace inside inline code spans indivisible while wrapping."""
+
+    used_characters = set(text)
+    whitespace_sentinels: dict[str, str] = {}
+    sentinel_replacements: dict[str, str] = {}
+    next_sentinel_codepoint = 0xE000
+
+    def sentinel_for(whitespace: str) -> str:
+        nonlocal next_sentinel_codepoint
+        sentinel = whitespace_sentinels.get(whitespace)
+        if sentinel is not None:
+            return sentinel
+        while (
+            next_sentinel_codepoint <= 0xF8FF
+            and chr(next_sentinel_codepoint) in used_characters
+        ):
+            next_sentinel_codepoint += 1
+        if next_sentinel_codepoint > 0xF8FF:
+            raise ValueError("commit message exhausts inline-code sentinels")
+        sentinel = chr(next_sentinel_codepoint)
+        next_sentinel_codepoint += 1
+        whitespace_sentinels[whitespace] = sentinel
+        sentinel_replacements[sentinel] = whitespace
+        return sentinel
+
+    protected_parts: list[str] = []
+    previous_end = 0
+    for match in INLINE_CODE_SPAN_PATTERN.finditer(text):
+        protected_parts.append(text[previous_end : match.start()])
+        protected_parts.append(
+            "".join(
+                sentinel_for(character) if character.isspace() else character
+                for character in match.group(0)
+            )
+        )
+        previous_end = match.end()
+    protected_parts.append(text[previous_end:])
+    return "".join(protected_parts), sentinel_replacements
+
+
+def wrap_prose_paragraph(paragraph_lines: Sequence[str]) -> list[str]:
+    """Wraps one prose paragraph without splitting inline code spans."""
+
+    paragraph_text = " ".join(line.strip() for line in paragraph_lines)
+    protected_text, sentinel_replacements = protect_inline_code_whitespace(
+        paragraph_text
+    )
+    wrapped_lines = textwrap.wrap(
+        protected_text,
+        width=LINE_LENGTH_LIMIT,
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [""]
+    if not sentinel_replacements:
+        return wrapped_lines
+    translation = str.maketrans(sentinel_replacements)
+    return [line.translate(translation) for line in wrapped_lines]
 
 
 def reflow_commit_message_text(message_text: str) -> str:
@@ -292,16 +369,7 @@ def reflow_commit_message_text(message_text: str) -> str:
     def flush_paragraph() -> None:
         if not paragraph_lines:
             return
-        paragraph_text = " ".join(line.strip() for line in paragraph_lines)
-        output_lines.extend(
-            textwrap.wrap(
-                paragraph_text,
-                width=LINE_LENGTH_LIMIT,
-                break_long_words=False,
-                break_on_hyphens=False,
-            )
-            or [""]
-        )
+        output_lines.extend(wrap_prose_paragraph(paragraph_lines))
         paragraph_lines.clear()
 
     for line_number, line in text_lines:
@@ -411,17 +479,6 @@ def validate_line_lengths(
         ):
             continue
         if len(line) > LINE_LENGTH_LIMIT:
-            is_autofixable = is_reflowable_body_line(line_number, line, trailer_lines)
-            hint = (
-                "Preserve the message content and reflow prose instead of "
-                "shortening, fragmenting, or rewriting it."
-            )
-            if not is_autofixable:
-                hint = (
-                    "Wrap this line manually. The prose reflow suggestion "
-                    "preserves structured lines such as lists, examples, and "
-                    "tables."
-                )
             diagnostics.append(
                 CommitMessageDiagnostic(
                     line_number=line_number,
@@ -430,9 +487,11 @@ def validate_line_lengths(
                         f"wrap prose to {LINE_LENGTH_LIMIT} columns"
                     ),
                     text=line,
-                    hint=hint,
+                    hint=(
+                        "Wrap this structured or unbreakable line manually; "
+                        "ordinary prose is reflowed automatically."
+                    ),
                     kind="line-length",
-                    autofixable=is_autofixable,
                 )
             )
     return diagnostics
@@ -502,18 +561,15 @@ def validate_commit_message_file(
     )
 
 
-def write_reflow_suggestion(message_file: Path, message_text: str) -> Path | None:
-    """Writes a reflowed message suggestion when it changes the user text."""
+def format_commit_message_file(message_file: Path) -> bool:
+    """Canonicalizes reflowable prose in a commit message file."""
 
+    message_text = message_file.read_text(encoding="utf-8")
     reflowed_text = reflow_commit_message_text(message_text)
     if reflowed_text == commit_message_user_text(message_text):
-        return None
-
-    suggestion_directory = REPO_ROOT / ".tmp" / "commit-msg"
-    suggestion_directory.mkdir(parents=True, exist_ok=True)
-    suggestion_path = suggestion_directory / f"{message_file.name}.reflowed"
-    suggestion_path.write_text(reflowed_text, encoding="utf-8")
-    return suggestion_path
+        return False
+    message_file.write_text(reflowed_text, encoding="utf-8")
+    return True
 
 
 def parse_arguments(argv: list[str]) -> argparse.Namespace:
@@ -541,6 +597,12 @@ def main(argv: list[str]) -> int:
         print(reflow_commit_message_text(message_text), end="")
         return 0
 
+    if format_commit_message_file(args.message_file):
+        print(
+            f"[fix] Reflowed commit-message prose to {LINE_LENGTH_LIMIT} columns.",
+            file=sys.stderr,
+        )
+
     diagnostics = validate_commit_message_file(
         args.message_file,
         changed_paths=staged_commit_paths(),
@@ -552,26 +614,10 @@ def main(argv: list[str]) -> int:
     if any(diagnostic.kind == "line-length" for diagnostic in diagnostics):
         print("", file=sys.stderr)
         print(
-            f"commit message body lines must be wrapped to {LINE_LENGTH_LIMIT} columns.",
+            "Structured and unbreakable commit-message body lines must be "
+            f"wrapped to {LINE_LENGTH_LIMIT} columns.",
             file=sys.stderr,
         )
-        print(
-            "Preserve the message content and reflow the prose instead of "
-            "shortening, fragmenting, or rewriting it.",
-            file=sys.stderr,
-        )
-        print("", file=sys.stderr)
-        print("Example:", file=sys.stderr)
-        print(
-            "  Before: This is a useful commit-message paragraph that is too "
-            "long for the Git log body width.",
-            file=sys.stderr,
-        )
-        print(
-            "  After:  This is a useful commit-message paragraph that is too",
-            file=sys.stderr,
-        )
-        print("          long for the Git log body width.", file=sys.stderr)
         print("", file=sys.stderr)
 
     for diagnostic in diagnostics:
@@ -582,37 +628,6 @@ def main(argv: list[str]) -> int:
         )
         if diagnostic.hint:
             print(f"    hint: {diagnostic.hint}", file=sys.stderr)
-
-    if any(diagnostic.kind == "line-length" for diagnostic in diagnostics):
-        suggestion_path = write_reflow_suggestion(args.message_file, message_text)
-        if suggestion_path is not None:
-            relative_suggestion_path = suggestion_path.relative_to(REPO_ROOT)
-            print("", file=sys.stderr)
-            print(
-                f"Suggested prose-only reflow written to {relative_suggestion_path}.",
-                file=sys.stderr,
-            )
-            print("Retry a normal commit with:", file=sys.stderr)
-            print(
-                f"  git commit -F {shlex.quote(str(relative_suggestion_path))}",
-                file=sys.stderr,
-            )
-            if any(
-                diagnostic.kind == "line-length" and not diagnostic.autofixable
-                for diagnostic in diagnostics
-            ):
-                print(
-                    "Some long lines were preserved because they look "
-                    "structured; wrap those diagnostics manually before "
-                    "retrying.",
-                    file=sys.stderr,
-                )
-            print(
-                "For amend, squash, or fixup commits, rerun the same git "
-                "commit command and replace the message source with that -F "
-                "argument.",
-                file=sys.stderr,
-            )
     return 1
 
 

--- a/build_tools/lefthook/commit_msg_test.py
+++ b/build_tools/lefthook/commit_msg_test.py
@@ -7,10 +7,12 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 COMMIT_MSG_PATH = Path(__file__).with_name("commit_msg.py")
 COMMIT_MSG_SPEC = importlib.util.spec_from_file_location("commit_msg", COMMIT_MSG_PATH)
@@ -182,7 +184,6 @@ class CommitMessageTest(unittest.TestCase):
                 "wrap prose to 72 columns"
             ],
         )
-        self.assertEqual([diagnostic.autofixable for diagnostic in diagnostics], [True])
 
     def test_allows_long_lines_inside_code_blocks(self):
         long_line = "x" * 120
@@ -229,9 +230,6 @@ class CommitMessageTest(unittest.TestCase):
                 "wrap prose to 72 columns"
             ],
         )
-        self.assertEqual(
-            [diagnostic.autofixable for diagnostic in diagnostics], [False]
-        )
 
     def test_reflows_ordinary_body_paragraphs(self):
         self.assertEqual(
@@ -254,6 +252,7 @@ class CommitMessageTest(unittest.TestCase):
         )
         long_url = "See https://example.com/" + "x" * 90
         long_code = "    git commit -m " + "x" * 90
+        indented_continuation = "  " + "continued list detail " * 5
         long_trailer = "Change-Id: " + "x" * 90
         message = (
             "[Infra] Subject\n"
@@ -264,39 +263,87 @@ class CommitMessageTest(unittest.TestCase):
             f"{'x' * 90}\n"
             "```\n"
             f"{long_code}\n"
+            f"{indented_continuation}\n"
             "\n"
             f"{long_trailer}\n"
         )
 
         self.assertEqual(commit_msg.reflow_commit_message_text(message), message)
 
-    def test_writes_reflow_suggestion(self):
+    def test_reflow_keeps_inline_code_spans_indivisible(self):
+        inline_code = "`dev.py cmake setup --venv`"
         message = (
             "[Infra] Subject\n"
             "\n"
-            "This body paragraph is intentionally long enough to require "
+            "Use the configured developer environment before invoking "
+            f"{inline_code} on every host.\n"
+        )
+
+        reflowed_message = commit_msg.reflow_commit_message_text(message)
+
+        self.assertIn(inline_code, reflowed_message)
+        self.assertTrue(
+            all(
+                len(line) <= commit_msg.LINE_LENGTH_LIMIT
+                for line in reflowed_message.splitlines()
+            )
+        )
+
+    def test_allows_unbreakable_inline_code_tokens(self):
+        inline_code = "`" + "command " + "--argument " * 8 + "value`"
+        message = f"[Infra] Subject\n\nRun {inline_code} exactly.\n"
+
+        reflowed_message = commit_msg.reflow_commit_message_text(message)
+
+        self.assertIn(inline_code, reflowed_message)
+        self.assertEqual(commit_msg.validate_commit_message_text(reflowed_message), [])
+
+    def test_main_reflows_commit_message_before_validation(self):
+        message = (
+            "[Infra] Subject\n"
+            "\n"
+            "This body paragraph is intentionally long enough to require\n"
             "wrapping while preserving all words in the original order.\n"
         )
         with tempfile.TemporaryDirectory() as temporary_directory:
-            old_repo_root = commit_msg.REPO_ROOT
-            commit_msg.REPO_ROOT = Path(temporary_directory)
-            try:
-                suggestion_path = commit_msg.write_reflow_suggestion(
-                    Path("COMMIT_EDITMSG"),
-                    message,
-                )
-            finally:
-                commit_msg.REPO_ROOT = old_repo_root
+            message_path = Path(temporary_directory) / "COMMIT_EDITMSG"
+            message_path.write_text(message, encoding="utf-8")
+            stderr = io.StringIO()
+            with (
+                mock.patch.object(commit_msg, "staged_commit_paths", return_value=[]),
+                mock.patch.object(commit_msg.sys, "stderr", stderr),
+            ):
+                returncode = commit_msg.main([str(message_path)])
 
-            self.assertIsNotNone(suggestion_path)
-            assert suggestion_path is not None
+            self.assertEqual(returncode, 0)
+            self.assertIn("[fix] Reflowed commit-message prose", stderr.getvalue())
             self.assertEqual(
-                suggestion_path.read_text(encoding="utf-8"),
+                message_path.read_text(encoding="utf-8"),
                 "[Infra] Subject\n"
                 "\n"
                 "This body paragraph is intentionally long enough to require wrapping\n"
                 "while preserving all words in the original order.\n",
             )
+
+    def test_main_preserves_and_rejects_overlong_structured_lines(self):
+        long_bullet = (
+            "- This bullet list item is intentionally too long for the commit "
+            "message body width."
+        )
+        message = f"[Infra] Subject\n\n{long_bullet}\n"
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            message_path = Path(temporary_directory) / "COMMIT_EDITMSG"
+            message_path.write_text(message, encoding="utf-8")
+            stderr = io.StringIO()
+            with (
+                mock.patch.object(commit_msg, "staged_commit_paths", return_value=[]),
+                mock.patch.object(commit_msg.sys, "stderr", stderr),
+            ):
+                returncode = commit_msg.main([str(message_path)])
+
+            self.assertEqual(returncode, 1)
+            self.assertEqual(message_path.read_text(encoding="utf-8"), message)
+            self.assertIn("structured or unbreakable line", stderr.getvalue())
 
     def test_ranks_tag_suggestions_from_paths(self):
         self.assertEqual(


### PR DESCRIPTION
Remove two avoidable periods of uncertainty from the local developer workflow. Commit-message formatting now completes in the original Git invocation, and CMake builds identify their execution context before entering a potentially long backend operation.

The commit-message hook canonicalizes ordinary prose directly in `COMMIT_EDITMSG` before applying policy checks. It keeps inline code spans indivisible and preserves fenced blocks, indented examples, tables, URLs, block quotes, list items, and trailers. Structured text that exceeds the policy width still fails for an explicit human edit; prose that can be handled mechanically no longer generates a scratch message and asks the caller to retry.

CMake build commands now print one flushed status line naming the resolved targets, configured generator, and selected build tree before launching `cmake --build`. Command steps remain quiet by default, and verbose mode remains the only mode that prints the full command. This exposes accidental serial generators or stale build-tree selection immediately without intercepting child output or manufacturing heartbeat progress.
