### PR TITLE
[Loom] Teach concurrent kernel JIT scheduling

### DIFF
--- a/loom/binding/c/example/BUILD.bazel
+++ b/loom/binding/c/example/BUILD.bazel
@@ -69,11 +69,20 @@ iree_executable_test(
     src = ":link_modules",
 )
 
+iree_cmake_extra_content(
+    content = """
+if(IREE_TARGET_HAS_THREADS)
+""",
+    inline = True,
+)
+
 loom_cc_binary(
     name = "product_frontier",
     srcs = ["product_frontier.c"],
     deps = [
         "//loom/binding/c:loomc",
+        "//loom/binding/c:task_pool",
+        "//loom/binding/c:task_queue",
         "//loom/binding/c/target/cmd",
     ],
 )
@@ -81,13 +90,6 @@ loom_cc_binary(
 iree_executable_test(
     name = "product_frontier_test",
     src = ":product_frontier",
-)
-
-iree_cmake_extra_content(
-    content = """
-if(IREE_TARGET_HAS_THREADS)
-""",
-    inline = True,
 )
 
 loom_cc_binary(

--- a/loom/binding/c/example/CMakeLists.txt
+++ b/loom/binding/c/example/CMakeLists.txt
@@ -43,6 +43,8 @@ iree_native_test(
     ::link_modules
 )
 
+if(IREE_TARGET_HAS_THREADS)
+
 loom_cc_binary(
   NAME
     product_frontier
@@ -51,6 +53,8 @@ loom_cc_binary(
   DEPS
     loom::binding::c::loomc
     loom::binding::c::target::cmd
+    loom::binding::c::task_pool
+    loom::binding::c::task_queue
 )
 
 iree_native_test(
@@ -59,8 +63,6 @@ iree_native_test(
   SRC
     ::product_frontier
 )
-
-if(IREE_TARGET_HAS_THREADS)
 
 loom_cc_binary(
   NAME

--- a/loom/binding/c/example/product_frontier.c
+++ b/loom/binding/c/example/product_frontier.c
@@ -9,9 +9,28 @@
 
 #include "loomc/loomc.h"
 #include "loomc/target/cmd.h"
+#include "loomc/task.h"
+#include "loomc/task_pool.h"
+#include "loomc/task_queue.h"
 
 static const char kSourceText[] =
-    "kernel.def @local() {\n"
+    "kernel.def @load() {\n"
+    "  %one = index.constant 1 : index\n"
+    "  kernel.launch.config workgroups(%one, %one, %one) "
+    "workgroup_size(%one, %one, %one) : index\n"
+    "} launch(%storage: buffer) {\n"
+    "  kernel.return\n"
+    "}\n"
+    "\n"
+    "kernel.def @transform() {\n"
+    "  %one = index.constant 1 : index\n"
+    "  kernel.launch.config workgroups(%one, %one, %one) "
+    "workgroup_size(%one, %one, %one) : index\n"
+    "} launch(%storage: buffer) {\n"
+    "  kernel.return\n"
+    "}\n"
+    "\n"
+    "kernel.def @store() {\n"
     "  %one = index.constant 1 : index\n"
     "  kernel.launch.config workgroups(%one, %one, %one) "
     "workgroup_size(%one, %one, %one) : index\n"
@@ -23,42 +42,89 @@ static const char kSourceText[] =
     "\n"
     "command.program.def public @run() launch(%storage: buffer) {\n"
     "  %one = index.constant 1 : index\n"
-    "  kernel.launch @local(%storage) : (buffer)\n"
+    "  kernel.launch @load(%storage) : (buffer)\n"
+    "  kernel.launch @transform(%storage) : (buffer)\n"
+    "  kernel.launch @store(%storage) : (buffer)\n"
     "  kernel.dispatch @external[%one](%storage) : [index](buffer)\n"
     "  command.return\n"
     "}\n";
 
-typedef struct product_frontier_state_t {
-  // Allocator shared by every independently owned object in the example.
+enum {
+  KERNEL_COMPILE_CAPACITY = 3,
+  COMMAND_REQUIREMENT_CAPACITY = 4,
+};
+
+typedef struct kernel_compile_output_t {
+  // Immutable source request transferred by command construction.
+  loomc_request_t* request;
+
+  // Independently compiled child product.
+  loomc_product_t* product;
+
+  // Compiler diagnostics retained through batch inspection.
+  loomc_result_t* result;
+
+  // Infrastructure status produced by the compile task.
+  loomc_status_t status;
+} kernel_compile_output_t;
+
+typedef struct jit_scheduler_t {
+  // Allocator shared by process, task, and product storage.
   loomc_allocator_t allocator;
 
-  // Shared source and compiler context.
+  // Shared context for indexing and compilation.
   loomc_context_t* context;
 
-  // Invocation-local mutable compiler scratch.
-  loomc_workspace_t* workspace;
+  // Mutable scratch used only by command-product construction.
+  loomc_workspace_t* command_workspace;
 
-  // Immutable source indexed as the command and kernel provider universe.
+  // Immutable source containing the command and kernel catalog.
   loomc_source_t* source;
 
-  // Frozen provider index shared by command-product construction.
+  // Frozen source index reused by command-product builds.
   loomc_link_index_t* link_index;
 
-  // Prepared compiler used for independently published kernel requests.
+  // Prepared compiler shared by kernel compile tasks.
   loomc_compiler_t* compiler;
 
-  // Prepared kernel compilation pipeline.
+  // Prepared pipeline shared by kernel compile tasks.
   loomc_pass_program_t* pass_program;
 
-  // Parent command product retained through result inspection.
+  // Optional standard worker population used by this example.
+  loomc_task_pool_t* task_pool;
+
+  // Compilation scheduling domain attached to the standard pool.
+  loomc_task_queue_t* compile_queue;
+
+  // Scheduler-neutral destination used by the publication callback.
+  loomc_task_sink_t compile_sink;
+
+  // Mutable compiler scratch indexed by dense worker ordinal.
+  loomc_workspace_t** worker_workspaces;
+
+  // Number of initialized entries in `worker_workspaces`.
+  loomc_host_size_t worker_workspace_count;
+
+  // Parent command product retained until child bindings are inspected.
   loomc_product_t* command_product;
 
-  // Source-backed kernel request transferred by command construction.
-  loomc_request_t* kernel_request;
+  // Accepted kernel compilations in publication order.
+  kernel_compile_output_t kernel_compiles[KERNEL_COMPILE_CAPACITY];
 
-  // Independently compiled child kernel product.
-  loomc_product_t* kernel_product;
-} product_frontier_state_t;
+  // Number of initialized entries in `kernel_compiles`.
+  loomc_host_size_t kernel_compile_count;
+} jit_scheduler_t;
+
+typedef struct kernel_compile_task_t {
+  // Generic task base transferred to the accepting scheduler.
+  loomc_task_t base;
+
+  // Shared prepared state and worker-local workspace table.
+  jit_scheduler_t* scheduler;
+
+  // Caller-owned output that outlives task execution.
+  kernel_compile_output_t* output;
+} kernel_compile_task_t;
 
 static void print_status(loomc_status_t status) {
   char buffer[1024] = {0};
@@ -68,6 +134,7 @@ static void print_status(loomc_status_t status) {
 }
 
 static void print_result_diagnostics(const loomc_result_t* result) {
+  if (result == NULL) return;
   for (loomc_host_size_t i = 0; i < loomc_result_diagnostic_count(result);
        ++i) {
     const loomc_diagnostic_t* diagnostic =
@@ -84,7 +151,7 @@ static loomc_status_t require_successful_result(const loomc_result_t* result,
   if (result != NULL && loomc_result_succeeded(result)) {
     return loomc_ok_status();
   }
-  if (result != NULL) print_result_diagnostics(result);
+  print_result_diagnostics(result);
   return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION, message);
 }
 
@@ -94,224 +161,422 @@ static loomc_status_t require_condition(bool condition, const char* message) {
              : loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION, message);
 }
 
-static void product_frontier_state_initialize(product_frontier_state_t* state) {
-  memset(state, 0, sizeof(*state));
-  state->allocator = loomc_allocator_system();
+static void jit_scheduler_initialize(jit_scheduler_t* scheduler) {
+  memset(scheduler, 0, sizeof(*scheduler));
+  scheduler->allocator = loomc_allocator_system();
 }
 
-static void product_frontier_state_deinitialize(
-    product_frontier_state_t* state) {
-  loomc_product_release(state->kernel_product);
-  loomc_request_release(state->kernel_request);
-  loomc_product_release(state->command_product);
-  loomc_pass_program_release(state->pass_program);
-  loomc_compiler_release(state->compiler);
-  loomc_link_index_release(state->link_index);
-  loomc_source_release(state->source);
-  loomc_workspace_release(state->workspace);
-  loomc_context_release(state->context);
-}
-
-// --8<-- [start:publish-request]
-static loomc_status_t publish_kernel_request(void* user_data,
-                                             loomc_request_t* request) {
-  product_frontier_state_t* state = (product_frontier_state_t*)user_data;
-  if (state->kernel_request != NULL) {
-    loomc_request_release(request);
-    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
-                             "example published more than one kernel request");
+static void jit_scheduler_deinitialize(jit_scheduler_t* scheduler) {
+  // Drain tasks before releasing their output slots or worker workspaces.
+  loomc_task_queue_free(scheduler->compile_queue);
+  for (loomc_host_size_t i = 0; i < scheduler->kernel_compile_count; ++i) {
+    kernel_compile_output_t* output = &scheduler->kernel_compiles[i];
+    loomc_status_free(output->status);
+    loomc_result_release(output->result);
+    loomc_product_release(output->product);
+    loomc_request_release(output->request);
   }
-  // Ownership transfers at callback entry. A concurrent embedding would
-  // enqueue this reference and commit its parent binding only after the parent
-  // command operation succeeds.
-  state->kernel_request = request;
+  for (loomc_host_size_t i = 0; i < scheduler->worker_workspace_count; ++i) {
+    loomc_workspace_release(scheduler->worker_workspaces[i]);
+  }
+  loomc_allocator_free(scheduler->allocator, scheduler->worker_workspaces);
+  loomc_task_pool_free(scheduler->task_pool);
+  loomc_product_release(scheduler->command_product);
+  loomc_pass_program_release(scheduler->pass_program);
+  loomc_compiler_release(scheduler->compiler);
+  loomc_link_index_release(scheduler->link_index);
+  loomc_source_release(scheduler->source);
+  loomc_workspace_release(scheduler->command_workspace);
+  loomc_context_release(scheduler->context);
+}
+
+// --8<-- [start:compile-task]
+static void execute_kernel_compile_task(loomc_task_t* base_task,
+                                        loomc_host_size_t worker_ordinal) {
+  kernel_compile_task_t* task = (kernel_compile_task_t*)base_task;
+  jit_scheduler_t* scheduler = task->scheduler;
+  kernel_compile_output_t* output = task->output;
+  if (worker_ordinal >= scheduler->worker_workspace_count) {
+    output->status = loomc_make_status(
+        LOOMC_STATUS_OUT_OF_RANGE,
+        "scheduler supplied an invalid compiler worker ordinal");
+    return;
+  }
+
+  loomc_workspace_t* workspace = scheduler->worker_workspaces[worker_ordinal];
+  const loomc_compile_options_t options = {
+      .type = LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
+      .structure_size = sizeof(options),
+      .module_name = loomc_make_cstring_view("scheduled-kernel"),
+      .artifact_flags = LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_BYTECODE,
+  };
+  output->status = loomc_compile_request(
+      scheduler->compiler, workspace, scheduler->pass_program, output->request,
+      &options, scheduler->allocator, &output->product, &output->result);
+  loomc_workspace_trim(workspace);
+}
+
+static void destroy_kernel_compile_task(loomc_task_t* base_task) {
+  kernel_compile_task_t* task = (kernel_compile_task_t*)base_task;
+  loomc_allocator_free(task->scheduler->allocator, task);
+}
+
+static const loomc_task_vtable_t kKernelCompileTaskVtable = {
+    .execute = execute_kernel_compile_task,
+    .destroy = destroy_kernel_compile_task,
+};
+// --8<-- [end:compile-task]
+
+static loomc_status_t allocate_kernel_compile_task(
+    jit_scheduler_t* scheduler, kernel_compile_output_t* output,
+    loomc_task_t** out_task) {
+  *out_task = NULL;
+  kernel_compile_task_t* task = NULL;
+  loomc_status_t status = loomc_allocator_malloc(scheduler->allocator,
+                                                 sizeof(*task), (void**)&task);
+  if (loomc_status_is_ok(status)) {
+    loomc_task_initialize(&kKernelCompileTaskVtable, &task->base);
+    task->scheduler = scheduler;
+    task->output = output;
+    *out_task = &task->base;
+  }
+  return status;
+}
+
+// --8<-- [start:schedule-request]
+static loomc_status_t schedule_kernel_request(void* user_data,
+                                              loomc_request_t* request) {
+  jit_scheduler_t* scheduler = (jit_scheduler_t*)user_data;
+  if (loomc_request_product_descriptor(request) !=
+      loomc_compiled_module_product_descriptor()) {
+    loomc_request_release(request);
+    return loomc_make_status(LOOMC_STATUS_UNIMPLEMENTED,
+                             "no compiler route for published request");
+  }
+  if (scheduler->kernel_compile_count == KERNEL_COMPILE_CAPACITY) {
+    loomc_request_release(request);
+    return loomc_make_status(LOOMC_STATUS_RESOURCE_EXHAUSTED,
+                             "example kernel compile capacity exceeded");
+  }
+
+  kernel_compile_output_t* output =
+      &scheduler->kernel_compiles[scheduler->kernel_compile_count];
+  output->request = request;
+
+  loomc_task_t* task = NULL;
+  loomc_status_t status =
+      allocate_kernel_compile_task(scheduler, output, &task);
+  if (loomc_status_is_ok(status)) {
+    status = loomc_task_sink_submit(scheduler->compile_sink, task);
+  }
+  if (!loomc_status_is_ok(status)) {
+    if (task != NULL) loomc_task_destroy(task);
+    loomc_request_release(output->request);
+    memset(output, 0, sizeof(*output));
+    return status;
+  }
+
+  // The sink owns `task` after successful submission. An inline scheduler may
+  // already have executed and destroyed it, so only the output slot is used.
+  ++scheduler->kernel_compile_count;
   return loomc_ok_status();
 }
-// --8<-- [end:publish-request]
+// --8<-- [end:schedule-request]
 
-// --8<-- [start:prepare]
-static loomc_status_t prepare_product_frontier(
-    product_frontier_state_t* state, loomc_host_size_t* out_root_ordinal) {
-  *out_root_ordinal = 0;
+static loomc_status_t prepare_source_catalog(jit_scheduler_t* scheduler,
+                                             loomc_host_size_t* out_root) {
+  *out_root = 0;
   loomc_status_t status =
-      loomc_context_create(NULL, state->allocator, &state->context);
+      loomc_context_create(NULL, scheduler->allocator, &scheduler->context);
   if (loomc_status_is_ok(status)) {
-    status = loomc_workspace_create(NULL, state->allocator, &state->workspace);
+    status = loomc_workspace_create(NULL, scheduler->allocator,
+                                    &scheduler->command_workspace);
   }
 
   const loomc_source_options_t source_options = {
       .type = LOOMC_STRUCTURE_TYPE_SOURCE_OPTIONS,
       .structure_size = sizeof(source_options),
       .format = LOOMC_SOURCE_FORMAT_TEXT,
-      .identifier = loomc_make_cstring_view("product_frontier.loom"),
+      .identifier = loomc_make_cstring_view("scheduled_jit.loom"),
       .contents = loomc_make_byte_span(kSourceText, sizeof(kSourceText) - 1),
       .storage = LOOMC_SOURCE_STORAGE_BORROWED,
   };
   if (loomc_status_is_ok(status)) {
-    status =
-        loomc_source_create(&source_options, state->allocator, &state->source);
+    status = loomc_source_create(&source_options, scheduler->allocator,
+                                 &scheduler->source);
   }
 
   loomc_link_index_builder_t* builder = NULL;
   loomc_result_t* index_result = NULL;
   if (loomc_status_is_ok(status)) {
-    status = loomc_link_index_builder_create(state->context, NULL,
-                                             state->allocator, &builder);
+    status = loomc_link_index_builder_create(scheduler->context, NULL,
+                                             scheduler->allocator, &builder);
   }
   const loomc_link_index_source_options_t provider_options = {
-      .provider_name = loomc_make_cstring_view("product-frontier"),
+      .provider_name = loomc_make_cstring_view("scheduled-jit"),
       .role = LOOMC_LINK_PROVIDER_ROLE_INPUT,
   };
   if (loomc_status_is_ok(status)) {
-    status = loomc_link_index_builder_add_source(builder, state->source,
+    status = loomc_link_index_builder_add_source(builder, scheduler->source,
                                                  &provider_options, NULL);
   }
   if (loomc_status_is_ok(status)) {
-    status = loomc_link_index_builder_finish(builder, &state->link_index,
+    status = loomc_link_index_builder_finish(builder, &scheduler->link_index,
                                              &index_result);
   }
   if (loomc_status_is_ok(status)) {
-    status =
-        require_successful_result(index_result, "provider indexing failed");
+    status = require_successful_result(index_result, "source indexing failed");
   }
 
   loomc_link_index_symbol_t root_symbol = {0};
   if (loomc_status_is_ok(status) &&
-      !loomc_link_index_lookup_global(
-          state->link_index, loomc_make_cstring_view("run"), &root_symbol)) {
+      !loomc_link_index_lookup_global(scheduler->link_index,
+                                      loomc_make_cstring_view("run"),
+                                      &root_symbol)) {
     status = loomc_make_status(LOOMC_STATUS_NOT_FOUND,
                                "command root @run was not indexed");
   }
-  if (loomc_status_is_ok(status)) {
-    *out_root_ordinal = root_symbol.ordinal;
-    status = loomc_compiler_create(state->context, NULL, state->allocator,
-                                   &state->compiler);
-  }
+  if (loomc_status_is_ok(status)) *out_root = root_symbol.ordinal;
 
-  loomc_result_t* pass_result = NULL;
-  if (loomc_status_is_ok(status)) {
-    status = loomc_pass_program_create_from_pipeline_text(
-        state->context, loomc_make_cstring_view("canonicalize,cse"), NULL,
-        state->allocator, &state->pass_program, &pass_result);
-  }
-  if (loomc_status_is_ok(status)) {
-    status = require_successful_result(pass_result,
-                                       "kernel pipeline preparation failed");
-  }
-
-  loomc_result_release(pass_result);
   loomc_result_release(index_result);
   loomc_link_index_builder_release(builder);
   return status;
 }
-// --8<-- [end:prepare]
+
+// --8<-- [start:prepare-scheduler]
+static loomc_status_t prepare_compile_scheduler(jit_scheduler_t* scheduler) {
+  loomc_status_t status = loomc_compiler_create(
+      scheduler->context, NULL, scheduler->allocator, &scheduler->compiler);
+
+  loomc_result_t* pass_result = NULL;
+  if (loomc_status_is_ok(status)) {
+    status = loomc_pass_program_create_from_pipeline_text(
+        scheduler->context, loomc_make_cstring_view("canonicalize,cse"), NULL,
+        scheduler->allocator, &scheduler->pass_program, &pass_result);
+  }
+  if (loomc_status_is_ok(status)) {
+    status =
+        require_successful_result(pass_result, "pipeline preparation failed");
+  }
+  loomc_result_release(pass_result);
+
+  const loomc_task_pool_options_t pool_options = {
+      .type = LOOMC_STRUCTURE_TYPE_TASK_POOL_OPTIONS,
+      .structure_size = sizeof(pool_options),
+      .max_worker_count = 4,
+  };
+  if (loomc_status_is_ok(status)) {
+    status = loomc_task_pool_allocate(&pool_options, scheduler->allocator,
+                                      &scheduler->task_pool);
+  }
+  if (loomc_status_is_ok(status)) {
+    status = loomc_task_queue_allocate(
+        scheduler->task_pool, scheduler->allocator, &scheduler->compile_queue);
+  }
+  if (loomc_status_is_ok(status)) {
+    scheduler->compile_sink = loomc_task_queue_sink(scheduler->compile_queue);
+    scheduler->worker_workspace_count =
+        loomc_task_pool_worker_count(scheduler->task_pool);
+    status = require_condition(scheduler->worker_workspace_count != 0,
+                               "task pool created no workers");
+  }
+  if (loomc_status_is_ok(status)) {
+    status = loomc_allocator_malloc(scheduler->allocator,
+                                    scheduler->worker_workspace_count *
+                                        sizeof(*scheduler->worker_workspaces),
+                                    (void**)&scheduler->worker_workspaces);
+  }
+  loomc_host_size_t initialized_workspace_count = 0;
+  while (loomc_status_is_ok(status) &&
+         initialized_workspace_count < scheduler->worker_workspace_count) {
+    status = loomc_workspace_create(
+        NULL, scheduler->allocator,
+        &scheduler->worker_workspaces[initialized_workspace_count]);
+    if (loomc_status_is_ok(status)) ++initialized_workspace_count;
+  }
+  scheduler->worker_workspace_count = initialized_workspace_count;
+  return status;
+}
+// --8<-- [end:prepare-scheduler]
 
 // --8<-- [start:build-command]
-static loomc_status_t build_command_product(product_frontier_state_t* state,
+static loomc_status_t build_command_product(jit_scheduler_t* scheduler,
                                             loomc_host_size_t root_ordinal) {
   const loomc_cmd_program_product_options_t options = {
       .type = LOOMC_STRUCTURE_TYPE_CMD_PROGRAM_PRODUCT_OPTIONS,
       .structure_size = sizeof(options),
-      .link_index = state->link_index,
+      .link_index = scheduler->link_index,
       .root_symbol_ordinals = &root_ordinal,
       .root_symbol_count = 1,
       .request_sink =
           {
-              .publish = publish_kernel_request,
-              .user_data = state,
+              .publish = schedule_kernel_request,
+              .user_data = scheduler,
           },
   };
   loomc_result_t* result = NULL;
   loomc_status_t status = loomc_cmd_program_product_build(
-      state->workspace, &options, state->allocator, &state->command_product,
-      &result);
+      scheduler->command_workspace, &options, scheduler->allocator,
+      &scheduler->command_product, &result);
   if (loomc_status_is_ok(status)) {
-    status = require_successful_result(result,
-                                       "command-product construction failed");
+    status = require_successful_result(result, "command construction failed");
   }
   if (loomc_status_is_ok(status)) {
     status = require_condition(
-        loomc_cmd_program_product_program_count(state->command_product) == 1 &&
-            loomc_product_requirement_count(state->command_product) == 2 &&
-            state->kernel_request != NULL,
-        "command product does not expose the expected frontier");
+        loomc_cmd_program_product_program_count(scheduler->command_product) ==
+                1 &&
+            loomc_product_requirement_count(scheduler->command_product) ==
+                COMMAND_REQUIREMENT_CAPACITY &&
+            scheduler->kernel_compile_count == KERNEL_COMPILE_CAPACITY,
+        "command construction published an unexpected kernel set");
   }
   loomc_result_release(result);
   return status;
 }
 // --8<-- [end:build-command]
 
-// --8<-- [start:compile-request]
-static loomc_status_t compile_kernel_request(product_frontier_state_t* state) {
-  const loomc_compile_options_t options = {
-      .type = LOOMC_STRUCTURE_TYPE_COMPILE_OPTIONS,
-      .structure_size = sizeof(options),
-      .module_name = loomc_make_cstring_view("product-frontier-kernel"),
-      .artifact_flags = LOOMC_COMPILE_ARTIFACT_FLAG_MODULE_BYTECODE,
-  };
-  loomc_result_t* result = NULL;
-  loomc_status_t status = loomc_compile_request(
-      state->compiler, state->workspace, state->pass_program,
-      state->kernel_request, &options, state->allocator, &state->kernel_product,
-      &result);
+static loomc_status_t drain_compile_queue(jit_scheduler_t* scheduler) {
+  if (scheduler->compile_queue == NULL) return loomc_ok_status();
+  loomc_status_t status = loomc_task_queue_shutdown(scheduler->compile_queue);
   if (loomc_status_is_ok(status)) {
-    status =
-        require_successful_result(result, "kernel request compilation failed");
+    status = loomc_task_queue_await_shutdown(scheduler->compile_queue);
   }
-  const loomc_artifact_t* artifact = NULL;
-  if (loomc_status_is_ok(status)) {
-    artifact = loomc_product_artifact_at(state->kernel_product, 0);
-    status = require_condition(
-        loomc_product_descriptor(state->kernel_product) ==
-                loomc_compiled_module_product_descriptor() &&
-            loomc_product_export_count(state->kernel_product) == 1 &&
-            loomc_product_requirement_count(state->kernel_product) == 0 &&
-            artifact != NULL &&
-            loomc_string_view_equal(
-                artifact->format,
-                loomc_make_cstring_view(LOOMC_ARTIFACT_FORMAT_LOOM_BYTECODE)),
-        "kernel product does not satisfy the child request");
+  if (!loomc_status_is_ok(status)) {
+    // The void teardown operation still drains accepted tasks, making output
+    // storage safe to inspect before preserving the explicit shutdown error.
+    loomc_task_queue_free(scheduler->compile_queue);
+    scheduler->compile_queue = NULL;
   }
-  loomc_result_release(result);
+  scheduler->compile_sink = (loomc_task_sink_t){0};
   return status;
 }
-// --8<-- [end:compile-request]
 
-static loomc_status_t print_product_summary(
-    const product_frontier_state_t* state) {
-  loomc_cmd_program_t program = {0};
-  if (!loomc_cmd_program_product_program_at(state->command_product, 0,
-                                            &program)) {
-    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
-                             "command program metadata is unavailable");
+// --8<-- [start:bind-results]
+static loomc_status_t inspect_kernel_products(jit_scheduler_t* scheduler,
+                                              bool parent_succeeded) {
+  loomc_status_t status = loomc_ok_status();
+  bool resolved_requirements[COMMAND_REQUIREMENT_CAPACITY] = {false};
+  loomc_host_size_t resolved_requirement_count = 0;
+
+  for (loomc_host_size_t i = 0; i < scheduler->kernel_compile_count; ++i) {
+    kernel_compile_output_t* output = &scheduler->kernel_compiles[i];
+    const bool compile_call_succeeded = loomc_status_is_ok(output->status);
+    status = loomc_status_join(status, output->status);
+    output->status = loomc_ok_status();
+    if (!compile_call_succeeded) continue;
+
+    if (output->result == NULL || !loomc_result_succeeded(output->result)) {
+      print_result_diagnostics(output->result);
+      status = loomc_status_join(
+          status, loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                                    "a scheduled kernel failed compilation"));
+      continue;
+    }
+
+    const loomc_artifact_t* artifact =
+        loomc_product_artifact_at(output->product, 0);
+    const bool product_is_valid =
+        loomc_product_descriptor(output->product) ==
+            loomc_compiled_module_product_descriptor() &&
+        loomc_product_export_count(output->product) ==
+            loomc_request_root_count(output->request) &&
+        loomc_product_requirement_count(output->product) == 0 &&
+        loomc_product_artifact_count(output->product) == 1 &&
+        artifact != NULL &&
+        loomc_string_view_equal(
+            artifact->format,
+            loomc_make_cstring_view(LOOMC_ARTIFACT_FORMAT_LOOM_BYTECODE));
+    if (!product_is_valid) {
+      status = loomc_status_join(
+          status,
+          loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                            "a scheduled kernel returned a bad product"));
+      continue;
+    }
+
+    if (!parent_succeeded) continue;
+    const loomc_host_size_t binding_count =
+        loomc_request_binding_count(output->request);
+    for (loomc_host_size_t j = 0; j < binding_count; ++j) {
+      loomc_request_binding_t binding = {0};
+      const bool binding_is_valid =
+          loomc_request_binding_at(output->request, j, &binding) &&
+          binding.requirement_ordinal < COMMAND_REQUIREMENT_CAPACITY &&
+          binding.root_ordinal < loomc_product_export_count(output->product) &&
+          !resolved_requirements[binding.requirement_ordinal];
+      if (!binding_is_valid) {
+        status = loomc_status_join(
+            status,
+            loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                              "a kernel request returned an invalid binding"));
+        continue;
+      }
+      resolved_requirements[binding.requirement_ordinal] = true;
+      ++resolved_requirement_count;
+    }
   }
-  printf("command=%.*s programs=1 requirements=%zu kernel_products=1\n",
+
+  if (!parent_succeeded || !loomc_status_is_ok(status)) return status;
+
+  loomc_host_size_t external_requirement_count = 0;
+  for (loomc_host_size_t i = 0; i < COMMAND_REQUIREMENT_CAPACITY; ++i) {
+    if (resolved_requirements[i]) continue;
+    loomc_cmd_entry_requirement_t requirement = {0};
+    if (!loomc_cmd_program_product_entry_requirement_at(
+            scheduler->command_product, i, &requirement) ||
+        !loomc_string_view_equal(requirement.symbol,
+                                 loomc_make_cstring_view("external"))) {
+      return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                               "unexpected external kernel requirement");
+    }
+    ++external_requirement_count;
+  }
+
+  loomc_cmd_program_t program = {0};
+  if (!loomc_cmd_program_product_program_at(scheduler->command_product, 0,
+                                            &program) ||
+      resolved_requirement_count != KERNEL_COMPILE_CAPACITY ||
+      external_requirement_count != 1) {
+    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
+                             "kernel products do not satisfy the command");
+  }
+  printf("command=%.*s requirements=%zu compiled=%zu external=%zu\n",
          (int)program.symbol.size, program.symbol.data,
-         (size_t)loomc_product_requirement_count(state->command_product));
-  return loomc_ok_status();
+         (size_t)loomc_product_requirement_count(scheduler->command_product),
+         (size_t)resolved_requirement_count,
+         (size_t)external_requirement_count);
+  return status;
+}
+// --8<-- [end:bind-results]
+
+static loomc_status_t run_scheduled_jit_example(void) {
+  jit_scheduler_t scheduler;
+  jit_scheduler_initialize(&scheduler);
+
+  loomc_host_size_t root_ordinal = 0;
+  loomc_status_t status = prepare_source_catalog(&scheduler, &root_ordinal);
+  if (loomc_status_is_ok(status)) {
+    status = prepare_compile_scheduler(&scheduler);
+  }
+  if (loomc_status_is_ok(status)) {
+    status = build_command_product(&scheduler, root_ordinal);
+  }
+  const bool parent_succeeded = loomc_status_is_ok(status);
+
+  loomc_status_t drain_status = drain_compile_queue(&scheduler);
+  status = loomc_status_join(status, drain_status);
+  loomc_status_t product_status =
+      inspect_kernel_products(&scheduler, parent_succeeded);
+  status = loomc_status_join(status, product_status);
+
+  jit_scheduler_deinitialize(&scheduler);
+  return status;
 }
 
 int main(void) {
-  product_frontier_state_t state;
-  product_frontier_state_initialize(&state);
-
-  loomc_host_size_t root_ordinal = 0;
-  loomc_status_t status = prepare_product_frontier(&state, &root_ordinal);
-  if (loomc_status_is_ok(status)) {
-    status = build_command_product(&state, root_ordinal);
-  }
-  if (loomc_status_is_ok(status)) {
-    status = compile_kernel_request(&state);
-  }
-  if (loomc_status_is_ok(status)) {
-    status = print_product_summary(&state);
-  }
-
-  product_frontier_state_deinitialize(&state);
-  if (!loomc_status_is_ok(status)) {
-    print_status(status);
-    loomc_status_free(status);
-    return 1;
-  }
-  return 0;
+  loomc_status_t status = run_scheduled_jit_example();
+  if (loomc_status_is_ok(status)) return 0;
+  print_status(status);
+  loomc_status_free(status);
+  return 1;
 }

--- a/loom/binding/c/include/loomc/artifact.h
+++ b/loom/binding/c/include/loomc/artifact.h
@@ -117,6 +117,8 @@ LOOMC_API_EXPORT loomc_status_t loomc_artifact_create_source(
 ///
 /// @ownership
 /// The caller retains ownership of `file`; this function does not close it.
+/// On Windows the underlying file descriptor is switched to binary mode and
+/// remains in that mode so artifact bytes are not newline-translated.
 LOOMC_API_EXPORT loomc_status_t
 loomc_artifact_write_to_file(const loomc_artifact_t* artifact, FILE* file);
 

--- a/loom/binding/c/src/artifact.c
+++ b/loom/binding/c/src/artifact.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 
 #include "iree/io/stdio_stream.h"
+#include "iree/io/stdio_util.h"
 #include "iree/io/stream.h"
 #include "loomc/iree.h"
 #include "source.h"
@@ -130,6 +131,16 @@ loomc_status_t loomc_artifact_write_to_file(const loomc_artifact_t* artifact,
                              "artifact and file must not be NULL");
   }
   LOOMC_RETURN_IF_ERROR(loomc_artifact_validate_contents(artifact->contents));
+  // The Windows CRT defaults stdout and text-opened files to newline
+  // translation. Artifacts are byte sequences even when their format is text.
+#if defined(IREE_PLATFORM_WINDOWS)
+  if (fflush(file) != 0 || IREE_IO_SET_BINARY_MODE(file) == -1) {
+    return loomc_make_status(LOOMC_STATUS_UNKNOWN,
+                             "failed to set artifact file to binary mode");
+  }
+#else
+  IREE_IO_SET_BINARY_MODE(file);
+#endif  // IREE_PLATFORM_WINDOWS
   return loomc_byte_sequence_enumerate(
       artifact->contents, (loomc_byte_sequence_callback_t){
                               .fn = loomc_artifact_write_file_segment,

--- a/loom/binding/c/test/artifact_test.cc
+++ b/loom/binding/c/test/artifact_test.cc
@@ -128,12 +128,13 @@ TEST(ArtifactTest, CreateSourceRetainsContiguousBytesAndInfersFormat) {
   EXPECT_EQ(loomc_source_contents(source_ptr.get()).data, artifact_span.data);
 }
 
-TEST(ArtifactTest, WriteToOpenFile) {
+TEST(ArtifactTest, WriteToTextModeFilePreservesArtifactBytes) {
   loomc_byte_sequence_t* contents = nullptr;
   loomc_artifact_t artifact = MakeTextModuleArtifact(&contents);
   HandlePtr<loomc_byte_sequence_t, loomc_byte_sequence_release> contents_owner(
       contents);
-  FILE* file = tmpfile();
+  iree::testing::TempFilePath path("loomc_artifact_text_stream", ".loom");
+  FILE* file = fopen(path.path().c_str(), "w+");
   ASSERT_NE(file, nullptr);
 
   loomc_status_t status = loomc_artifact_write_to_file(&artifact, file);
@@ -143,6 +144,7 @@ TEST(ArtifactTest, WriteToOpenFile) {
             std::vector<uint8_t>(expected.begin(), expected.end()));
 
   EXPECT_EQ(fclose(file), 0);
+  EXPECT_TRUE(path.Remove());
 }
 
 TEST(ArtifactTest, WriteToPath) {

--- a/loom/docs/examples/integration/product-frontier/.doc-generate.sh
+++ b/loom/docs/examples/integration/product-frontier/.doc-generate.sh
@@ -5,8 +5,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Runs the public product-frontier example and stages its source and checked
-# output for MkDocs.
+# Runs the public scheduled-JIT example and stages its source and checked output
+# for MkDocs.
 
 set -euo pipefail
 
@@ -49,7 +49,7 @@ trap cleanup EXIT
 
 summary_output="${temporary_root}/summary.txt"
 "${product_frontier}" >"${summary_output}"
-expected_summary='command=run programs=1 requirements=2 kernel_products=1'
+expected_summary='command=run requirements=4 compiled=3 external=1'
 actual_summary="$(<"${summary_output}")"
 if [[ "${actual_summary}" != "${expected_summary}" ]]; then
   printf 'unexpected product-frontier summary:\n%s\n' "${actual_summary}" >&2

--- a/loom/docs/hooks/prepare.py
+++ b/loom/docs/hooks/prepare.py
@@ -33,6 +33,32 @@ from loom.gen.docs.reference import (  # noqa: E402
 )
 
 
+def _script_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    python_bin_dir = str(Path(sys.executable).parent)
+    environment["PATH"] = python_bin_dir + os.pathsep + environment.get("PATH", "")
+    if os.name == "nt":
+        # POSIX build wrappers honor this override instead of resolving the
+        # Windows Store's python3 application alias from Git Bash.
+        environment["PYTHON"] = sys.executable
+    return environment
+
+
+def _script_command(
+    script: Path, arguments: list[str], environment: dict[str, str]
+) -> list[str]:
+    command = [str(script), *arguments]
+    if os.name != "nt":
+        return command
+    shell = environment.get("BAZEL_SH")
+    if not shell:
+        raise RuntimeError(
+            "BAZEL_SH is required to run documentation generators on Windows; "
+            "invoke the documented `python dev.py docs ...` entry point"
+        )
+    return [shell, *command]
+
+
 def _work_root() -> Path:
     configured_root = Path(os.environ.get("LOOM_DOCS_WORK_DIR", DEFAULT_WORK_ROOT))
     if not configured_root.is_absolute():
@@ -65,15 +91,14 @@ def _remove_generated_directory(path: Path) -> None:
 def _generate_c_api(work_root: Path) -> Path:
     output_root = work_root / "c-api"
     _remove_generated_directory(output_root)
-    environment = os.environ.copy()
-    python_bin_dir = str(Path(sys.executable).parent)
-    environment["PATH"] = python_bin_dir + os.pathsep + environment.get("PATH", "")
+    environment = _script_environment()
+    print("Generating Loom C API reference...", flush=True)
     subprocess.run(
-        [
-            str(C_API_GENERATOR),
-            "--check",
-            f"--output={output_root}",
-        ],
+        _script_command(
+            C_API_GENERATOR,
+            ["--check", f"--output={output_root}"],
+            environment,
+        ),
         cwd=REPO_ROOT,
         env=environment,
         check=True,
@@ -89,15 +114,17 @@ def _generate_example_outputs(work_root: Path) -> Path:
     _remove_generated_directory(output_root)
     output_root.mkdir(parents=True)
 
-    environment = os.environ.copy()
-    python_bin_dir = str(Path(sys.executable).parent)
-    environment["PATH"] = python_bin_dir + os.pathsep + environment.get("PATH", "")
+    environment = _script_environment()
     for generator in sorted(EXAMPLE_SOURCE_ROOT.rglob(DOC_GENERATOR_NAME)):
         relative_package = generator.parent.relative_to(EXAMPLE_SOURCE_ROOT)
         package_output_root = output_root / relative_package
         package_output_root.mkdir(parents=True)
+        print(
+            f"Generating documentation example {relative_package.as_posix()}...",
+            flush=True,
+        )
         subprocess.run(
-            [str(generator), str(package_output_root)],
+            _script_command(generator, [str(package_output_root)], environment),
             cwd=REPO_ROOT,
             env=environment,
             check=True,

--- a/loom/docs/hooks/prepare_test.py
+++ b/loom/docs/hooks/prepare_test.py
@@ -68,21 +68,23 @@ class PrepareTest(unittest.TestCase):
 
             with (
                 mock.patch.object(prepare, "EXAMPLE_SOURCE_ROOT", example_root),
+                mock.patch.dict(prepare.os.environ, {"BAZEL_SH": "test-bash"}),
                 mock.patch.object(prepare.subprocess, "run") as run,
             ):
                 output_root = prepare._generate_example_outputs(work_root)
 
             self.assertEqual(output_root, work_root / "examples")
             self.assertFalse(stale_output.exists())
+            self.assertEqual(len(run.call_args_list), 2)
             self.assertEqual(
-                [call.args[0] for call in run.call_args_list],
-                [
-                    [str(first_generator), str(output_root / "alpha")],
-                    [
-                        str(second_generator),
-                        str(output_root / "nested" / "beta"),
-                    ],
-                ],
+                {
+                    (Path(call.args[0][-2]), Path(call.args[0][-1]))
+                    for call in run.call_args_list
+                },
+                {
+                    (first_generator, output_root / "alpha"),
+                    (second_generator, output_root / "nested" / "beta"),
+                },
             )
             for call in run.call_args_list:
                 self.assertEqual(call.kwargs["cwd"], prepare.REPO_ROOT)

--- a/loom/docs/mkdocs.yml
+++ b/loom/docs/mkdocs.yml
@@ -81,7 +81,7 @@ nav:
       - Agent-driven kernel development: workflows/agent-driven-kernel-development.md
       - Format and verify source: workflows/format-and-verify.md
       - Link and package modules: workflows/link-and-package.md
-      - Compose recursive product frontiers: workflows/product-frontiers.md
+      - Split command and kernel compilation: workflows/product-frontiers.md
       - Build libraries and binaries with Bazel: workflows/build-with-bazel.md
       - Test correctness: workflows/test-correctness.md
       - Benchmark checked work: workflows/benchmark.md
@@ -94,8 +94,8 @@ nav:
   - Integration:
       - Integration map: integration/index.md
       - Compose modules in memory: integration/module-composition.md
-      - Embed product frontiers: integration/product-frontier.md
-      - Schedule concurrent JIT work: integration/jit-task-pool.md
+      - Parallelize kernel JIT compilation: integration/product-frontier.md
+      - Use the JIT task pool: integration/jit-task-pool.md
       - Embed kernel JIT compilation: integration/jit-kernel.md
   - Reference:
       - Reference map: reference/index.md

--- a/loom/docs/src/guide/command-programs.md
+++ b/loom/docs/src/guide/command-programs.md
@@ -354,8 +354,8 @@ schedule remain runtime responsibilities.
 [Source modules and canonical text](source-modules.md) explains declaration
 and library ownership. [Facts and specialization](facts-and-specialization.md)
 shows how configuration, assumptions, and target facts constrain the values
-used here. [Compose recursive product
-frontiers](../workflows/product-frontiers.md) follows local, linked, classified,
+used here. [Split command and kernel
+compilation](../workflows/product-frontiers.md) follows local, linked, classified,
 and external kernels through one checked product. [Compile
 artifacts](../workflows/compile-artifacts.md#emit-portable-command-programs)
 covers the public command-line artifact workflow.

--- a/loom/docs/src/integration/index.md
+++ b/loom/docs/src/integration/index.md
@@ -41,10 +41,11 @@ created them only after the application loads or copies them.
 - [Compose modules in memory](module-composition.md) shows both declaration-only
   and logical-provider composition over caller-owned source bytes and one
   reusable frozen link index.
-- [Embed command and kernel product frontiers](product-frontier.md) shows how a
-  portable command product publishes independently compilable kernel requests
-  while preserving external executable requirements.
-- [Schedule concurrent JIT work](jit-task-pool.md) shows how generic tasks,
+- [Parallelize kernel JIT compilation](product-frontier.md) shows how a
+  portable command program discovers live kernels, checks cached products, and
+  schedules independent compilation while preserving external executable
+  requirements.
+- [Use the JIT task pool](jit-task-pool.md) shows how generic tasks,
   cache-before-submit policy, worker-local workspaces, and independent queues
   on one optional shared pool compose without making scheduling part of the
   compiler API.

--- a/loom/docs/src/integration/jit-task-pool.md
+++ b/loom/docs/src/integration/jit-task-pool.md
@@ -1,4 +1,4 @@
-# Schedule concurrent JIT work
+# Use the JIT task pool
 
 **Example source:** [`loom/binding/c/example/jit_task_pool.c`](https://github.com/ROCm/hrx-system/blob/main/loom/binding/c/example/jit_task_pool.c)
 
@@ -122,14 +122,14 @@ for the service lifetime, then uses request completion objects, callbacks,
 futures, or event-loop messages. Neither a queue nor the pool exposes a global
 idle wait: another producer may publish work at any time, and observing a
 transiently empty domain does not mean an application request is complete. The
-request owner knows its actual frontier and terminalizes it when every required
-product has resolved.
+request owner knows exactly which products it is waiting for and terminalizes
+its completion object when all of them have resolved.
 
 Queue shutdown is drain-only. It stops that domain from accepting work, executes
 every accepted task, and releases its cooperative process without affecting
 other domains attached to the pool. Work that recursively publishes child tasks
-therefore completes its application frontier before its queue begins teardown;
-publication attempted after shutdown is correctly rejected. Attached queues
+therefore completes its request before its queue begins teardown; publication
+attempted after shutdown is correctly rejected. Attached queues
 retain the shared executor, so they may outlive the convenience pool handle and
 the final owner joins the worker threads.
 

--- a/loom/docs/src/integration/product-frontier.md
+++ b/loom/docs/src/integration/product-frontier.md
@@ -1,91 +1,213 @@
-# Embed command and kernel product frontiers
+# Parallelize kernel JIT compilation
 
-**Example source:** [`loom/binding/c/example/product_frontier.c`](https://github.com/ROCm/hrx-system/blob/main/loom/binding/c/example/product_frontier.c)
+**Complete example:** [`loom/binding/c/example/product_frontier.c`](https://github.com/ROCm/hrx-system/blob/main/loom/binding/c/example/product_frontier.c)
 
-A command product can finish before the executable kernels it references. The
-parent owns portable command bytes and an explicit requirement table; each
-source-backed child crosses the boundary as an independently owned ordinary
-Loom bytecode request. A host can compile those requests locally, send their
-ordinary bytecode and durable roots through its own compiler-service protocol,
-or satisfy the same requirements from prebuilt executables. The product
-descriptor that selects a local pipeline is deliberately process-local and is
-not part of the serialized source.
+Loading a model or specializing a workload can make dozens or hundreds of
+kernels ready to compile at once. Compiling them serially extends startup
+latency, while giving every kernel its own compiler or thread pool repeats
+setup and oversubscribes the host.
 
-The checked C example uses only the public `loomc` API. It deliberately runs
-the parent and child synchronously so the ownership boundary remains visible;
-an application worker pool uses the same callback to enqueue transferred
-requests without changing the compiler operations.
+The `loomc` API turns the live kernel set into small, independent build
+requests. An application checks each request against its cache, submits only
+the misses to a bounded scheduler, and binds the completed kernel products back
+to the command program that requested them. Immutable compiler state is shared
+across the process; each worker owns only its mutable scratch workspace.
 
-## Prepare immutable process state
+The scheduler boundary is intentionally generic. Applications with an existing
+executor implement `loomc_task_sink_t`. Applications without one can use
+Loom's optional `loomc_task_pool_t` and `loomc_task_queue_t`. The compile task
+and its ownership rules are identical in both cases.
 
-The example creates one context, one worker-local workspace, and one frozen
-link index over the source universe. It resolves the human-readable command
-root once and keeps the index-wide ordinal for the hot path. A compiler and
-prepared pass program are also created once for child requests:
+This guide covers:
 
-```c
---8<-- "generated/examples/integration/product-frontier/product_frontier.c:prepare"
+- when independent kernel compilation improves JIT latency;
+- how command construction discovers only the kernels that remain live after
+  linking and specialization;
+- where cache lookup, scheduling, compilation, and completion belong; and
+- how to use either an application scheduler or Loom's standard worker pool.
+
+## Choose this path for batches and continuous specialization
+
+Independent scheduling helps when one application event creates several
+compilation opportunities:
+
+| Application event | Useful scheduling policy |
+| --- | --- |
+| Model load | Compile the model's live kernel set concurrently and retain the loaded results with the model plan. |
+| Shape or workload specialization | Reuse cached versions and schedule only newly selected semantic classes. |
+| Continuous JIT | Keep a bounded compile queue alive and attach each invocation to its own completion object. |
+| Autotuning or search | Submit independent configuration candidates without constructing a compiler per candidate. |
+
+A single kernel compiled once during process startup does not need this
+machinery. Ahead-of-time packaging remains a better fit when all relevant
+target and workload facts are already known at build time.
+
+## Split command construction from kernel compilation
+
+A command program describes host-side orchestration and names the executable
+kernel entries it will dispatch. Building that command program can determine
+which kernel implementations are actually needed without compiling every
+kernel body in the source catalog.
+
+```text
+command roots + configuration
+             |
+             v
+loomc_cmd_program_product_build
+             |
+             +----> portable command bytes
+             |
+             +----> executable-entry requirements
+                         |
+                         +----> source-backed request -> cache -> compile
+                         |
+                         +----> external entry -------> application binding
 ```
 
-Frozen indexes, compilers, pass programs, and immutable sources can be shared
-by workers. A workspace is mutable invocation scratch and belongs to one active
-worker. The example reuses one workspace only because its parent and child
-operations run sequentially.
+The API reference calls this split a **product frontier**. A product is the
+immutable output of one successful compiler operation. Its frontier is simply
+the set of requirements that another product or the application must satisfy.
+There is no frontier object to manage and no special source format: every
+published kernel request contains ordinary Loom bytecode plus exact roots.
 
-## Publish only source-backed child work
+Command construction applies linking, configuration, dead-code elimination,
+and schedule selection before publishing requests. Dead branches create no JIT
+work. Launch sites that select the same semantic kernel class can share one
+request. A bodyless `kernel.entry.decl` remains an external requirement and
+does not create a fake compile job.
 
-The parent source contains one local `kernel.def` and one bodyless
-`kernel.entry.decl`. Command construction creates two executable-entry
-requirements, but it publishes a request only for the local definition. The
-external entry remains a real requirement for the embedding to bind from HIP,
-SPIR-V, HSACO, or another provider.
+## Prepare a long-lived compile service
 
-The callback accepts ownership of each immutable child request:
+Prepare expensive immutable state once:
+
+- one context and target environment;
+- source catalogs frozen into link indexes;
+- compilers and pass programs for the supported product routes; and
+- a bounded scheduler with one `loomc_workspace_t` per worker.
+
+The checked example uses Loom's standard four-worker pool and attaches one
+compile queue:
 
 ```c
---8<-- "generated/examples/integration/product-frontier/product_frontier.c:publish-request"
+--8<-- "generated/examples/integration/product-frontier/product_frontier.c:prepare-scheduler"
 ```
 
-Publication is provisional until command construction returns an OK status
-with a successful result. An asynchronous host may begin a cache lookup or
-compilation immediately, but it commits the child-to-parent binding only after
-the parent succeeds. Already transferred request references remain owned by
-the receiver if the parent later fails.
+`loomc_task_pool_worker_count` reports the actual worker count after host CPU
+affinity and topology are applied. The example allocates exactly that many
+workspaces. Task callbacks receive a dense, mutually exclusive worker ordinal,
+so selecting scratch is an array lookup rather than a lock or workspace lease.
 
-Supplying the callback enables source publication:
+An application-owned executor replaces only the sink and worker setup. It
+implements `loomc_task_sink_t::submit`, assigns each execution lane a stable
+ordinal, and invokes `loomc_task_execute` exactly once for every accepted task.
+The application does not link `loomc/task_pool.h`, `loomc/task_queue.h`, or the
+IREE task runtime in that configuration.
+
+## Publish compile requests while building the command
+
+Pass a `loomc_request_sink_t` when building the selected command roots:
 
 ```c
 --8<-- "generated/examples/integration/product-frontier/product_frontier.c:build-command"
 ```
 
-Leaving `request_sink.publish` null is the body-blind path. It returns the same
-command programs and entry requirements without opening, classifying, cloning,
-or serializing implementation bodies.
+`loomc_cmd_program_product_build` is synchronous with respect to the command
+product, but calls `request_sink.publish` as independent kernel requests become
+available. The callback may submit work immediately, allowing kernel
+compilation to overlap the remainder of command construction.
 
-## Compile children as ordinary requests
+The example command uses three source-backed kernels and one externally
+provided entry. Command construction therefore publishes three requests while
+returning four executable-entry requirements. Omitting `request_sink.publish`
+builds the same command bytes and requirements without opening kernel
+implementation bodies; that is useful when all executables are already
+available from another provider.
 
-Every published child carries a normal `.loombc` source, exact source-local
-root ordinals, the required process-local product descriptor, and provisional
-bindings to its parent requirements. It retains no mutable module, workspace,
-link plan, or analysis state.
+Publication is provisional until command construction returns both an OK
+status and a succeeded result. A latency-oriented service can schedule requests
+immediately and discard their parent bindings if the command later fails. A
+service that cannot tolerate speculative work can retain the requests in the
+callback and submit them only after the parent succeeds.
 
-The example compiles its child through the generic prepared compiler and asks
-for a bytecode module product:
+## Check the cache before crossing the scheduler
+
+The request callback is the cache boundary. A production key normally includes:
+
+- request bytecode contents and exact root ordinals;
+- the required product route;
+- target profile and invocation configuration;
+- selected pass pipeline and artifact options; and
+- compiler and executable-format compatibility versions.
+
+A cache hit records the existing product against the request's parent bindings
+without allocating a task. A miss wraps the immutable request in an
+application-owned task record and submits it. Cache policy stays outside
+`loomc`: an in-process JIT, a compiler service, and a persistent artifact cache
+can use different storage and eviction policies over the same requests.
+
+The checked callback omits a cache because every process run starts empty. Its
+scheduler-facing path is the same path used after a real cache miss:
 
 ```c
---8<-- "generated/examples/integration/product-frontier/product_frontier.c:compile-request"
+--8<-- "generated/examples/integration/product-frontier/product_frontier.c:schedule-request"
 ```
 
-This target-independent pipeline keeps the example available in builds that
-disable AMDGPU, SPIR-V, and LLVM emission. A target integration selects its
-normal target pipeline and executable emitter for the same exact request. The
-[kernel JIT guide](jit-kernel.md) shows target specialization, native artifact
-emission, and runtime loading for AMDGPU and SPIR-V.
+The publication callback owns `request` at entry. Successful task submission
+transfers the task to the sink, which executes and destroys it exactly once. A
+rejected submission leaves task ownership with the caller. The output slot
+retains the request until its completed product has been bound or discarded.
 
-The child product preserves request-root order as export order and has no
-unresolved requirements. Its parent binding is separate from compilation
-identity, so two parents can reuse one compiled product while binding its
-exports into different requirement ordinals.
+The request's process-local product descriptor selects the compilation route.
+This example accepts the compiled-module route used by
+`loomc_compile_request`. A service supporting additional product families uses
+the descriptor as a dispatch key rather than guessing from symbol names,
+filenames, or target strings.
+
+## Compile with worker-local scratch
+
+Each task shares the prepared compiler and pass program and selects its
+workspace by worker ordinal:
+
+```c
+--8<-- "generated/examples/integration/product-frontier/product_frontier.c:compile-task"
+```
+
+The example requests compiled `.loombc` so it runs in target-independent
+builds. A native JIT gives the task its prepared target pipeline and continues
+through the compile-and-emit sequence shown in [Embed kernel JIT
+compilation](jit-kernel.md). The scheduling contract does not change when the
+result becomes an HSACO, SPIR-V module, or another runtime executable.
+
+Task execution writes its `loomc_status_t`, `loomc_result_t`, and product into
+caller-owned completion state. A non-OK status reports API misuse or an
+infrastructure failure. An OK status may still accompany a failed compiler
+result with diagnostics. Both must be checked before caching or loading a
+product.
+
+## Bind completed kernels to the command
+
+Every request carries provisional mappings from requirement ordinals in the
+parent command product to root ordinals in the child request. Successful child
+products preserve request-root order as export order, so the same mapping
+identifies the compiled export that satisfies each command requirement:
+
+```c
+--8<-- "generated/examples/integration/product-frontier/product_frontier.c:bind-results"
+```
+
+The example verifies three compiled bindings and leaves the bodyless
+`@external` entry for the application. A real runtime uses those mappings to
+join loaded executable exports to command-program entry slots. Two command
+products may reuse one cached child product while carrying different parent
+requirement ordinals.
+
+Completion belongs to the application request, not to the worker pool. The
+short-lived example shuts down its queue to drain one finite batch. A
+continuous JIT keeps the pool and queues alive, increments a per-command
+pending count for each accepted request, resolves cache hits immediately, and
+signals its future, callback, or event-loop message when every required binding
+has completed. Observing an empty queue is not a completion protocol because
+another producer may submit work at any time.
 
 ## Run the checked example
 
@@ -93,31 +215,16 @@ exports into different requirement ordinals.
 python dev.py bazel run //loom/binding/c/example:product_frontier
 ```
 
-The output summarizes the mixed frontier:
+The output distinguishes compiled source kernels from the executable that the
+application must provide:
 
 ```text
 --8<-- "generated/examples/integration/product-frontier/summary.txt"
 ```
 
-The one local kernel produces one child product. The external kernel accounts
-for the second parent requirement without producing a fake source request.
-
-## Place caching and concurrency outside compilation
-
-The low-level flow has four independent decisions:
-
-| Decision | Interface |
-| --- | --- |
-| Which command roots to build | Exact ordinals in a frozen link index or ordinary request |
-| Whether source-backed children are needed | Presence of `loomc_request_sink_t::publish` |
-| Which pipeline produces a requested representation | `loomc_request_product_descriptor` plus embedding policy |
-| Where work and reuse live | The embedding's queue, worker-local workspaces, and process-local cache |
-
-No task runtime or cache implementation is required by the compiler API. A
-single-threaded application can run the example literally. A concurrent host
-retains each request, checks its cache before leasing a workspace, and schedules
-only misses. Product artifacts are immutable byte sequences, so successful
-results can pass directly to executable loaders or packaging code without a
-filesystem round trip. [Schedule concurrent JIT work](jit-task-pool.md) shows
-that composition with caller-owned completion and the optional standard task
-pool.
+For the generic task protocol and standard pool lifecycle in isolation, see
+[Use the JIT task pool](jit-task-pool.md). For target profiles, native artifact
+emission, launch configuration, and runtime loading, continue with [Embed
+kernel JIT compilation](jit-kernel.md). The generated [`loomc` C API
+reference](../reference/c-api/index.md) defines the exact ownership and
+thread-safety contract for every handle used here.

--- a/loom/docs/src/workflows/index.md
+++ b/loom/docs/src/workflows/index.md
@@ -38,7 +38,7 @@ at `.loombc`. A JIT embedding can perform the same operations in memory through
 | Inspect symbols and dependency closure | [Link and package modules](link-and-package.md#inspect-before-linking) |
 | Build a root-selected artifact input | [Link and package modules](link-and-package.md#link-one-program) |
 | Merge a reusable bytecode catalog | [Link and package modules](link-and-package.md#merge-a-reusable-catalog) |
-| Split parent and child compilation products | [Compose recursive product frontiers](product-frontiers.md) |
+| Split command and kernel compilation | [Split command and kernel compilation](product-frontiers.md) |
 | Declare relocatable libraries in Bazel | [Build libraries and binaries with Bazel](build-with-bazel.md#libraries-stay-relocatable) |
 | Build kernel, command, or VM products | [Build libraries and binaries with Bazel](build-with-bazel.md#binary-roots-close-one-product) |
 

--- a/loom/docs/src/workflows/link-and-package.md
+++ b/loom/docs/src/workflows/link-and-package.md
@@ -144,8 +144,8 @@ re-exported through every product that consumes one definition.
 
 Some products close before every reachable implementation. Portable command
 construction, for example, follows a kernel's contract and pure configuration
-without pulling its device body into the command artifact. [Compose recursive
-product frontiers](product-frontiers.md) follows that boundary through mixed
+without pulling its device body into the command artifact. [Split command and
+kernel compilation](product-frontiers.md) follows that boundary through mixed
 local, linked, bytecode, and external kernels and shows how child source
 requests remain ordinary Loom modules.
 

--- a/loom/docs/src/workflows/product-frontiers.md
+++ b/loom/docs/src/workflows/product-frontiers.md
@@ -1,14 +1,18 @@
-# Compose recursive product frontiers
+# Split command and kernel compilation
 
-A product frontier closes one parent artifact while leaving each child
-implementation as an explicit requirement. This lets one command program become
-portable command bytes without embedding every kernel body, and it lets each
-required kernel compile or resolve from a cache independently.
+A command program can be compiled into portable orchestration bytes without
+embedding every device kernel it references. Loom records each executable entry
+as a requirement and can export each source-backed kernel implementation as an
+independent `.loombc` request. The application may compile those requests in
+parallel, satisfy them from a cache, or bind requirements to externally
+provided executables.
 
-The frontier is a normal selective-link boundary. It does not introduce a fact
-sidecar, generated source format, or graph-specific package. Child requests
-carry ordinary Loom bytecode plus exact roots, so the same formatter, linker,
-compiler, diagnostics, and cache keys apply at every level.
+The compiler API calls the boundary between one completed product and its
+unresolved requirements a **product frontier**. The workflow is ordinary
+selective linking: it introduces no fact sidecar, generated source format, or
+graph-specific package. Child requests carry ordinary Loom bytecode plus exact
+roots, so the same formatter, linker, compiler, diagnostics, and cache keys
+apply at every level.
 
 ## Start from requester ownership
 


### PR DESCRIPTION
Loom's public product-frontier page previously opened with compiler-internal vocabulary and demonstrated one synchronous child compilation. It explained neither the application problem nor the scheduling architecture needed when a model load or continuously specialized workload makes many kernels ready at once.

This turns that page into a guide to parallel kernel JIT compilation. It starts from startup latency and host oversubscription, then follows live kernels through command construction, cache lookup, bounded scheduling, worker-local compilation, product binding, and application-owned completion. Product and frontier terminology is introduced only after the concrete split is visible.

## Make live kernel requests the scheduling boundary

The checked C example now builds one command containing three source-backed kernels and one externally supplied entry:

```text
command roots + configuration
             |
             v
command product build
             |
             +----> portable command bytes
             |
             +----> executable-entry requirements
                         |
                         +----> source request -> cache -> compile
                         |
                         +----> external entry -> application binding
```

Command construction publishes one ordinary bytecode request for each live source-backed semantic class. The callback validates the request's product descriptor, wraps a cache-miss-shaped request in a generic `loomc_task_t`, and submits it through `loomc_task_sink_t`. The callback has no dependency on Loom's task-pool implementation, so an application executor and the optional standard pool consume the same task representation and ownership protocol.

The example uses a four-worker Loom pool to make the complete path executable. It queries the actual worker count, allocates one mutable workspace per dense worker ordinal, and shares the immutable compiler and pass program. Kernel tasks may overlap the rest of synchronous command construction. Their products remain independently useful if the parent fails, while their provisional parent bindings are committed only after the command result succeeds.

## Keep cache and completion policy in the application

The guide places cache lookup before task allocation and describes the request, target, pipeline, artifact, and compatibility inputs needed by a production cache key. Cache hits bind an existing immutable product without crossing the scheduler; misses use the same compile task shown by the example.

Each task terminalizes caller-owned status, compiler result, and product state. Completed request bindings map parent requirement ordinals to child export ordinals without making parent position part of compilation identity, allowing one cached product to satisfy different command products.

Queue shutdown is explicitly the finite example's drain operation, not a production completion protocol. The continuous-JIT path keeps its queues alive and completes a request-owned future, callback, or event-loop message when all required bindings resolve. Queue emptiness is never treated as application completion.

## Rewrite the surrounding reader path

Navigation and adjacent workflow links now describe user tasks such as "Parallelize kernel JIT compilation" and "Split command and kernel compilation." The lower-level task-pool page remains a focused reference for the optional scheduler implementation, while the rewritten guide owns the end-to-end application flow. Existing page paths remain stable.

## Make checked documentation portable on Windows

Running the complete checked documentation path exposed two platform contract violations. Documentation hooks were passing POSIX generator scripts directly to Windows process creation, and text-mode `FILE*` streams could newline-translate artifact bytes.

Windows documentation generation now launches scripts through the hermetic `BAZEL_SH` selected by `dev.py`, routes wrapper Python calls through the active managed interpreter, and announces each generator before compiler-backed work begins. POSIX hosts retain direct script execution.

`loomc_artifact_write_to_file` now switches Windows streams to binary mode before writing. This preserves the API's byte-for-byte artifact contract for stdout and caller-opened text streams as well as explicitly binary files.

## Reviewer Notes

The highest-value review surfaces are:

- request ownership transfer from command publication, through generic task submission, to completed product storage;
- the distinction between provisional parent bindings and independently valid compiled child products;
- worker-ordinal workspace ownership and the separation of scheduling from application completion; and
- the Windows shell-selection and binary-stream fixes required by the checked documentation build.
