### PR TITLE
[Loom] Add a first-kernel quickstart

### DIFF
--- a/loom/docs/examples/getting-started/first-kernel/.doc-generate.sh
+++ b/loom/docs/examples/getting-started/first-kernel/.doc-generate.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Runs the hardware-independent portion of the public quickstart, verifies its
+# products, and stages the exact source and Bazel declaration included by the
+# page.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
+if [[ "$#" -gt 1 ]]; then
+  printf 'usage: %s [output-directory]\n' "$0" >&2
+  exit 64
+fi
+
+if [[ -n "${RUNFILES_DIR:-}" ]]; then
+  workspace="${TEST_WORKSPACE:-_main}"
+  repo_root="${RUNFILES_DIR}/${workspace}"
+  export LOOM_FORMAT="${repo_root}/loom/src/loom/tools/loom-format/loom-format"
+  export LOOM_COMPILE="${repo_root}/loom/src/loom/tools/loom-compile/loom-compile"
+  export IREE_BENCHMARK_LOOM="${repo_root}/loom/src/loom/tools/iree-benchmark-loom/iree-benchmark-loom"
+else
+  repo_root="$(cd -- "${script_dir}/../../../../.." && pwd -P)"
+  "${repo_root}/build_tools/bin/iree-bazel-build" \
+    --config=asan \
+    //loom/src/loom/tools/loom-format:loom-format \
+    //loom/src/loom/tools/loom-compile:loom-compile \
+    //loom/src/loom/tools/iree-benchmark-loom:iree-benchmark-loom
+  export LOOM_FORMAT="${repo_root}/bazel-bin/loom/src/loom/tools/loom-format/loom-format"
+  export LOOM_COMPILE="${repo_root}/bazel-bin/loom/src/loom/tools/loom-compile/loom-compile"
+  export IREE_BENCHMARK_LOOM="${repo_root}/bazel-bin/loom/src/loom/tools/iree-benchmark-loom/iree-benchmark-loom"
+fi
+
+source_file="${script_dir}/saxpy.loom"
+build_file="${script_dir}/BUILD.bazel"
+output_dir="${1:-${TEST_UNDECLARED_OUTPUTS_DIR:-${repo_root}/build/loom-docs/examples/getting-started/first-kernel}}"
+mkdir -p -- "${output_dir}"
+output_dir="$(cd -- "${output_dir}" && pwd -P)"
+
+temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/loom-doc-first-kernel.XXXXXX")"
+cleanup() {
+  rm -r -- "${temporary_root}"
+}
+trap cleanup EXIT
+
+artifact_root="${temporary_root}/artifacts"
+"${script_dir}/run.sh" gfx11-generic "${artifact_root}" --compile-only
+
+grep -Fq '"benchmark":"saxpy_f32_64k"' \
+  "${artifact_root}/saxpy-plan.json"
+grep -Fq '"element_count":65536' "${artifact_root}/saxpy-plan.json"
+test -s "${artifact_root}/saxpy.hsaco"
+
+cp -- "${source_file}" "${output_dir}/saxpy.loom"
+cp -- "${build_file}" "${output_dir}/BUILD.bazel"
+
+printf 'Generated documentation snippets:\n'
+printf '  %s\n' \
+  "${output_dir}/saxpy.loom" \
+  "${output_dir}/BUILD.bazel"

--- a/loom/docs/examples/getting-started/first-kernel/BUILD.bazel
+++ b/loom/docs/examples/getting-started/first-kernel/BUILD.bazel
@@ -1,0 +1,30 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# bazel-to-cmake: skip
+
+# --8<-- [start:kernel-library]
+load(
+    "@hrx//loom/build_tools/bazel:defs.bzl",
+    "loom_kernel_library",
+)
+load(
+    "@hrx//loom/target/amdgpu:execution_profiles.bzl",
+    "AMDGPU_HARDWARE_PROFILE",
+)
+
+package(
+    default_visibility = ["//visibility:private"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+loom_kernel_library(
+    name = "saxpy",
+    srcs = ["saxpy.loom"],
+    execution_profiles = [AMDGPU_HARDWARE_PROFILE],
+    targets = ["@hrx//loom/target/amdgpu:gfx11-generic"],
+)
+# --8<-- [end:kernel-library]

--- a/loom/docs/examples/getting-started/first-kernel/run.sh
+++ b/loom/docs/examples/getting-started/first-kernel/run.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=loom/docs/examples/example.shlib
+source "${script_dir}/../../example.shlib"
+
+if [[ "$#" -gt 3 ]]; then
+  printf 'usage: %s [target] [output-directory] [--compile-only]\n' "$0" >&2
+  exit 64
+fi
+
+target="${1:-gfx11-generic}"
+output_dir="${2:-build/first-kernel/${target}}"
+mode="${3:-}"
+if [[ -n "${mode}" && "${mode}" != "--compile-only" ]]; then
+  printf 'unsupported mode: %s\n' "${mode}" >&2
+  printf 'supported mode: --compile-only\n' >&2
+  exit 64
+fi
+
+loom_example_configure_target "${target}"
+
+if [[ "${output_dir}" != /* ]]; then
+  output_dir="${PWD}/${output_dir}"
+fi
+mkdir -p -- "${output_dir}"
+output_dir="$(cd -- "${output_dir}" && pwd -P)"
+
+loom_format="${LOOM_FORMAT:-loom-format}"
+loom_compile="${LOOM_COMPILE:-loom-compile}"
+iree_benchmark_loom="${IREE_BENCHMARK_LOOM:-iree-benchmark-loom}"
+
+loom_example_require_tool "${loom_format}"
+loom_example_require_tool "${loom_compile}"
+loom_example_require_tool "${iree_benchmark_loom}"
+
+if [[ -z "${mode}" ]]; then
+  iree_test_loom="${IREE_TEST_LOOM:-iree-test-loom}"
+  loom_example_require_tool "${iree_test_loom}"
+fi
+
+cd -- "${script_dir}"
+
+loom_example_section "Check the authored source"
+loom_example_run_tool loom-format "${loom_format}" --check saxpy.loom
+
+loom_example_section "Plan the named benchmark workload"
+loom_example_run_tool iree-benchmark-loom "${iree_benchmark_loom}" \
+  saxpy.loom \
+  --benchmark=@saxpy_f32_64k \
+  --dry-run \
+  --output="${output_dir}/saxpy-plan.json"
+
+loom_example_section "Compile the deployment kernel for ${target}"
+loom_example_run_tool loom-compile "${loom_compile}" \
+  saxpy.loom \
+  --backend="${LOOM_EXAMPLE_BACKEND}" \
+  --target="${LOOM_EXAMPLE_TARGET}" \
+  --root=@saxpy_f32 \
+  --output="${output_dir}/saxpy.hsaco"
+
+if [[ -z "${mode}" ]]; then
+  loom_example_section "Execute every correctness sample on AMDGPU"
+  printf '  $ iree-test-loom saxpy.loom --device=amdgpu > %q\n' \
+    "${output_dir}/saxpy-test.json"
+  "${iree_test_loom}" saxpy.loom --device=amdgpu \
+    >"${output_dir}/saxpy-test.json"
+
+  loom_example_section "Benchmark the proven 64K workload"
+  loom_example_run_tool iree-benchmark-loom "${iree_benchmark_loom}" \
+    saxpy.loom \
+    --device=amdgpu \
+    --benchmark=@saxpy_f32_64k \
+    --measure=dispatch_complete \
+    --batch-size=64 \
+    --output="${output_dir}/saxpy-benchmark.json"
+fi
+
+loom_example_section "Artifacts"
+printf '  %s\n' \
+  "${output_dir}/saxpy-plan.json" \
+  "${output_dir}/saxpy.hsaco"
+if [[ -z "${mode}" ]]; then
+  printf '  %s\n' \
+    "${output_dir}/saxpy-test.json" \
+    "${output_dir}/saxpy-benchmark.json"
+fi

--- a/loom/docs/examples/getting-started/first-kernel/saxpy.loom
+++ b/loom/docs/examples/getting-started/first-kernel/saxpy.loom
@@ -1,0 +1,39 @@
+// Computes y = alpha * x + y for a runtime-sized f32 vector.
+kernel.def export("saxpy_f32") @saxpy_f32(%element_count: index) {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 256 : index
+  %rounding = index.sub %workgroup_size, %unit : index
+  %rounded_count = index.add %element_count, %rounding : index
+  %workgroups = index.div %rounded_count, %workgroup_size : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%element_count: index, %alpha: f32, %x: buffer, %y: buffer) {
+  %workgroup = kernel.workgroup.id<x> : index
+  %lane = kernel.workitem.id<x> : index
+  %workgroup_size = kernel.workgroup.size<x> : index
+  %element_index = index.madd %workgroup, %workgroup_size, %lane : index
+  %in_bounds = index.cmp ult, %element_index, %element_count : index
+  %x_noalias, %y_noalias = buffer.assume.noalias %x, %y : buffer, buffer
+  %base = index.constant 0 : offset
+  %x_view = buffer.view %x_noalias[%base] : buffer -> view<[%element_count]xf32>
+  %y_view = buffer.view %y_noalias[%base] : buffer -> view<[%element_count]xf32>
+  scf.if %in_bounds {
+    %x_value = view.load %x_view[%element_index] : view<[%element_count]xf32> -> f32
+    %y_value = view.load %y_view[%element_index] : view<[%element_count]xf32> -> f32
+    %result = scalar.fmaf %alpha, %x_value, %y_value : f32
+    view.store %result, %y_view[%element_index] : f32, view<[%element_count]xf32>
+  }
+  kernel.return
+}
+
+check.case public @saxpy_f32_case {
+  %element_count = check.param.choice values([1, 255, 256, 257, 1009, 65536]) name("element_count") : index
+  %alpha = check.literal value(4.0) : f32
+  %x = check.generate.fill value(2.0) : tensor<[%element_count]xf32>
+  %y = check.generate.fill value(3.0) : tensor<[%element_count]xf32>
+  %expected = check.generate.fill value(11.0) : tensor<[%element_count]xf32>
+  kernel.launch @saxpy_f32[%element_count](%element_count, %alpha, %x, %y) : [index](index, f32, tensor<[%element_count]xf32>, tensor<[%element_count]xf32>)
+  check.expect.equal actual(%y) expected(%expected) : tensor<[%element_count]xf32>
+  check.return
+}
+
+check.benchmark<@saxpy_f32_case> @saxpy_f32_64k {element_count = 65536}

--- a/loom/docs/mkdocs.yml
+++ b/loom/docs/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
   - Programming guide:
       - Guide map: guide/index.md
       - Acquiring Loom: getting-started/acquiring-loom.md
+      - Run your first kernel: getting-started/first-kernel.md
       - From source to artifacts: getting-started/source-to-artifacts.md
       - Source modules and canonical text: guide/source-modules.md
       - Values, types, and shapes: guide/values-types-shapes.md

--- a/loom/docs/src/getting-started/acquiring-loom.md
+++ b/loom/docs/src/getting-started/acquiring-loom.md
@@ -31,3 +31,6 @@ registers source-built toolchains automatically, while a local module override
 keeps compiler and kernel edits in one live Bazel graph. [Build libraries and
 binaries with Bazel](../workflows/build-with-bazel.md#depend-on-hrx) defines the
 module declaration, public loads, target profiles, and deployment products.
+
+Once the tools or Bzlmod dependency are available, [run your first
+kernel](first-kernel.md) from one checked source file.

--- a/loom/docs/src/getting-started/first-kernel.md
+++ b/loom/docs/src/getting-started/first-kernel.md
@@ -1,0 +1,187 @@
+# Run your first Loom kernel
+
+**Example files:**
+[`loom/docs/examples/getting-started/first-kernel/`](https://github.com/ROCm/hrx-system/tree/main/loom/docs/examples/getting-started/first-kernel)
+
+This quickstart takes one source file from readable kernel code to checked
+AMDGPU execution and a real benchmark. The example computes SAXPY,
+`y = alpha * x + y`, over a runtime-sized `f32` vector.
+
+The same file owns three related things:
+
+- the kernel and its launch geometry;
+- deterministic correctness samples and expected results; and
+- a named benchmark that selects one of those proven samples.
+
+There is no generated host harness or separate benchmark program. Loom's tools
+compile the kernel for the selected device, materialize the tensors declared by
+the case, launch the work, check the result, and measure the same workload when
+requested.
+
+This page assumes the Loom tools are on `PATH` and that `--device=amdgpu` is
+available. [Acquiring Loom](acquiring-loom.md) describes the current
+source-build and Bazel setup.
+
+## Create one source file
+
+Save the following as `saxpy.loom`:
+
+```loom title="saxpy.loom"
+--8<-- "generated/examples/getting-started/first-kernel/saxpy.loom"
+```
+
+The [`kernel.def`](../reference/dialects/kernel/ops/def.md) has two regions. The
+first maps `%element_count` to a physical launch using 256 work-items per
+workgroup. The second is the device body. Each work-item computes one element
+index, guards the partial final workgroup, loads `x` and `y`, performs the fused
+multiply-add, and stores the result back to `y`.
+
+`%element_count` appears in both signatures for different reasons. The value
+before `launch` is workload input used by the host-side launch calculation. The
+value inside `launch(...)` is an explicit device argument used for bounds and
+buffer views. Loom does not silently turn one into the other.
+
+The [`check.case`](../reference/dialects/check/ops/case.md) expands to six
+deterministic samples. Sizes 255, 256, and 257 cover both sides of the workgroup
+boundary; 1009 exercises a larger tail; and 65536 supplies the benchmark
+workload. Every sample fills `x` with 2, initializes `y` to 3, launches with
+`alpha = 4`, and requires every result to equal 11.
+
+The final [`check.benchmark`](../reference/dialects/check/ops/benchmark.md) does
+not duplicate that setup. It gives the 65536-element assignment a stable
+workload name and reuses the case's inputs, launch, and expectation.
+
+## Check the source before compiling
+
+`loom-format --check` parses and verifies the complete program and rejects noncanonical text:
+
+```shell
+loom-format --check saxpy.loom
+```
+
+This is more than whitespace checking. Invalid SSA use, mismatched types, and
+malformed launch signatures fail at this boundary. The test and benchmark
+runners then plan concrete parameter samples and reject assignments that do
+not select a valid case sample.
+
+## Execute every correctness sample on AMDGPU
+
+Run the checked program directly:
+
+```shell
+iree-test-loom saxpy.loom --device=amdgpu >saxpy-test.json
+```
+
+The runner discovers `@saxpy_f32_case`, plans its six parameter assignments,
+compiles the reachable kernel for the selected AMDGPU device, allocates and
+initializes each tensor, executes the launch, and evaluates
+`check.expect.equal`. It returns a failing process status if any sample fails
+and writes the structured report before exiting.
+
+The report distinguishes cases from their concrete samples. This case has one
+authored definition and six executions; a failure records the exact
+`element_count` and stable sample ordinal needed to reproduce it.
+
+Select one sample while editing without changing the source:
+
+```shell
+iree-test-loom saxpy.loom \
+  --device=amdgpu \
+  --case=@saxpy_f32_case \
+  --sample=3
+```
+
+Sample 3 is the 257-element tail. The ordinal comes from the deterministic
+parameter plan rather than hidden random state.
+
+## Benchmark the proven workload
+
+Measure the named 64K dispatch workload:
+
+```shell
+iree-benchmark-loom saxpy.loom \
+  --device=amdgpu \
+  --benchmark=@saxpy_f32_64k \
+  --measure=dispatch_complete \
+  --batch-size=64 \
+  --output=saxpy-benchmark.json
+```
+
+The benchmark runner executes the selected case and verifies its expected
+result before accepting timing evidence. `dispatch_complete` measures host
+submission through device completion for a prepared batch, and the report
+normalizes the result per logical SAXPY operation. The batch size remains part
+of the recorded measurement policy instead of becoming source metadata.
+
+Benchmark with an optimized, uninstrumented tool build on an otherwise quiet
+device. The JSON report carries device identity, parameter values, timing
+policy, score distribution, and warnings needed to interpret the number.
+
+The checked-in example wraps the same steps and also emits a generic gfx11
+deployment artifact:
+
+```shell
+loom/docs/examples/getting-started/first-kernel/run.sh \
+  gfx11-generic build/first-kernel/gfx11-generic
+```
+
+The script prints each public command before executing it and leaves the test,
+benchmark, plan, and native artifact reports together in the output directory.
+
+## Put the source under Bazel
+
+An authoring repository can give the same file automated format, lint, plan,
+correctness, and benchmark-smoke coverage with one rule:
+
+```starlark title="BUILD.bazel"
+--8<-- "generated/examples/getting-started/first-kernel/BUILD.bazel:kernel-library"
+```
+
+The built-in AMDGPU execution profile owns the compiler and driver
+requirements, `--device=amdgpu` argument, GPU resource serialization, and
+stable query tags. The source remains target-independent; the profile chooses
+where this test instance runs.
+
+Build the reusable bytecode library:
+
+```shell
+bazel build :saxpy
+```
+
+Run its generated test suite on a configured AMDGPU machine:
+
+```shell
+bazel test :saxpy_test
+```
+
+`saxpy_test` performs source lint and canonical-format checks, plans every
+benchmark without a device, emits and inspects the generic gfx11 deployment
+artifact, executes all correctness cases on AMDGPU, and runs every benchmark
+once with no warmups as a smoke test. Full repeated timing remains the explicit
+`iree-benchmark-loom` command above; CI should prove that the workload remains
+correct and executable without turning shared runners into performance
+laboratories.
+
+`loom_kernel_library` links the authored file into reusable `.loombc` and builds
+a separate test module that retains the root library's checks. Deployment
+linking selects exported production roots such as `@saxpy_f32` and strips
+`check.case` and `check.benchmark` records before target compilation. Test code
+therefore stays next to the kernel without entering the native artifact.
+
+## Follow the boundary that matters next
+
+You now have one portable source file that formats, verifies, executes across
+tail sizes, names a benchmark workload, participates in automated AMDGPU
+testing, and remains linkable as a library.
+
+- [Kernels and launch configuration](../guide/kernels-and-launch.md) explains
+  the workload, launch, and device-argument split.
+- [Checks and benchmarks](../guide/checks-and-benchmarks.md) develops richer
+  generators, oracles, comparisons, and sample plans.
+- [Benchmark checked work](../workflows/benchmark.md) covers timing modes, data
+  reuse, profiling, and interleaved comparisons.
+- [Build libraries and binaries with Bazel](../workflows/build-with-bazel.md)
+  grows this one-file rule into reusable libraries and deployment artifacts.
+- [From source to artifacts](source-to-artifacts.md) follows a larger
+  multi-module program through linking, target specialization, command
+  programs, and compiler reports.

--- a/loom/docs/src/guide/index.md
+++ b/loom/docs/src/guide/index.md
@@ -4,10 +4,12 @@ The programming guide explains Loom by the boundary that owns each decision.
 It is written for systems and ML engineers who are comfortable reading a
 kernel.
 
-Start with the [source-to-artifacts walkthrough](../getting-started/source-to-artifacts.md)
-if modules, templates, launch configuration, checks, and command programs are
-all new. Use the chapters here to understand why a source construct exists and
-when it is the right construct. Use the [generated
+Start with [Run your first Loom kernel](../getting-started/first-kernel.md) for
+one direct author-test-benchmark loop. Continue with the
+[source-to-artifacts walkthrough](../getting-started/source-to-artifacts.md)
+when you are ready to add modules, templates, specialization, and command
+programs. Use the chapters here to understand why a source construct exists
+and when it is the right construct. Use the [generated
 reference](../reference/index.md) when you need the exhaustive syntax or field
 contract for one operation.
 

--- a/loom/docs/src/guide/kernels-and-launch.md
+++ b/loom/docs/src/guide/kernels-and-launch.md
@@ -53,6 +53,12 @@ guard the tail. A value needed only for launch arithmetic does not consume a
 device argument; a buffer needed only by the device does not become a workload
 argument.
 
+`index` and `offset` are logical source types, not fixed-width device ABI
+types. A target may select a 32- or 64-bit representation for a launch argument
+from the facts proven about that value. Loom's execution tools pack arguments
+from the loaded executable's parameter reflection; a direct HAL host must use
+the same reflection instead of assuming a width from the source spelling.
+
 ## Launch configuration is pure executable logic
 
 The launch-configuration region is a pure function of its workload arguments

--- a/loom/docs/src/index.md
+++ b/loom/docs/src/index.md
@@ -15,7 +15,7 @@ cases, benchmark workloads, and compile evidence connected from readable IR to
 native artifacts.
 
 [Get Loom](getting-started/acquiring-loom.md){ .md-button .md-button--primary }
-[Follow a program](getting-started/source-to-artifacts.md){ .md-button }
+[Run your first kernel](getting-started/first-kernel.md){ .md-button }
 [Read the guide](guide/index.md){ .md-button }
 [Explore the reference](reference/index.md){ .md-button }
 

--- a/loom/src/loom/tooling/execution/hal/testbench_actual.c
+++ b/loom/src/loom/tooling/execution/hal/testbench_actual.c
@@ -330,6 +330,8 @@ void loom_run_hal_testbench_actual_provider_deinitialize(
   if (provider->context != NULL) {
     iree_allocator_free(provider->context->host_allocator,
                         provider->workload_arguments);
+    iree_allocator_free(provider->context->host_allocator,
+                        provider->function_parameters);
   }
   *provider = (loom_run_hal_testbench_actual_provider_t){0};
 }
@@ -585,6 +587,54 @@ static iree_status_t loom_run_hal_testbench_resolve_target_requirement(
   return iree_ok_status();
 }
 
+static iree_status_t loom_run_hal_testbench_reflect_function_parameters(
+    loom_run_hal_testbench_actual_provider_t* provider) {
+  iree_hal_executable_t* executable = provider->prepared_candidate.executable;
+  iree_string_view_t function_name =
+      iree_string_view_trim(provider->invocation_options.function_name);
+  if (iree_string_view_starts_with_char(function_name, '@')) {
+    function_name = iree_string_view_remove_prefix(function_name, 1);
+  }
+
+  iree_hal_executable_function_t function =
+      iree_hal_executable_function_invalid();
+  IREE_RETURN_IF_ERROR(iree_hal_executable_lookup_function_by_name(
+      executable, function_name, &function));
+  iree_hal_executable_function_info_t function_info = {0};
+  IREE_RETURN_IF_ERROR(
+      iree_hal_executable_function_info(executable, function, &function_info));
+
+  // Some backends only reflect aggregate constant and binding counts and
+  // therefore require source-type packing. A nonzero count is a complete ABI
+  // contract and must match the source.
+  if (function_info.parameter_count == 0) {
+    return iree_ok_status();
+  }
+  if (function_info.parameter_count != provider->kernel_launch->input_count) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "loaded HAL function '%.*s' reflects %u parameters for %" PRIhsz
+        " source inputs",
+        (int)function_name.size, function_name.data,
+        (unsigned)function_info.parameter_count,
+        provider->kernel_launch->input_count);
+  }
+
+  iree_hal_executable_function_parameter_t* parameters = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc_array(
+      provider->context->host_allocator, function_info.parameter_count,
+      sizeof(*parameters), (void**)&parameters));
+  iree_status_t status = iree_hal_executable_function_parameters(
+      executable, function, function_info.parameter_count, parameters);
+  if (iree_status_is_ok(status)) {
+    provider->function_parameters = parameters;
+    provider->function_parameter_count = function_info.parameter_count;
+  } else {
+    iree_allocator_free(provider->context->host_allocator, parameters);
+  }
+  return status;
+}
+
 iree_status_t loom_run_hal_testbench_actual_provider_compile(
     loom_run_hal_testbench_actual_provider_t* provider) {
   if (provider->prepared_candidate_initialized || provider->compile_rejected) {
@@ -733,15 +783,23 @@ iree_status_t loom_run_hal_testbench_actual_provider_compile(
         provider->context->device_provider->artifact_provider->name.data);
   }
 
-  IREE_RETURN_IF_ERROR(loom_run_hal_prepared_candidate_prepare(
+  status = loom_run_hal_prepared_candidate_prepare(
       &provider->context->runtime, &provider->candidate.device_artifact,
-      provider->context->host_allocator, &provider->prepared_candidate));
-  provider->prepared_candidate_initialized = true;
-  return iree_ok_status();
+      provider->context->host_allocator, &provider->prepared_candidate);
+  if (iree_status_is_ok(status)) {
+    provider->prepared_candidate_initialized = true;
+    status = loom_run_hal_testbench_reflect_function_parameters(provider);
+  }
+  if (!iree_status_is_ok(status) && provider->prepared_candidate_initialized) {
+    loom_run_hal_prepared_candidate_deinitialize(&provider->prepared_candidate);
+    provider->prepared_candidate_initialized = false;
+  }
+  return status;
 }
 
 static iree_status_t loom_run_hal_testbench_invocation_options_push_constant(
     const loom_testbench_value_t* value, loom_type_t source_type,
+    const iree_hal_executable_function_parameter_t* parameter,
     loom_run_hal_invocation_options_t* options) {
   if (!loom_testbench_value_is_scalar(value)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
@@ -755,31 +813,55 @@ static iree_status_t loom_run_hal_testbench_invocation_options_push_constant(
   }
   const loom_scalar_type_t source_scalar_type =
       loom_type_element_type(source_type);
-  if (source_scalar_type == LOOM_SCALAR_TYPE_INDEX) {
+  iree_host_size_t abi_word_count = 0;
+  if (parameter != NULL) {
+    if (parameter->type !=
+        IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "HAL executable parameter for scalar input is not a constant");
+    }
+    if (parameter->size == 0 ||
+        (parameter->size % sizeof(options->constants[0])) != 0) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "HAL executable constant parameter has invalid byte length %u",
+          (unsigned)parameter->size);
+    }
+    const iree_host_size_t expected_offset =
+        options->constant_count * sizeof(options->constants[0]);
+    if (parameter->offset != expected_offset) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "HAL executable constant parameter offset %u does not match next "
+          "packed offset %" PRIhsz,
+          (unsigned)parameter->offset, expected_offset);
+    }
+    abi_word_count = parameter->size / sizeof(options->constants[0]);
+  }
+  if (source_scalar_type == LOOM_SCALAR_TYPE_INDEX ||
+      source_scalar_type == LOOM_SCALAR_TYPE_OFFSET) {
     int64_t integer_value = 0;
     IREE_RETURN_IF_ERROR(loom_testbench_value_as_i64(value, &integer_value));
-    if (integer_value < INT32_MIN || integer_value > INT32_MAX) {
+    if (abi_word_count == 0) {
+      abi_word_count = source_scalar_type == LOOM_SCALAR_TYPE_INDEX ? 1 : 2;
+    }
+    if (abi_word_count != 1 && abi_word_count != 2) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "HAL dispatch %s constant has unsupported ABI word count %" PRIhsz,
+          loom_scalar_type_name(source_scalar_type), abi_word_count);
+    }
+    if (abi_word_count == 1 &&
+        (integer_value < INT32_MIN || integer_value > UINT32_MAX)) {
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "HAL dispatch %s constant value %" PRId64
                               " does not fit the 32-bit direct-constant ABI",
                               loom_scalar_type_name(source_scalar_type),
                               integer_value);
     }
-    if (options->constant_count + 1 > LOOM_RUN_HAL_MAX_CONSTANT_COUNT) {
-      return iree_make_status(
-          IREE_STATUS_OUT_OF_RANGE,
-          "HAL dispatch constant count exceeds capacity "
-          "%" PRIhsz,
-          (iree_host_size_t)LOOM_RUN_HAL_MAX_CONSTANT_COUNT);
-    }
-    options->constants[options->constant_count++] =
-        (uint32_t)(int32_t)integer_value;
-    return iree_ok_status();
-  }
-  if (source_scalar_type == LOOM_SCALAR_TYPE_OFFSET) {
-    int64_t integer_value = 0;
-    IREE_RETURN_IF_ERROR(loom_testbench_value_as_i64(value, &integer_value));
-    if (options->constant_count + 2 > LOOM_RUN_HAL_MAX_CONSTANT_COUNT) {
+    if (options->constant_count + abi_word_count >
+        LOOM_RUN_HAL_MAX_CONSTANT_COUNT) {
       return iree_make_status(
           IREE_STATUS_OUT_OF_RANGE,
           "HAL dispatch constant count exceeds capacity "
@@ -788,7 +870,10 @@ static iree_status_t loom_run_hal_testbench_invocation_options_push_constant(
     }
     const uint64_t raw_value = (uint64_t)integer_value;
     options->constants[options->constant_count++] = (uint32_t)raw_value;
-    options->constants[options->constant_count++] = (uint32_t)(raw_value >> 32);
+    if (abi_word_count == 2) {
+      options->constants[options->constant_count++] =
+          (uint32_t)(raw_value >> 32);
+    }
     return iree_ok_status();
   }
 
@@ -796,6 +881,13 @@ static iree_status_t loom_run_hal_testbench_invocation_options_push_constant(
   iree_host_size_t word_count = 0;
   IREE_RETURN_IF_ERROR(iree_tooling_value_write_abi_words(
       &value->scalar, IREE_ARRAYSIZE(words), words, &word_count));
+  if (abi_word_count != 0 && word_count != abi_word_count) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "HAL dispatch %s constant requires %" PRIhsz
+                            " reflected ABI words but materializes %" PRIhsz,
+                            loom_scalar_type_name(source_scalar_type),
+                            abi_word_count, word_count);
+  }
   if (options->constant_count + word_count > LOOM_RUN_HAL_MAX_CONSTANT_COUNT) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "HAL dispatch constant count exceeds capacity "
@@ -808,8 +900,29 @@ static iree_status_t loom_run_hal_testbench_invocation_options_push_constant(
   return iree_ok_status();
 }
 
+static iree_status_t loom_run_hal_testbench_validate_buffer_parameter(
+    const iree_hal_executable_function_parameter_t* parameter,
+    iree_host_size_t binding_ordinal) {
+  if (parameter == NULL) {
+    return iree_ok_status();
+  }
+  if (parameter->type != IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "HAL executable parameter for buffer input is not a binding");
+  }
+  if (parameter->offset != binding_ordinal) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "HAL executable binding ordinal %u does not match "
+                            "next binding %" PRIhsz,
+                            (unsigned)parameter->offset, binding_ordinal);
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t loom_run_hal_testbench_append_buffer_binding(
     const loom_testbench_value_t* input,
+    const iree_hal_executable_function_parameter_t* parameter,
     loom_run_hal_binding_list_t* bindings) {
   if (!loom_testbench_value_is_buffer(input) ||
       input->buffer.kind == IREE_TOOLING_BUFFER_BINDING_KIND_NONE ||
@@ -823,6 +936,8 @@ static iree_status_t loom_run_hal_testbench_append_buffer_binding(
                             "%" PRIhsz,
                             bindings->capacity);
   }
+  IREE_RETURN_IF_ERROR(loom_run_hal_testbench_validate_buffer_parameter(
+      parameter, bindings->count));
   iree_tooling_buffer_binding_t* binding = &bindings->values[bindings->count];
   *binding = input->buffer;
   iree_hal_buffer_retain(binding->buffer);
@@ -833,13 +948,16 @@ static iree_status_t loom_run_hal_testbench_append_buffer_binding(
 
 static iree_status_t loom_run_hal_testbench_input_append(
     loom_run_hal_binding_list_t* bindings, const loom_testbench_value_t* input,
-    loom_type_t input_type, loom_run_hal_invocation_options_t* options) {
+    loom_type_t input_type,
+    const iree_hal_executable_function_parameter_t* parameter,
+    loom_run_hal_invocation_options_t* options) {
   if (loom_testbench_value_is_buffer(input)) {
-    return loom_run_hal_testbench_append_buffer_binding(input, bindings);
+    return loom_run_hal_testbench_append_buffer_binding(input, parameter,
+                                                        bindings);
   }
   if (loom_testbench_value_is_scalar(input)) {
     return loom_run_hal_testbench_invocation_options_push_constant(
-        input, input_type, options);
+        input, input_type, parameter, options);
   }
   return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                           "HAL invocation input must be a buffer binding or "
@@ -848,6 +966,7 @@ static iree_status_t loom_run_hal_testbench_input_append(
 
 iree_status_t loom_run_hal_testbench_invocation_inputs_from_values(
     const loom_testbench_value_t* inputs, const loom_type_t* input_types,
+    const iree_hal_executable_function_parameter_t* input_parameters,
     iree_host_size_t input_count, loom_run_hal_invocation_options_t* options,
     iree_allocator_t allocator, loom_run_hal_binding_list_t* out_bindings) {
   if (input_count != 0 && (inputs == NULL || input_types == NULL)) {
@@ -861,8 +980,10 @@ iree_status_t loom_run_hal_testbench_invocation_inputs_from_values(
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t i = 0; iree_status_is_ok(status) && i < input_count;
        ++i) {
-    status = loom_run_hal_testbench_input_append(out_bindings, &inputs[i],
-                                                 input_types[i], options);
+    const iree_hal_executable_function_parameter_t* parameter =
+        input_parameters != NULL ? &input_parameters[i] : NULL;
+    status = loom_run_hal_testbench_input_append(
+        out_bindings, &inputs[i], input_types[i], parameter, options);
   }
   if (!iree_status_is_ok(status)) {
     loom_run_hal_binding_list_deinitialize(out_bindings);
@@ -952,8 +1073,12 @@ iree_status_t loom_run_hal_testbench_actual_invoke(
         provider->kernel_launch->input_value_ids[i];
     const loom_type_t input_type =
         loom_module_value_type(provider->run_module->module, input_value_id);
+    const iree_hal_executable_function_parameter_t* parameter =
+        provider->function_parameter_count != 0
+            ? &provider->function_parameters[i]
+            : NULL;
     status = loom_run_hal_testbench_input_append(
-        &bindings, &inputs[i], input_type, &invocation_options);
+        &bindings, &inputs[i], input_type, parameter, &invocation_options);
     if (!iree_status_is_ok(status)) {
       status = iree_status_annotate_f(
           status, "preparing HAL actual input %" PRIhsz " for value ID %u", i,
@@ -1339,11 +1464,16 @@ static iree_status_t loom_run_hal_testbench_actual_sequence_prepare_sample(
     }
     IREE_RETURN_IF_ERROR(loom_run_hal_testbench_evaluate_launch_config(
         provider, invocation->workload_count, &step->options));
+    iree_host_size_t invocation_binding_ordinal = 0;
     for (iree_host_size_t input_index = 0;
          input_index < invocation->input_count; ++input_index) {
       const loom_testbench_value_t* input = span->input_values[input_offset++];
       const loom_type_t input_type = loom_module_value_type(
           invocation->module, invocation->input_value_ids[input_index]);
+      const iree_hal_executable_function_parameter_t* parameter =
+          provider->function_parameter_count != 0
+              ? &provider->function_parameters[input_index]
+              : NULL;
       if (loom_type_is_shaped(input_type)) {
         if (!loom_testbench_value_is_buffer(input) ||
             input->buffer.buffer == NULL) {
@@ -1351,11 +1481,14 @@ static iree_status_t loom_run_hal_testbench_actual_sequence_prepare_sample(
               IREE_STATUS_INVALID_ARGUMENT,
               "HAL kernel launch shaped input is not a buffer");
         }
+        IREE_RETURN_IF_ERROR(loom_run_hal_testbench_validate_buffer_parameter(
+            parameter, invocation_binding_ordinal));
         span->binding_lengths[binding_offset++] = input->buffer.byte_length;
+        ++invocation_binding_ordinal;
       } else {
         IREE_RETURN_IF_ERROR(
             loom_run_hal_testbench_invocation_options_push_constant(
-                input, input_type, &step->options));
+                input, input_type, parameter, &step->options));
       }
     }
   }
@@ -1601,8 +1734,12 @@ iree_status_t loom_run_hal_testbench_materialize_invocation_from_table(
     if (iree_status_is_ok(status)) {
       const loom_type_t input_type =
           loom_module_value_type(table->module, invocation->input_value_ids[i]);
-      status = loom_run_hal_testbench_input_append(out_bindings, &value,
-                                                   input_type, out_options);
+      const iree_hal_executable_function_parameter_t* parameter =
+          provider->function_parameter_count != 0
+              ? &provider->function_parameters[i]
+              : NULL;
+      status = loom_run_hal_testbench_input_append(
+          out_bindings, &value, input_type, parameter, out_options);
     }
     loom_testbench_value_deinitialize(&value);
   }

--- a/loom/src/loom/tooling/execution/hal/testbench_actual.h
+++ b/loom/src/loom/tooling/execution/hal/testbench_actual.h
@@ -171,6 +171,12 @@ typedef struct loom_run_hal_testbench_actual_provider_t {
   loom_device_target_t compile_device_target;
   // Prepared executable retained for correctness and benchmark dispatches.
   loom_run_hal_prepared_candidate_t prepared_candidate;
+  // Allocator-owned reflected logical parameter layout for the prepared
+  // executable function. Parameter string views borrow executable storage.
+  iree_hal_executable_function_parameter_t* function_parameters;
+  // Number of entries in |function_parameters|. Zero means the backend did
+  // not publish logical parameter reflection.
+  iree_host_size_t function_parameter_count;
   // Dispatch options derived from the compiled source entry.
   loom_run_hal_invocation_options_t invocation_options;
   // Most recently resolved source launch configuration. This is refreshed
@@ -308,11 +314,12 @@ loom_run_hal_testbench_actual_sequence_provider(
 
 // Appends borrowed testbench input values to HAL bindings/constants.
 //
-// Scalar constants are packed according to the corresponding Loom source input
-// type, not only the scalar carrier type. This matters for index/offset values,
-// which have target ABI widths independent of the materialized scalar storage.
+// When |input_parameters| is provided, scalar widths and HAL table offsets are
+// taken from the loaded executable's reflected ABI. A NULL parameter list uses
+// the source-type defaults required by backends without parameter reflection.
 iree_status_t loom_run_hal_testbench_invocation_inputs_from_values(
     const loom_testbench_value_t* inputs, const loom_type_t* input_types,
+    const iree_hal_executable_function_parameter_t* input_parameters,
     iree_host_size_t input_count, loom_run_hal_invocation_options_t* options,
     iree_allocator_t allocator, loom_run_hal_binding_list_t* out_bindings);
 

--- a/loom/src/loom/tooling/execution/hal/testbench_actual_test.cc
+++ b/loom/src/loom/tooling/execution/hal/testbench_actual_test.cc
@@ -111,6 +111,14 @@ static loom_testbench_value_t I64Value(int64_t value) {
   return result;
 }
 
+static loom_testbench_value_t F32Value(float value) {
+  loom_testbench_value_t result = {};
+  result.kind = LOOM_TESTBENCH_VALUE_KIND_SCALAR;
+  result.scalar.kind = IREE_TOOLING_VALUE_KIND_F32;
+  result.scalar.storage.f32 = value;
+  return result;
+}
+
 static loom_testbench_value_t F64Value(double value) {
   loom_testbench_value_t result = {};
   result.kind = LOOM_TESTBENCH_VALUE_KIND_SCALAR;
@@ -220,8 +228,8 @@ TEST_F(HalTestbenchActualTest, ScalarInputsPackDispatchConstantWords) {
   loom_run_hal_binding_list_t bindings = {};
 
   IREE_ASSERT_OK(loom_run_hal_testbench_invocation_inputs_from_values(
-      inputs, input_types, IREE_ARRAYSIZE(inputs), &options,
-      iree_allocator_system(), &bindings));
+      inputs, input_types, /*input_parameters=*/nullptr, IREE_ARRAYSIZE(inputs),
+      &options, iree_allocator_system(), &bindings));
 
   EXPECT_EQ(bindings.count, 0u);
   EXPECT_EQ(options.constant_count, 3u);
@@ -244,8 +252,8 @@ TEST_F(HalTestbenchActualTest, F64InputsPackDispatchConstantWords) {
   loom_run_hal_binding_list_t bindings = {};
 
   IREE_ASSERT_OK(loom_run_hal_testbench_invocation_inputs_from_values(
-      inputs, input_types, IREE_ARRAYSIZE(inputs), &options,
-      iree_allocator_system(), &bindings));
+      inputs, input_types, /*input_parameters=*/nullptr, IREE_ARRAYSIZE(inputs),
+      &options, iree_allocator_system(), &bindings));
 
   EXPECT_EQ(bindings.count, 0u);
   EXPECT_EQ(options.constant_count, 2u);
@@ -267,12 +275,52 @@ TEST_F(HalTestbenchActualTest, IndexInputPacksAsOneDispatchConstantWord) {
   loom_run_hal_binding_list_t bindings = {};
 
   IREE_ASSERT_OK(loom_run_hal_testbench_invocation_inputs_from_values(
-      inputs, input_types, IREE_ARRAYSIZE(inputs), &options,
-      iree_allocator_system(), &bindings));
+      inputs, input_types, /*input_parameters=*/nullptr, IREE_ARRAYSIZE(inputs),
+      &options, iree_allocator_system(), &bindings));
 
   EXPECT_EQ(bindings.count, 0u);
   EXPECT_EQ(options.constant_count, 1u);
   EXPECT_EQ(options.constants[0], 3584u);
+
+  loom_run_hal_binding_list_deinitialize(&bindings);
+}
+
+TEST_F(HalTestbenchActualTest, MixedInputsUseReflectedWidthsAndOffsets) {
+  loom_testbench_value_t inputs[] = {
+      I64Value(3584),
+      F32Value(4.0f),
+  };
+  loom_type_t input_types[] = {
+      loom_type_scalar(LOOM_SCALAR_TYPE_INDEX),
+      loom_type_scalar(LOOM_SCALAR_TYPE_F32),
+  };
+  iree_hal_executable_function_parameter_t input_parameters[] = {
+      {
+          /*.type=*/IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT,
+          /*.flags=*/{},
+          /*.size=*/8,
+          /*.offset=*/0,
+      },
+      {
+          /*.type=*/IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT,
+          /*.flags=*/{},
+          /*.size=*/4,
+          /*.offset=*/8,
+      },
+  };
+  loom_run_hal_invocation_options_t options = {};
+  loom_run_hal_invocation_options_initialize(&options);
+  loom_run_hal_binding_list_t bindings = {};
+
+  IREE_ASSERT_OK(loom_run_hal_testbench_invocation_inputs_from_values(
+      inputs, input_types, input_parameters, IREE_ARRAYSIZE(inputs), &options,
+      iree_allocator_system(), &bindings));
+
+  EXPECT_EQ(bindings.count, 0u);
+  EXPECT_EQ(options.constant_count, 3u);
+  EXPECT_EQ(options.constants[0], 3584u);
+  EXPECT_EQ(options.constants[1], 0u);
+  EXPECT_EQ(options.constants[2], 0x40800000u);
 
   loom_run_hal_binding_list_deinitialize(&bindings);
 }
@@ -289,13 +337,41 @@ TEST_F(HalTestbenchActualTest, OffsetInputPacksAsTwoDispatchConstantWords) {
   loom_run_hal_binding_list_t bindings = {};
 
   IREE_ASSERT_OK(loom_run_hal_testbench_invocation_inputs_from_values(
-      inputs, input_types, IREE_ARRAYSIZE(inputs), &options,
-      iree_allocator_system(), &bindings));
+      inputs, input_types, /*input_parameters=*/nullptr, IREE_ARRAYSIZE(inputs),
+      &options, iree_allocator_system(), &bindings));
 
   EXPECT_EQ(bindings.count, 0u);
   EXPECT_EQ(options.constant_count, 2u);
   EXPECT_EQ(options.constants[0], 0x55667788u);
   EXPECT_EQ(options.constants[1], 0x11223344u);
+
+  loom_run_hal_binding_list_deinitialize(&bindings);
+}
+
+TEST_F(HalTestbenchActualTest, OffsetInputUsesReflectedFourByteWidth) {
+  loom_testbench_value_t inputs[] = {
+      I64Value(3584),
+  };
+  loom_type_t input_types[] = {
+      loom_type_scalar(LOOM_SCALAR_TYPE_OFFSET),
+  };
+  iree_hal_executable_function_parameter_t input_parameters[] = {{
+      /*.type=*/IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT,
+      /*.flags=*/{},
+      /*.size=*/4,
+      /*.offset=*/0,
+  }};
+  loom_run_hal_invocation_options_t options = {};
+  loom_run_hal_invocation_options_initialize(&options);
+  loom_run_hal_binding_list_t bindings = {};
+
+  IREE_ASSERT_OK(loom_run_hal_testbench_invocation_inputs_from_values(
+      inputs, input_types, input_parameters, IREE_ARRAYSIZE(inputs), &options,
+      iree_allocator_system(), &bindings));
+
+  EXPECT_EQ(bindings.count, 0u);
+  EXPECT_EQ(options.constant_count, 1u);
+  EXPECT_EQ(options.constants[0], 3584u);
 
   loom_run_hal_binding_list_deinitialize(&bindings);
 }

--- a/loom/src/loom/tooling/target/amdgpu/test/BUILD.bazel
+++ b/loom/src/loom/tooling/target/amdgpu/test/BUILD.bazel
@@ -11,7 +11,7 @@ load(
     "loom_test",
 )
 load(
-    "//loom/src/loom/tooling/target/amdgpu:execution_profiles.bzl",
+    "//loom/target/amdgpu:execution_profiles.bzl",
     "AMDGPU_ACCESS_PROFILE",
     "AMDGPU_ASAN_PROFILE",
     "AMDGPU_HARDWARE_PROFILE",

--- a/loom/target/amdgpu/BUILD.bazel
+++ b/loom/target/amdgpu/BUILD.bazel
@@ -17,6 +17,8 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["execution_profiles.bzl"])
+
 [
     loom_amdgpu_target_profile(
         name = target,

--- a/loom/target/amdgpu/execution_profiles.bzl
+++ b/loom/target/amdgpu/execution_profiles.bzl
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Execution profiles owned by the Loom AMDGPU target provider."""
+"""Public execution profiles owned by the Loom AMDGPU target provider."""
 
 load("//loom/build_tools/bazel:defs.bzl", "loom_execution_profile")
 load(


### PR DESCRIPTION
Loom's programming guide currently moves from acquisition directly into a multi-module source-to-artifacts tour. That is useful architectural material, but it asks a new kernel author to absorb composition, specialization, command programs, and compiler reports before seeing one kernel execute. This adds a narrow first-success path: one readable source file that formats, tests boundary cases on AMDGPU, benchmarks a proven workload, and participates in the normal Bazel library flow. It also fixes the target-ABI packing defect that this first end-to-end example exposed.

## Keep the implementation, oracle, and workload together

The new SAXPY example owns its dynamic launch calculation, tail-safe device body, deterministic correctness samples, and one named 64K benchmark in `saxpy.loom`. Sizes immediately around the 256-work-item boundary make the first test useful instead of merely proving that compilation returned success. The benchmark selects the largest checked sample instead of copying setup or inventing a parallel benchmark harness.

The package's public `run.sh` prints and executes the same format, planning, target-emission, AMDGPU correctness, and benchmark commands taught by the page. Documentation generation takes its explicit compiler-only path, verifies the planned workload and generic gfx11 artifact, and stages the exact source and BUILD declaration included by MkDocs.

## Make one Bazel declaration own the lifecycle

The example uses `loom_kernel_library` with an AMDGPU execution profile and generic gfx11 target. Its generated suite owns source formatting and linting, benchmark planning, deployment-artifact inspection, AMDGPU correctness, and one-pass benchmark smoke execution. Deployment linking selects the exported kernel root and strips the colocated `check.case` and `check.benchmark` records before target compilation.

The existing AMDGPU execution profiles move from an internal compiler-test package to the public AMDGPU target package without changing their policy. External kernel repositories can therefore reuse the same requirements, device arguments, sanitizer variants, resource serialization, and query tags as Loom's own tests.

## Make the compiled artifact own dispatch packing

AMDGPU lowering can represent an `index` or `offset` launch argument with one or two 32-bit words based on the facts proven about that value. The HAL testbench instead inferred fixed widths from source types, allowing its dispatch payload to disagree with the executable ABI after legal fact-sensitive lowering.

The testbench now queries logical parameter reflection once from the loaded executable and uses the reported parameter kinds, widths, constant offsets, and binding ordinals for both one-shot correctness execution and batched benchmark execution. Backends that publish only aggregate interface counts retain their established source-type packing; a nonzero but incomplete or inconsistent reflected layout fails before submission. The kernel guide now makes the source-type versus device-ABI distinction explicit for direct HAL hosts as well.

## Put the quickstart at the front door

The new guide becomes the first tutorial from the site landing page, acquisition page, and programming-guide map. The larger source-to-artifacts walkthrough remains the next step for readers ready to learn module composition, specialization, and command products.

## Reviewer Notes

- Review `saxpy.loom` as the complete reader contract: kernel, boundary samples, oracle, and benchmark should remain understandable in one pass.
- Review the `loom_kernel_library` declaration and public AMDGPU profile move together; the example should consume target-owned policy rather than recreate repository-specific CI arguments.
- Review the executable-reflection packing path across one-shot and batched execution; source argument order must agree with reflected constant offsets and binding ordinals.
- Review `.doc-generate.sh` and `run.sh` as one workflow with two environments: a hardware-independent documentation build and a default hardware-backed reader run.
