### PR TITLE
[Loom] Encode cooperative matrix strides in elements

### DIFF
--- a/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows.py
+++ b/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows.py
@@ -201,7 +201,7 @@ class _PacketRow:
     memory_scope: str | None = None
     memory_semantics: str | None = None
     cooperative_matrix_layout: str | None = None
-    cooperative_matrix_stride: int = 0
+    cooperative_matrix_element_stride: int = 0
     cooperative_matrix_operands: str | None = None
 
     def encoded_operand_types(self) -> tuple[str, ...]:
@@ -248,8 +248,8 @@ class _PacketRow:
             lines.append(f"            .payload.barrier.memory_semantics = {self.memory_semantics},")
         if self.cooperative_matrix_layout is not None:
             lines.append(f"            .payload.cooperative_matrix.layout = {self.cooperative_matrix_layout},")
-        if self.cooperative_matrix_stride:
-            lines.append(f"            .payload.cooperative_matrix.stride = {self.cooperative_matrix_stride},")
+        if self.cooperative_matrix_element_stride:
+            lines.append(f"            .payload.cooperative_matrix.element_stride = {self.cooperative_matrix_element_stride},")
         if self.cooperative_matrix_operands is not None:
             lines.append(f"            .payload.cooperative_matrix.operands = {self.cooperative_matrix_operands},")
         lines.append("        },")
@@ -388,10 +388,6 @@ def _workgroup_rows() -> list[_PacketRow]:
     return rows
 
 
-def _row_byte_stride(columns: int, scalar: StorageBufferScalar) -> int:
-    return columns * scalar.byte_width
-
-
 def _cooperative_matrix_rows_for_case(case: CooperativeMatrixCase) -> list[_PacketRow]:
     lhs_scalar = case.lhs_scalar
     rhs_scalar = case.rhs_scalar
@@ -422,10 +418,10 @@ def _cooperative_matrix_rows_for_case(case: CooperativeMatrixCase) -> list[_Pack
         matrix_use="LOOM_SPIRV_COOPERATIVE_MATRIX_USE_MATRIX_ACCUMULATOR_KHR",
     )
     row_major_layout = "LOOM_SPIRV_COOPERATIVE_MATRIX_LAYOUT_ROW_MAJOR_KHR"
-    lhs_stride = _row_byte_stride(case.lhs_columns, lhs_scalar)
-    rhs_stride = _row_byte_stride(case.rhs_columns, rhs_scalar)
-    accumulator_stride = _row_byte_stride(case.accumulator_columns, accumulator_scalar)
-    result_stride = _row_byte_stride(case.accumulator_columns, result_scalar)
+    lhs_element_stride = case.lhs_columns
+    rhs_element_stride = case.rhs_columns
+    accumulator_element_stride = case.accumulator_columns
+    result_element_stride = case.accumulator_columns
     return [
         _PacketRow(
             case.descriptor_key(
@@ -440,7 +436,7 @@ def _cooperative_matrix_rows_for_case(case: CooperativeMatrixCase) -> list[_Pack
             result_count=1,
             memory_alignment=16,
             cooperative_matrix_layout=row_major_layout,
-            cooperative_matrix_stride=lhs_stride,
+            cooperative_matrix_element_stride=lhs_element_stride,
         ),
         _PacketRow(
             case.descriptor_key(
@@ -455,7 +451,7 @@ def _cooperative_matrix_rows_for_case(case: CooperativeMatrixCase) -> list[_Pack
             result_count=1,
             memory_alignment=16,
             cooperative_matrix_layout=row_major_layout,
-            cooperative_matrix_stride=rhs_stride,
+            cooperative_matrix_element_stride=rhs_element_stride,
         ),
         _PacketRow(
             case.descriptor_key(
@@ -470,7 +466,7 @@ def _cooperative_matrix_rows_for_case(case: CooperativeMatrixCase) -> list[_Pack
             result_count=1,
             memory_alignment=16,
             cooperative_matrix_layout=row_major_layout,
-            cooperative_matrix_stride=accumulator_stride,
+            cooperative_matrix_element_stride=accumulator_element_stride,
         ),
         _PacketRow(
             case.descriptor_key(
@@ -499,7 +495,7 @@ def _cooperative_matrix_rows_for_case(case: CooperativeMatrixCase) -> list[_Pack
             ),
             memory_alignment=16,
             cooperative_matrix_layout=row_major_layout,
-            cooperative_matrix_stride=result_stride,
+            cooperative_matrix_element_stride=result_element_stride,
         ),
     ]
 

--- a/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows_test.py
+++ b/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows_test.py
@@ -234,7 +234,7 @@ def test_generation_emits_complete_float_constant_packet_rows() -> None:
         assert descriptor.feature_mask_words == ((scalar.feature_bits,) if scalar.feature_bits else ())
 
 
-def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
+def test_generation_uses_element_strides_for_cooperative_matrix_rows() -> None:
     f16_lhs = _packet_row(
         _cooperative_matrix_descriptor(
             "op_cooperative_matrix_load_khr",
@@ -265,9 +265,9 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    assert f16_lhs.cooperative_matrix_stride == 32
-    assert f16_init.cooperative_matrix_stride == 64
-    assert f16_store.cooperative_matrix_stride == 64
+    assert f16_lhs.cooperative_matrix_element_stride == 16
+    assert f16_init.cooperative_matrix_element_stride == 16
+    assert f16_store.cooperative_matrix_element_stride == 16
 
     bf16_rhs = _packet_row(
         _cooperative_matrix_descriptor(
@@ -279,7 +279,7 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    assert bf16_rhs.cooperative_matrix_stride == 32
+    assert bf16_rhs.cooperative_matrix_element_stride == 16
 
     s8_lhs = _packet_row(
         _cooperative_matrix_descriptor(
@@ -311,9 +311,9 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
             layout="row_major",
         ),
     )
-    assert s8_lhs.cooperative_matrix_stride == 32
-    assert s8_rhs.cooperative_matrix_stride == 16
-    assert s8_store.cooperative_matrix_stride == 64
+    assert s8_lhs.cooperative_matrix_element_stride == 32
+    assert s8_rhs.cooperative_matrix_element_stride == 16
+    assert s8_store.cooperative_matrix_element_stride == 16
 
     u8_lhs = _packet_row(
         _cooperative_matrix_descriptor(
@@ -337,8 +337,8 @@ def test_generation_uses_byte_strides_for_cooperative_matrix_rows() -> None:
     )
     assert "LOOM_SPIRV_SCALAR_TYPE_U8" in u8_lhs.result_type
     assert "LOOM_SPIRV_SCALAR_TYPE_U32" in u8_store.operand_types[1]
-    assert u8_lhs.cooperative_matrix_stride == 32
-    assert u8_store.cooperative_matrix_stride == 64
+    assert u8_lhs.cooperative_matrix_element_stride == 32
+    assert u8_store.cooperative_matrix_element_stride == 16
 
 
 def test_generation_offsets_storage_buffer_address_before_pointer_conversion() -> None:

--- a/loom/src/loom/target/arch/spirv/packet_rows.h
+++ b/loom/src/loom/target/arch/spirv/packet_rows.h
@@ -85,8 +85,8 @@ typedef struct loom_spirv_packet_row_t {
     struct {
       // Cooperative matrix layout literal for load/store rows.
       uint32_t layout;
-      // Cooperative matrix stride literal for load/store rows.
-      uint32_t stride;
+      // Row stride in elements of the load/store pointer's pointee type.
+      uint32_t element_stride;
       // Cooperative matrix operands mask literal for mul-add rows.
       uint32_t operands;
     } cooperative_matrix;

--- a/loom/src/loom/target/emit/spirv/function_emitter.c
+++ b/loom/src/loom/target/emit/spirv/function_emitter.c
@@ -806,9 +806,9 @@ static iree_status_t loom_spirv_emit_cooperative_matrix_layout_operands(
   IREE_RETURN_IF_ERROR(loom_spirv_emit_u32_constant(
       state->type_context, row->payload.cooperative_matrix.layout,
       out_layout_id));
-  return loom_spirv_emit_u32_constant(state->type_context,
-                                      row->payload.cooperative_matrix.stride,
-                                      out_stride_id);
+  return loom_spirv_emit_u32_constant(
+      state->type_context, row->payload.cooperative_matrix.element_stride,
+      out_stride_id);
 }
 
 static iree_status_t loom_spirv_emit_cooperative_matrix_load_packet(

--- a/loom/src/loom/target/emit/spirv/test/cooperative_matrix.loom-test
+++ b/loom/src/loom/target/emit/spirv/test/cooperative_matrix.loom-test
@@ -100,10 +100,8 @@ low.kernel.def target<spirv.logical.core>(@hal_target_coop_f16) workgroup_size(3
     %uint_16 = OpConstant %uint 16
      %uint_0 = OpConstant %uint 0
          %65 = OpTypeCooperativeMatrixKHR %half %uint_3 %uint_16 %uint_16 %uint_0
-    %uint_32 = OpConstant %uint 32
-         %68 = OpTypeCooperativeMatrixKHR %half %uint_3 %uint_16 %uint_16 %uint_1
-         %70 = OpTypeCooperativeMatrixKHR %float %uint_3 %uint_16 %uint_16 %uint_2_0
-    %uint_64 = OpConstant %uint 64
+         %67 = OpTypeCooperativeMatrixKHR %half %uint_3 %uint_16 %uint_16 %uint_1
+         %69 = OpTypeCooperativeMatrixKHR %float %uint_3 %uint_16 %uint_16 %uint_2_0
 %spirv_raw_bda_cooperative_matrix_f16 = OpFunction %void None %10
          %11 = OpLabel
          %16 = OpAccessChain %_ptr_PushConstant_uint %8 %int_6 %int_0
@@ -138,11 +136,11 @@ low.kernel.def target<spirv.logical.core>(@hal_target_coop_f16) workgroup_size(3
   %init_view = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_float %57
          %61 = OpIAdd %ulong %out_buffer %byte_offset
    %out_view = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_float %61
-        %lhs = OpCooperativeMatrixLoadKHR %65 %lhs_view %uint_0 %uint_32 Aligned 16
-        %rhs = OpCooperativeMatrixLoadKHR %68 %rhs_view %uint_0 %uint_32 Aligned 16
-       %init = OpCooperativeMatrixLoadKHR %70 %init_view %uint_0 %uint_64 Aligned 16
-     %result = OpCooperativeMatrixMulAddKHR %70 %lhs %rhs %init
-               OpCooperativeMatrixStoreKHR %out_view %result %uint_0 %uint_64 Aligned 16
+        %lhs = OpCooperativeMatrixLoadKHR %65 %lhs_view %uint_0 %uint_16 Aligned 16
+        %rhs = OpCooperativeMatrixLoadKHR %67 %rhs_view %uint_0 %uint_16 Aligned 16
+       %init = OpCooperativeMatrixLoadKHR %69 %init_view %uint_0 %uint_16 Aligned 16
+     %result = OpCooperativeMatrixMulAddKHR %69 %lhs %rhs %init
+               OpCooperativeMatrixStoreKHR %out_view %result %uint_0 %uint_16 Aligned 16
                OpReturn
                OpFunctionEnd
 
@@ -253,7 +251,6 @@ low.kernel.def target<spirv.logical.core>(@hal_target_coop_s8) workgroup_size(32
          %65 = OpTypeCooperativeMatrixKHR %char %uint_3 %uint_16 %uint_32 %uint_0
          %67 = OpTypeCooperativeMatrixKHR %char %uint_3 %uint_32 %uint_16 %uint_1
          %69 = OpTypeCooperativeMatrixKHR %int %uint_3 %uint_16 %uint_16 %uint_2_0
-    %uint_64 = OpConstant %uint 64
 %spirv_raw_bda_cooperative_matrix_s8_signed_saturating = OpFunction %void None %10
          %11 = OpLabel
          %16 = OpAccessChain %_ptr_PushConstant_uint %8 %int_6 %int_0
@@ -290,9 +287,9 @@ low.kernel.def target<spirv.logical.core>(@hal_target_coop_s8) workgroup_size(32
    %out_view = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_int %60
         %lhs = OpCooperativeMatrixLoadKHR %65 %lhs_view %uint_0 %uint_32 Aligned 16
         %rhs = OpCooperativeMatrixLoadKHR %67 %rhs_view %uint_0 %uint_16 Aligned 16
-       %init = OpCooperativeMatrixLoadKHR %69 %init_view %uint_0 %uint_64 Aligned 16
+       %init = OpCooperativeMatrixLoadKHR %69 %init_view %uint_0 %uint_16 Aligned 16
      %result = OpCooperativeMatrixMulAddKHR %69 %lhs %rhs %init MatrixASignedComponentsKHR|MatrixBSignedComponentsKHR|MatrixCSignedComponentsKHR|MatrixResultSignedComponentsKHR|SaturatingAccumulationKHR
-               OpCooperativeMatrixStoreKHR %out_view %result %uint_0 %uint_64 Aligned 16
+               OpCooperativeMatrixStoreKHR %out_view %result %uint_0 %uint_16 Aligned 16
                OpReturn
                OpFunctionEnd
 
@@ -403,7 +400,6 @@ low.kernel.def target<spirv.logical.core>(@hal_target_coop_u8) workgroup_size(32
          %65 = OpTypeCooperativeMatrixKHR %uchar %uint_3 %uint_16 %uint_32 %uint_0
          %67 = OpTypeCooperativeMatrixKHR %uchar %uint_3 %uint_32 %uint_16 %uint_1
          %69 = OpTypeCooperativeMatrixKHR %uint %uint_3 %uint_16 %uint_16 %uint_2_0
-    %uint_64 = OpConstant %uint 64
 %spirv_raw_bda_cooperative_matrix_u8 = OpFunction %void None %10
          %11 = OpLabel
          %16 = OpAccessChain %_ptr_PushConstant_uint %8 %int_6 %int_0
@@ -440,9 +436,9 @@ low.kernel.def target<spirv.logical.core>(@hal_target_coop_u8) workgroup_size(32
    %out_view = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_uint %60
         %lhs = OpCooperativeMatrixLoadKHR %65 %lhs_view %uint_0 %uint_32 Aligned 16
         %rhs = OpCooperativeMatrixLoadKHR %67 %rhs_view %uint_0 %uint_16 Aligned 16
-       %init = OpCooperativeMatrixLoadKHR %69 %init_view %uint_0 %uint_64 Aligned 16
+       %init = OpCooperativeMatrixLoadKHR %69 %init_view %uint_0 %uint_16 Aligned 16
      %result = OpCooperativeMatrixMulAddKHR %69 %lhs %rhs %init
-               OpCooperativeMatrixStoreKHR %out_view %result %uint_0 %uint_64 Aligned 16
+               OpCooperativeMatrixStoreKHR %out_view %result %uint_0 %uint_16 Aligned 16
                OpReturn
                OpFunctionEnd
 
@@ -553,10 +549,8 @@ low.kernel.def target<spirv.logical.core>(@hal_target_coop_bf16) workgroup_size(
     %uint_16 = OpConstant %uint 16
      %uint_0 = OpConstant %uint 0
          %65 = OpTypeCooperativeMatrixKHR %bfloat16 %uint_3 %uint_16 %uint_16 %uint_0
-    %uint_32 = OpConstant %uint 32
-         %68 = OpTypeCooperativeMatrixKHR %bfloat16 %uint_3 %uint_16 %uint_16 %uint_1
-         %70 = OpTypeCooperativeMatrixKHR %float %uint_3 %uint_16 %uint_16 %uint_2_0
-    %uint_64 = OpConstant %uint 64
+         %67 = OpTypeCooperativeMatrixKHR %bfloat16 %uint_3 %uint_16 %uint_16 %uint_1
+         %69 = OpTypeCooperativeMatrixKHR %float %uint_3 %uint_16 %uint_16 %uint_2_0
 %spirv_raw_bda_cooperative_matrix_bf16 = OpFunction %void None %10
          %11 = OpLabel
          %16 = OpAccessChain %_ptr_PushConstant_uint %8 %int_6 %int_0
@@ -591,10 +585,10 @@ low.kernel.def target<spirv.logical.core>(@hal_target_coop_bf16) workgroup_size(
   %init_view = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_float %57
          %61 = OpIAdd %ulong %out_buffer %byte_offset
    %out_view = OpConvertUToPtr %_ptr_PhysicalStorageBuffer_float %61
-        %lhs = OpCooperativeMatrixLoadKHR %65 %lhs_view %uint_0 %uint_32 Aligned 16
-        %rhs = OpCooperativeMatrixLoadKHR %68 %rhs_view %uint_0 %uint_32 Aligned 16
-       %init = OpCooperativeMatrixLoadKHR %70 %init_view %uint_0 %uint_64 Aligned 16
-     %result = OpCooperativeMatrixMulAddKHR %70 %lhs %rhs %init
-               OpCooperativeMatrixStoreKHR %out_view %result %uint_0 %uint_64 Aligned 16
+        %lhs = OpCooperativeMatrixLoadKHR %65 %lhs_view %uint_0 %uint_16 Aligned 16
+        %rhs = OpCooperativeMatrixLoadKHR %67 %rhs_view %uint_0 %uint_16 Aligned 16
+       %init = OpCooperativeMatrixLoadKHR %69 %init_view %uint_0 %uint_16 Aligned 16
+     %result = OpCooperativeMatrixMulAddKHR %69 %lhs %rhs %init
+               OpCooperativeMatrixStoreKHR %out_view %result %uint_0 %uint_16 Aligned 16
                OpReturn
                OpFunctionEnd


### PR DESCRIPTION
SPV_KHR_cooperative_matrix defines load and store strides in elements of the pointer pointee type. Loom instead emitted byte counts, causing f16/bf16 rows and every 32-bit accumulator/result row to skip memory; 8-bit input rows happened to mask the bug.

Encode each matrix row width directly in generated packet data and rename the checked-in packet field to `element_stride`, making the unit part of the C emitter contract. Updated emission expectations cover f16, bf16, s8, and u8 paths.

This completes the typed physical-storage pointer path enabled by #404: byte offsets are applied to raw addresses, while cooperative-matrix strides retain their independent pointee-element semantics.