### PR TITLE
[Infra] Define repository code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Default ownership for every path not assigned to a subsystem below.
+* @ROCm/hrx-system-leads
+
+# Subsystem ownership. The last matching pattern wins for each file.
+/libhrx/ @ROCm/libhrx-leads
+/loom/ @ROCm/loom-leads
+/runtime/ @ROCm/runtime-leads
+
+# Explicit high-signal restatements of the default ownership policy.
+/build_tools/ @ROCm/hrx-system-leads
+/.github/ @ROCm/hrx-system-leads


### PR DESCRIPTION
Routes code-review requests through stable lead-team identities so ownership changes happen through team membership instead of policy-file churn.

- `hrx-system-leads` owns repository-wide paths by default, including build infrastructure and repository policy.
- `loom-leads` and `runtime-leads` own their corresponding subsystem trees.
- `libhrx-leads` replaces the default owner within `libhrx/`, keeping libhrx-only reviews with Andrew.

Merge enforcement is intentionally separate from assignment. Three path-specific repository rulesets are installed in Evaluate mode for `loom/**`, `runtime/**`, and `.github/CODEOWNERS`; they record would-be violations without blocking merges. Each lead team has a pull-request-only bypass in its own ruleset so lead-authored changes retain a PR and audit trail without pretending that authors can approve themselves.
