### PR TITLE
[Infra] Repair CODEOWNERS team handles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,8 +3,8 @@
 
 # Subsystem ownership. The last matching pattern wins for each file.
 /libhrx/ @ROCm/libhrx-leads
-/loom/ @ROCm/loom-leads
-/runtime/ @ROCm/runtime-leads
+/loom/ @ROCm/hrx-loom-leads
+/runtime/ @ROCm/hrx-runtime-leads
 
 # Explicit high-signal restatements of the default ownership policy.
 /build_tools/ @ROCm/hrx-system-leads


### PR DESCRIPTION
Updates the Loom and Runtime CODEOWNERS entries to match their renamed HRX-prefixed team handles, restoring automatic review requests for both subsystem trees.

The System and libhrx handles are unchanged. Ruleset reviewers and bypass actors continue to use stable team IDs and require no updates.
