### PR TITLE
[Loom] Retry fragmented Low register allocations

### DIFF
--- a/loom/py/loom/target/test/descriptors.py
+++ b/loom/py/loom/target/test/descriptors.py
@@ -180,6 +180,14 @@ def _v4i32_operand(field_name: str) -> Operand:
     return Operand(field_name, OperandRole.OPERAND, _I32_ALT, unit_count=4)
 
 
+def _v8i32_result(field_name: str = "dst") -> Operand:
+    return Operand(field_name, OperandRole.RESULT, _I32_ALT, unit_count=8)
+
+
+def _v8i32_operand(field_name: str) -> Operand:
+    return Operand(field_name, OperandRole.OPERAND, _I32_ALT, unit_count=8)
+
+
 def _phys_result(field_name: str = "dst") -> Operand:
     return Operand(field_name, OperandRole.RESULT, _PHYS_ALT)
 
@@ -589,6 +597,26 @@ TEST_LOW_MMA_I32_2X2X2_DESCRIPTOR = Descriptor(
         Operand("lhs", OperandRole.OPERAND, _I32_ALT, unit_count=4),
         Operand("rhs", OperandRole.OPERAND, _I32_ALT, unit_count=4),
         Operand("acc", OperandRole.OPERAND, _I32_ALT, unit_count=4),
+    ),
+    asm_forms=_asm(results=("dst",), operands=("lhs", "rhs", "acc")),
+    schedule_class=_SCHEDULE_VECTOR_ALU,
+    flags=(DescriptorFlag.DEAD_REMOVABLE,),
+)
+
+TEST_LOW_ACCUMULATE_V8I32_DESCRIPTOR = Descriptor(
+    key="test.accumulate.v8i32",
+    mnemonic="test.accumulate.v8i32",
+    semantic_tag="vector.accumulate.i32x8",
+    operands=(
+        _v8i32_result(),
+        _v8i32_operand("lhs"),
+        _v8i32_operand("rhs"),
+        _v8i32_operand("acc"),
+    ),
+    constraints=(
+        Constraint(ConstraintKind.TIED, 0, 3),
+        Constraint(ConstraintKind.DESTRUCTIVE, 0, 3),
+        Constraint(ConstraintKind.EARLY_CLOBBER, 0),
     ),
     asm_forms=_asm(results=("dst",), operands=("lhs", "rhs", "acc")),
     schedule_class=_SCHEDULE_VECTOR_ALU,
@@ -1327,6 +1355,7 @@ TEST_LOW_CORE_DESCRIPTOR_SET = DescriptorSet(
         TEST_LOW_EARLY_TIED_V4I32_DESCRIPTOR,
         TEST_LOW_DOT4I_S8S8_DESCRIPTOR,
         TEST_LOW_MMA_I32_2X2X2_DESCRIPTOR,
+        TEST_LOW_ACCUMULATE_V8I32_DESCRIPTOR,
         TEST_LOW_SHUFFLE_V4I32_DESCRIPTOR,
         TEST_LOW_FROM_ELEMENTS_V4I32_DESCRIPTOR,
         TEST_LOW_CMP_EQ_V4I32_DESCRIPTOR,

--- a/loom/src/loom/codegen/low/allocation.c
+++ b/loom/src/loom/codegen/low/allocation.c
@@ -6,6 +6,8 @@
 
 #include "loom/codegen/low/allocation.h"
 
+#include <string.h>
+
 #include "loom/codegen/low/allocation/copy_decision.h"
 #include "loom/codegen/low/allocation/edge_copy.h"
 #include "loom/codegen/low/allocation/interval_assignment.h"
@@ -90,6 +92,99 @@ static iree_status_t loom_low_allocation_validate_synthesis_mode(
       loom_low_allocation_mode_name(allocation_mode));
 }
 
+static loom_low_allocation_interval_assignment_context_t
+loom_low_allocation_make_interval_assignment_context(
+    loom_low_allocation_build_state_t* state,
+    const loom_low_function_model_t* model,
+    loom_low_allocation_search_strategy_t search_strategy,
+    iree_arena_allocator_t* arena,
+    loom_low_allocation_target_constraints_t* target_constraints,
+    loom_low_allocation_storage_lease_state_t* storage_leases) {
+  return (loom_low_allocation_interval_assignment_context_t){
+      .module = state->module,
+      .body = state->body,
+      .function_op = state->function_op,
+      .target = &state->target,
+      .liveness = &state->liveness,
+      .schedule = state->options->schedule,
+      .placement = &state->placement,
+      .target_constraints = target_constraints,
+      .required_register_values = state->options->required_register_values,
+      .unit_liveness = &state->unit_liveness,
+      .residency_model = state->options->residency_model,
+      .storage_leases = storage_leases,
+      .arena = arena,
+      .function_cfg_graph = &model->cfg_graph,
+      .search_strategy = search_strategy,
+  };
+}
+
+// Probes the fragmentation-repair coloring in isolated mutable state. The
+// caller only commits this strategy when the probe proves that it eliminates
+// every spill, leaving the ordinary first-fit result authoritative otherwise.
+static iree_status_t loom_low_allocation_fragmentation_repair_eliminates_spills(
+    loom_low_allocation_build_state_t* state,
+    const loom_low_function_model_t* model,
+    const loom_local_value_domain_t* value_domain,
+    bool* out_eliminates_spills) {
+  *out_eliminates_spills = false;
+  iree_arena_allocator_t scratch_arena;
+  iree_arena_initialize(state->arena->block_pool, &scratch_arena);
+
+  loom_low_allocation_target_constraints_t scratch_target_constraints =
+      state->target_constraints;
+  scratch_target_constraints.emitter = (iree_diagnostic_emitter_t){0};
+  scratch_target_constraints.error_count = 0;
+  scratch_target_constraints.max_assigned_location_end_by_reg_class = NULL;
+
+  iree_status_t status = iree_ok_status();
+  const iree_host_size_t reg_class_count =
+      state->target.descriptor_set->reg_class_count;
+  if (reg_class_count != 0) {
+    status = iree_arena_allocate_array(
+        &scratch_arena, reg_class_count,
+        sizeof(
+            *scratch_target_constraints.max_assigned_location_end_by_reg_class),
+        (void**)&scratch_target_constraints
+            .max_assigned_location_end_by_reg_class);
+    if (iree_status_is_ok(status)) {
+      memset(scratch_target_constraints.max_assigned_location_end_by_reg_class,
+             0,
+             reg_class_count *
+                 sizeof(*scratch_target_constraints
+                             .max_assigned_location_end_by_reg_class));
+    }
+  }
+
+  loom_low_allocation_storage_lease_state_t scratch_storage_leases = {0};
+  if (iree_status_is_ok(status)) {
+    status = loom_low_allocation_storage_lease_state_initialize(
+        &state->options->storage_leases, state->module, state->function_op,
+        value_domain, &state->liveness, &scratch_arena,
+        &scratch_storage_leases);
+  }
+
+  loom_low_allocation_interval_assignment_result_t scratch_result = {0};
+  if (iree_status_is_ok(status)) {
+    const loom_low_allocation_interval_assignment_context_t scratch_context =
+        loom_low_allocation_make_interval_assignment_context(
+            state, model,
+            LOOM_LOW_ALLOCATION_SEARCH_STRATEGY_FRAGMENTATION_REPAIR,
+            &scratch_arena, &scratch_target_constraints,
+            &scratch_storage_leases);
+    status = loom_low_allocation_interval_assignment_build(&scratch_context,
+                                                           &scratch_result);
+  }
+  if (iree_status_is_ok(status)) {
+    *out_eliminates_spills = scratch_target_constraints.error_count == 0 &&
+                             scratch_result.spill_count == 0 &&
+                             scratch_result.spill_plan_count == 0;
+  }
+
+  iree_arena_deinitialize(&scratch_arena);
+  return status;
+}
+
 iree_status_t loom_low_allocate_function(
     const loom_low_function_model_t* model,
     const loom_low_allocation_options_t* options, iree_arena_allocator_t* arena,
@@ -154,6 +249,8 @@ iree_status_t loom_low_allocate_function(
         &state.unit_liveness, options->fixed_values, options->fixed_value_count,
         arena);
   }
+  const iree_arena_checkpoint_t interval_assignment_checkpoint =
+      iree_arena_checkpoint_save(arena);
   if (iree_status_is_ok(status) && state.target_constraints.error_count == 0) {
     status = loom_low_allocation_storage_lease_state_initialize(
         &options->storage_leases, model->module, model->function_op,
@@ -161,24 +258,40 @@ iree_status_t loom_low_allocate_function(
   }
   if (iree_status_is_ok(status) && state.target_constraints.error_count == 0) {
     const loom_low_allocation_interval_assignment_context_t
-        interval_assignment_context = {
-            .module = state.module,
-            .body = state.body,
-            .function_op = state.function_op,
-            .target = &state.target,
-            .liveness = &state.liveness,
-            .schedule = options->schedule,
-            .placement = &state.placement,
-            .target_constraints = &state.target_constraints,
-            .required_register_values = options->required_register_values,
-            .unit_liveness = &state.unit_liveness,
-            .residency_model = options->residency_model,
-            .storage_leases = &state.storage_leases,
-            .arena = arena,
-            .function_cfg_graph = &model->cfg_graph,
-        };
+        interval_assignment_context =
+            loom_low_allocation_make_interval_assignment_context(
+                &state, model, LOOM_LOW_ALLOCATION_SEARCH_STRATEGY_FIRST_FIT,
+                arena, &state.target_constraints, &state.storage_leases);
     status = loom_low_allocation_interval_assignment_build(
         &interval_assignment_context, &state.interval_assignment);
+  }
+  if (iree_status_is_ok(status) && state.target_constraints.error_count == 0 &&
+      state.interval_assignment.spill_count != 0) {
+    bool fragmentation_repair_eliminates_spills = false;
+    status = loom_low_allocation_fragmentation_repair_eliminates_spills(
+        &state, model, value_domain, &fragmentation_repair_eliminates_spills);
+    if (iree_status_is_ok(status) && fragmentation_repair_eliminates_spills) {
+      iree_arena_checkpoint_restore(&interval_assignment_checkpoint);
+      loom_low_allocation_target_constraints_rebuild_assignment_location_ends(
+          &state.target_constraints, /*assignments=*/NULL,
+          /*assignment_count=*/0);
+      state.storage_leases = (loom_low_allocation_storage_lease_state_t){0};
+      state.interval_assignment =
+          (loom_low_allocation_interval_assignment_result_t){0};
+      status = loom_low_allocation_storage_lease_state_initialize(
+          &options->storage_leases, model->module, model->function_op,
+          value_domain, &state.liveness, arena, &state.storage_leases);
+      if (iree_status_is_ok(status)) {
+        const loom_low_allocation_interval_assignment_context_t
+            interval_assignment_context =
+                loom_low_allocation_make_interval_assignment_context(
+                    &state, model,
+                    LOOM_LOW_ALLOCATION_SEARCH_STRATEGY_FRAGMENTATION_REPAIR,
+                    arena, &state.target_constraints, &state.storage_leases);
+        status = loom_low_allocation_interval_assignment_build(
+            &interval_assignment_context, &state.interval_assignment);
+      }
+    }
   }
   // Backedge placement belongs to the final physical assignment. Spill repair
   // rewrites the IR and rebuilds the frame, so relocating a provisional spill

--- a/loom/src/loom/codegen/low/allocation/interval_assignment.c
+++ b/loom/src/loom/codegen/low/allocation/interval_assignment.c
@@ -90,6 +90,7 @@ loom_low_allocation_interval_assignment_search_context(
       .storage_leases = state->context->storage_leases,
       .required_register_values = state->context->required_register_values,
       .spill_traffic_by_value_ordinal = state->spill_traffic_by_value_ordinal,
+      .strategy = state->context->search_strategy,
   };
 }
 

--- a/loom/src/loom/codegen/low/allocation/interval_assignment.h
+++ b/loom/src/loom/codegen/low/allocation/interval_assignment.h
@@ -15,6 +15,7 @@
 #include "loom/analysis/liveness.h"
 #include "loom/codegen/low/allocation/assignment.h"
 #include "loom/codegen/low/allocation/assignment_map.h"
+#include "loom/codegen/low/allocation/search.h"
 #include "loom/codegen/low/allocation/storage_lease.h"
 #include "loom/codegen/low/allocation/table.h"
 #include "loom/codegen/low/allocation/target_constraints.h"
@@ -61,6 +62,8 @@ typedef struct loom_low_allocation_interval_assignment_context_t {
   // Borrowed bitmap indexed by module value ID. Set values require register
   // storage throughout allocation.
   iree_bitmap_t required_register_values;
+  // Concrete-location ordering for this whole-function assignment attempt.
+  loom_low_allocation_search_strategy_t search_strategy;
 } loom_low_allocation_interval_assignment_context_t;
 
 typedef struct loom_low_allocation_interval_assignment_result_t {

--- a/loom/src/loom/codegen/low/allocation/search.c
+++ b/loom/src/loom/codegen/low/allocation/search.c
@@ -295,7 +295,7 @@ static void loom_low_allocation_search_find_location_for_release_policy(
     loom_low_allocation_search_context_t* context,
     const loom_low_allocation_assignment_t* candidate_template,
     const loom_low_allocation_search_location_preference_t* preference,
-    uint32_t last_base, uint32_t alignment,
+    uint32_t last_base, uint32_t alignment, uint32_t scalar_packing_frontier,
     loom_low_allocation_storage_release_policy_t release_policy,
     loom_low_allocation_search_location_choice_t* out_choice) {
   *out_choice = (loom_low_allocation_search_location_choice_t){0};
@@ -312,15 +312,23 @@ static void loom_low_allocation_search_find_location_for_release_policy(
               context, preference, &candidate);
       const uint32_t first_base =
           out_choice->found ? out_choice->first_base : base;
+      const bool candidate_is_below_frontier =
+          scalar_packing_frontier != 0 && base < scalar_packing_frontier;
+      const bool choice_is_below_frontier =
+          out_choice->found && scalar_packing_frontier != 0 &&
+          out_choice->base < scalar_packing_frontier;
       if (!out_choice->found ||
-          preference_penalty < out_choice->preference_penalty) {
+          preference_penalty < out_choice->preference_penalty ||
+          (preference_penalty == out_choice->preference_penalty &&
+           candidate_is_below_frontier &&
+           (!choice_is_below_frontier || base > out_choice->base))) {
         *out_choice = (loom_low_allocation_search_location_choice_t){
             .base = base,
             .first_base = first_base,
             .preference_penalty = preference_penalty,
             .found = true,
         };
-        if (preference_penalty == 0) {
+        if (preference_penalty == 0 && scalar_packing_frontier == 0) {
           return;
         }
       }
@@ -330,6 +338,50 @@ static void loom_low_allocation_search_find_location_for_release_policy(
     }
     base += alignment;
   }
+}
+
+static bool loom_low_allocation_search_intervals_overlap(
+    const loom_liveness_interval_t* lhs, const loom_liveness_interval_t* rhs) {
+  return lhs->start_point < rhs->end_point && rhs->start_point < lhs->end_point;
+}
+
+// Returns the exclusive upper frontier where scalar values should pack from
+// high to low. A bounded class only benefits from separating scalars from the
+// interiors of wider values when its liveness lower bound still fits the
+// requested capacity.
+static uint32_t loom_low_allocation_search_scalar_packing_frontier(
+    const loom_low_allocation_search_context_t* context,
+    const loom_liveness_interval_t* interval,
+    const loom_low_allocation_class_capacity_t* capacity) {
+  if (context->strategy !=
+          LOOM_LOW_ALLOCATION_SEARCH_STRATEGY_FRAGMENTATION_REPAIR ||
+      interval->unit_count != 1 || !capacity->is_bounded) {
+    return 0;
+  }
+  uint32_t frontier = 0;
+  for (iree_host_size_t i = 0; i < context->liveness->pressure_summary_count;
+       ++i) {
+    const loom_liveness_pressure_summary_t* summary =
+        &context->liveness->pressure_summaries[i];
+    if (loom_liveness_value_class_equal(summary->value_class,
+                                        interval->value_class)) {
+      frontier = summary->peak_live_units;
+      break;
+    }
+  }
+  if (frontier == 0 || frontier > capacity->max_units) {
+    return 0;
+  }
+  for (iree_host_size_t i = 0; i < context->liveness->interval_count; ++i) {
+    const loom_liveness_interval_t* other = &context->liveness->intervals[i];
+    if (other->unit_count > 1 &&
+        loom_liveness_value_class_equal(other->value_class,
+                                        interval->value_class) &&
+        loom_low_allocation_search_intervals_overlap(interval, other)) {
+      return frontier;
+    }
+  }
+  return 0;
 }
 
 static uint32_t loom_low_allocation_search_location_residency_tier(
@@ -401,14 +453,19 @@ bool loom_low_allocation_search_find_free_location(
   const loom_low_allocation_search_location_preference_t preference =
       loom_low_allocation_search_location_preference(context,
                                                      &candidate_template);
+  const uint32_t scalar_packing_frontier =
+      loom_low_allocation_search_scalar_packing_frontier(context, interval,
+                                                         &capacity);
   loom_low_allocation_search_location_choice_t release_free = {0};
   loom_low_allocation_search_find_location_for_release_policy(
       context, &candidate_template, &preference, last_base, alignment,
-      LOOM_LOW_ALLOCATION_STORAGE_RELEASE_FORBIDDEN, &release_free);
+      scalar_packing_frontier, LOOM_LOW_ALLOCATION_STORAGE_RELEASE_FORBIDDEN,
+      &release_free);
   loom_low_allocation_search_location_choice_t pressure_release = {0};
   if (loom_low_allocation_search_has_pressure_release_records(context)) {
     loom_low_allocation_search_find_location_for_release_policy(
         context, &candidate_template, &preference, last_base, alignment,
+        scalar_packing_frontier,
         LOOM_LOW_ALLOCATION_STORAGE_RELEASE_FOR_PRESSURE, &pressure_release);
   }
   if (pressure_release.found &&
@@ -428,7 +485,8 @@ bool loom_low_allocation_search_find_free_location(
             context, &candidate_template, &release_free, &release_free_tier)) {
       loom_low_allocation_search_find_location_for_release_policy(
           context, &candidate_template, &preference, last_base, alignment,
-          LOOM_LOW_ALLOCATION_STORAGE_RELEASE_ALLOWED, &release_allowed);
+          scalar_packing_frontier, LOOM_LOW_ALLOCATION_STORAGE_RELEASE_ALLOWED,
+          &release_allowed);
       searched_release_allowed = true;
       if (release_allowed.found && release_allowed.base < release_free.base &&
           loom_low_allocation_search_location_residency_tier(
@@ -449,7 +507,8 @@ bool loom_low_allocation_search_find_free_location(
   if (!searched_release_allowed) {
     loom_low_allocation_search_find_location_for_release_policy(
         context, &candidate_template, &preference, last_base, alignment,
-        LOOM_LOW_ALLOCATION_STORAGE_RELEASE_ALLOWED, &release_allowed);
+        scalar_packing_frontier, LOOM_LOW_ALLOCATION_STORAGE_RELEASE_ALLOWED,
+        &release_allowed);
   }
   if (release_allowed.found) {
     *out_base = release_allowed.base;

--- a/loom/src/loom/codegen/low/allocation/search.h
+++ b/loom/src/loom/codegen/low/allocation/search.h
@@ -30,6 +30,15 @@ extern "C" {
 
 struct loom_target_residency_model_t;
 
+// Concrete-location ordering used for one whole-function assignment attempt.
+typedef enum loom_low_allocation_search_strategy_e {
+  // Searches legal locations from low to high.
+  LOOM_LOW_ALLOCATION_SEARCH_STRATEGY_FIRST_FIT = 0,
+  // Separates overlapping scalar and wide intervals across the feasible
+  // liveness-pressure frontier to repair first-fit fragmentation.
+  LOOM_LOW_ALLOCATION_SEARCH_STRATEGY_FRAGMENTATION_REPAIR = 1,
+} loom_low_allocation_search_strategy_t;
+
 // Borrowed allocator facts used when probing physical storage.
 typedef struct loom_low_allocation_search_context_t {
   // Module containing the allocated low function.
@@ -60,6 +69,8 @@ typedef struct loom_low_allocation_search_context_t {
   // Borrowed bitmap indexed by module value ID. Set values require register
   // storage throughout allocation.
   iree_bitmap_t required_register_values;
+  // Concrete-location ordering for the current assignment attempt.
+  loom_low_allocation_search_strategy_t strategy;
 } loom_low_allocation_search_context_t;
 
 // Active assignment set selected for spilling before an interval is assigned.
@@ -96,7 +107,8 @@ bool loom_low_allocation_search_location_conflicts(
     uint16_t ignored_storage_lease_value_count,
     loom_low_allocation_storage_release_policy_t release_policy);
 
-// Finds the first concrete location for |interval| under |capacity|.
+// Finds a concrete location for |interval| under |capacity| using the context's
+// search strategy. Placement preferences and hard conflicts remain primary.
 bool loom_low_allocation_search_find_free_location(
     loom_low_allocation_search_context_t* context,
     const loom_liveness_interval_t* interval,

--- a/loom/src/loom/codegen/low/allocation/search_test.cc
+++ b/loom/src/loom/codegen/low/allocation/search_test.cc
@@ -457,6 +457,144 @@ TEST_F(LowAllocationSearchTest, PreservesFirstFitWithoutPlacementPreference) {
   loom_module_free(module);
 }
 
+TEST_F(LowAllocationSearchTest,
+       FragmentationRepairPacksScalarBelowWidePressureFrontier) {
+  loom_module_t* module = AllocateModule();
+  const loom_value_id_t scalar_value = DefineValue(module);
+  const loom_value_id_t wide_value = DefineValue(module);
+  const loom_value_id_t unrelated_scalar_value = DefineValue(module);
+  loom_module_value_ordinal_scratch_acquire(module);
+  loom_module_value_ordinal_scratch_set(module, scalar_value, /*ordinal=*/0);
+  loom_module_value_ordinal_scratch_set(module, wide_value, /*ordinal=*/1);
+  loom_module_value_ordinal_scratch_set(module, unrelated_scalar_value,
+                                        /*ordinal=*/2);
+
+  const uint64_t descriptor_set_id = 31;
+  const loom_liveness_value_class_t value_class =
+      RegisterValueClass(descriptor_set_id);
+  const loom_liveness_interval_t intervals[] = {
+      Interval(scalar_value, /*start=*/0, /*end=*/8, value_class,
+               /*unit_count=*/1),
+      Interval(wide_value, /*start=*/1, /*end=*/7, value_class,
+               /*unit_count=*/4),
+      Interval(unrelated_scalar_value, /*start=*/8, /*end=*/10, value_class,
+               /*unit_count=*/1),
+  };
+  const uint32_t interval_indices[] = {0, 1, 2};
+  const loom_value_id_t value_ids[] = {scalar_value, wide_value,
+                                       unrelated_scalar_value};
+  const loom_liveness_pressure_summary_t pressure_summaries[] = {
+      {
+          /*.value_class=*/value_class,
+          /*.peak_live_units=*/5,
+      },
+  };
+  loom_liveness_analysis_t liveness = {};
+  liveness.intervals = intervals;
+  liveness.interval_count = IREE_ARRAYSIZE(intervals);
+  liveness.value_ids = value_ids;
+  liveness.value_count = IREE_ARRAYSIZE(value_ids);
+  liveness.value_interval_indices = interval_indices;
+  liveness.pressure_summaries = pressure_summaries;
+  liveness.pressure_summary_count = IREE_ARRAYSIZE(pressure_summaries);
+
+  uint32_t unit_point_starts[] = {0, 1, 5};
+  uint32_t unit_end_points[] = {8, 7, 7, 7, 7, 10};
+  uint64_t edge_handoff_words[] = {0};
+  loom_low_allocation_unit_liveness_t unit_liveness = {};
+  unit_liveness.point_starts_by_value_ordinal = unit_point_starts;
+  unit_liveness.end_points = unit_end_points;
+  unit_liveness.point_count = IREE_ARRAYSIZE(unit_end_points);
+  unit_liveness.values_with_incomplete_storage_segments = {
+      liveness.value_count,
+      edge_handoff_words,
+  };
+
+  const loom_low_reg_class_t reg_class =
+      RegClass(/*allocatable_count=*/8, LOOM_LOW_REG_CLASS_FLAG_PHYSICAL);
+  const loom_low_descriptor_set_t descriptor_set =
+      DescriptorSet(&reg_class, descriptor_set_id);
+  const loom_low_resolved_target_t target = ResolvedTarget(&descriptor_set);
+  uint32_t max_assigned_location_end_by_reg_class[] = {0};
+  loom_low_allocation_target_constraints_t target_constraints = {};
+  target_constraints.target = &target;
+  target_constraints.max_assigned_location_end_by_reg_class =
+      max_assigned_location_end_by_reg_class;
+
+  const uint32_t assignment_indices_by_value_ordinal[] = {
+      UINT32_MAX,
+      UINT32_MAX,
+      UINT32_MAX,
+  };
+  loom_low_allocation_assignment_t assignments[1] = {};
+  loom_low_allocation_assignment_map_t assignment_map = {};
+  assignment_map.module = module;
+  assignment_map.liveness = &liveness;
+  assignment_map.assignments = assignments;
+  assignment_map.assignment_indices_by_value_ordinal =
+      assignment_indices_by_value_ordinal;
+
+  loom_low_allocation_active_set_t active_set = {};
+  IREE_ASSERT_OK(loom_low_allocation_active_set_initialize(
+      &liveness, /*assignment_capacity=*/3, /*unit_capacity=*/6, &arena_,
+      &active_set));
+  loom_low_allocation_storage_lease_state_t storage_leases = {};
+  loom_low_allocation_search_context_t context = {};
+  context.module = module;
+  context.descriptor_set = &descriptor_set;
+  context.liveness = &liveness;
+  context.unit_liveness = &unit_liveness;
+  context.target_constraints = &target_constraints;
+  context.assignment_map = &assignment_map;
+  context.active_set = &active_set;
+  context.storage_leases = &storage_leases;
+
+  // Ordinary first-fit retains the lowest legal location.
+  uint32_t location_base = UINT32_MAX;
+  EXPECT_TRUE(loom_low_allocation_search_find_free_location(
+      &context, &intervals[0], Capacity(/*max_units=*/8), &location_base));
+  EXPECT_EQ(location_base, 0u);
+
+  context.strategy = LOOM_LOW_ALLOCATION_SEARCH_STRATEGY_FRAGMENTATION_REPAIR;
+  location_base = UINT32_MAX;
+  EXPECT_TRUE(loom_low_allocation_search_find_free_location(
+      &context, &intervals[0], Capacity(/*max_units=*/8), &location_base));
+  EXPECT_EQ(location_base, 4u);
+
+  // The opposite packing direction is local to scalars whose own live range
+  // overlaps a wide value.
+  location_base = UINT32_MAX;
+  EXPECT_TRUE(loom_low_allocation_search_find_free_location(
+      &context, &intervals[2], Capacity(/*max_units=*/8), &location_base));
+  EXPECT_EQ(location_base, 0u);
+
+  // A pressure lower bound above the capacity proves that packing direction
+  // cannot make the whole class fit and retains ordinary first-fit behavior.
+  location_base = UINT32_MAX;
+  EXPECT_TRUE(loom_low_allocation_search_find_free_location(
+      &context, &intervals[0], Capacity(/*max_units=*/4), &location_base));
+  EXPECT_EQ(location_base, 0u);
+
+  loom_low_allocation_resolved_reserved_range_t reserved_range = {
+      /*.descriptor_reg_class_id=*/0,
+      /*.location_kind=*/LOOM_LOW_ALLOCATION_LOCATION_PHYSICAL_REGISTER,
+      /*.location_base=*/0,
+      /*.location_count=*/5,
+  };
+  target_constraints.reserved_ranges = &reserved_range;
+  target_constraints.reserved_range_count = 1;
+  location_base = UINT32_MAX;
+  EXPECT_TRUE(loom_low_allocation_search_find_free_location(
+      &context, &intervals[0], Capacity(/*max_units=*/8), &location_base));
+  EXPECT_EQ(location_base, 5u);
+
+  loom_module_value_ordinal_scratch_clear(module, scalar_value);
+  loom_module_value_ordinal_scratch_clear(module, wide_value);
+  loom_module_value_ordinal_scratch_clear(module, unrelated_scalar_value);
+  loom_module_value_ordinal_scratch_release(module);
+  loom_module_free(module);
+}
+
 TEST_F(LowAllocationSearchTest, KeepsReleaseFreeLocationWithoutResidencyModel) {
   loom_module_t* module = AllocateModule();
   EXPECT_EQ(FindFreeLocationWithStorageLease(module, &arena_,

--- a/loom/src/loom/codegen/low/test/BUILD.bazel
+++ b/loom/src/loom/codegen/low/test/BUILD.bazel
@@ -16,6 +16,7 @@ loom_check_test_suite(
     name = "test",
     srcs = [
         "allocation.loom-test",
+        "allocation_fragmentation.loom-test",
         "hazard_plan.loom-test",
         "packet.loom-test",
     ],

--- a/loom/src/loom/codegen/low/test/CMakeLists.txt
+++ b/loom/src/loom/codegen/low/test/CMakeLists.txt
@@ -14,6 +14,7 @@ loom_check_test_suite(
     test
   SRCS
     "allocation.loom-test"
+    "allocation_fragmentation.loom-test"
     "hazard_plan.loom-test"
     "packet.loom-test"
 )

--- a/loom/src/loom/codegen/low/test/allocation_fragmentation.loom-test
+++ b/loom/src/loom/codegen/low/test/allocation_fragmentation.loom-test
@@ -4,52 +4,69 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// The summary tracks the zero-spill contract without pinning an exact coloring.
-// RUN: emit low-allocation @loop_fragmentation amdgpu.vgpr=52
+// A single-unit condition stays live while loop-carried eight-unit aggregates
+// and four-unit load pairs compete for one 52-unit register bank. The summary
+// tracks the zero-spill contract without pinning an exact coloring.
+// RUN: emit low-allocation @loop_fragmentation test.i32=52
 
-amdgpu.target<gfx1100> @target {subgroup_size = 32}
+test.target<low_core> @test_target
 
-low.func.def target<amdgpu.rdna3.core>(@target) @loop_fragmentation(
-    %address: reg<amdgpu.vgpr>,
-    %condition: reg<amdgpu.scc>,
-    %rhs0: reg<amdgpu.vgpr x8>,
-    %rhs1: reg<amdgpu.vgpr x8>,
-    %acc0: reg<amdgpu.vgpr x8>,
-    %acc1: reg<amdgpu.vgpr x8>,
-    %acc2: reg<amdgpu.vgpr x8>) ->
-    (reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>) asm {
-  low.br ^loop(%acc0: reg<amdgpu.vgpr x8>, %acc1: reg<amdgpu.vgpr x8>, %acc2: reg<amdgpu.vgpr x8>)
-^loop(%carried0: reg<amdgpu.vgpr x8>, %carried1: reg<amdgpu.vgpr x8>, %carried2: reg<amdgpu.vgpr x8>):
-  %lhs0_low = ds_read_b128 %address
-  %lhs0_high = ds_read_b128 %address {offset = 16}
-  %lhs0 = concat(%lhs0_low, %lhs0_high) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
-  %next0 = v_wmma_f32_16x16x16_f16 %lhs0, %rhs0, %carried0
-  %lhs1_low = ds_read_b128 %address {offset = 32}
-  %lhs1_high = ds_read_b128 %address {offset = 48}
-  %lhs1 = concat(%lhs1_low, %lhs1_high) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
-  %next1 = v_wmma_f32_16x16x16_f16 %lhs1, %rhs1, %carried1
-  %lhs2_low = ds_read_b128 %address {offset = 64}
-  %lhs2_high = ds_read_b128 %address {offset = 80}
-  %lhs2 = concat(%lhs2_low, %lhs2_high) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
-  %next2 = v_wmma_f32_16x16x16_f16 %lhs2, %rhs0, %carried2
-  low.cond_br %condition, ^backedge, ^exit_edge : reg<amdgpu.scc>
+low.func.def target<test.low.core>(@test_target) @loop_fragmentation(
+    %pointer: reg<test.ptr>,
+    %condition: reg<test.i32>,
+    %rhs0: reg<test.i32 x8>,
+    %rhs1: reg<test.i32 x8>,
+    %acc0: reg<test.i32 x8>,
+    %acc1: reg<test.i32 x8>,
+    %acc2: reg<test.i32 x8>) ->
+    (reg<test.i32 x8>, reg<test.i32 x8>, reg<test.i32 x8>) asm {
+  low.br ^loop(%acc0: reg<test.i32 x8>, %acc1: reg<test.i32 x8>, %acc2: reg<test.i32 x8>)
+^loop(%carried0: reg<test.i32 x8>, %carried1: reg<test.i32 x8>, %carried2: reg<test.i32 x8>):
+  %lhs0_low = low.op<test.load.v4i32>(%pointer) :
+      (reg<test.ptr>) -> reg<test.i32 x4>
+  %lhs0_high = low.op<test.load.v4i32>(%pointer) :
+      (reg<test.ptr>) -> reg<test.i32 x4>
+  %lhs0 = concat(%lhs0_low, %lhs0_high) :
+      (reg<test.i32 x4>, reg<test.i32 x4>) -> reg<test.i32 x8>
+  %next0 = low.op<test.accumulate.v8i32>(%lhs0, %rhs0, %carried0) :
+      (reg<test.i32 x8>, reg<test.i32 x8>, reg<test.i32 x8>) ->
+      %carried0 as reg<test.i32 x8>
+  %lhs1_low = low.op<test.load.v4i32>(%pointer) :
+      (reg<test.ptr>) -> reg<test.i32 x4>
+  %lhs1_high = low.op<test.load.v4i32>(%pointer) :
+      (reg<test.ptr>) -> reg<test.i32 x4>
+  %lhs1 = concat(%lhs1_low, %lhs1_high) :
+      (reg<test.i32 x4>, reg<test.i32 x4>) -> reg<test.i32 x8>
+  %next1 = low.op<test.accumulate.v8i32>(%lhs1, %rhs1, %carried1) :
+      (reg<test.i32 x8>, reg<test.i32 x8>, reg<test.i32 x8>) ->
+      %carried1 as reg<test.i32 x8>
+  %lhs2_low = low.op<test.load.v4i32>(%pointer) :
+      (reg<test.ptr>) -> reg<test.i32 x4>
+  %lhs2_high = low.op<test.load.v4i32>(%pointer) :
+      (reg<test.ptr>) -> reg<test.i32 x4>
+  %lhs2 = concat(%lhs2_low, %lhs2_high) :
+      (reg<test.i32 x4>, reg<test.i32 x4>) -> reg<test.i32 x8>
+  %next2 = low.op<test.accumulate.v8i32>(%lhs2, %rhs0, %carried2) :
+      (reg<test.i32 x8>, reg<test.i32 x8>, reg<test.i32 x8>) ->
+      %carried2 as reg<test.i32 x8>
+  low.cond_br %condition, ^backedge, ^exit_edge : reg<test.i32>
 ^backedge:
-  low.br ^loop(%next0: reg<amdgpu.vgpr x8>, %next1: reg<amdgpu.vgpr x8>, %next2: reg<amdgpu.vgpr x8>)
+  low.br ^loop(%next0: reg<test.i32 x8>, %next1: reg<test.i32 x8>, %next2: reg<test.i32 x8>)
 ^exit_edge:
-  low.br ^exit(%next0: reg<amdgpu.vgpr x8>, %next1: reg<amdgpu.vgpr x8>, %next2: reg<amdgpu.vgpr x8>)
-^exit(%result0: reg<amdgpu.vgpr x8>, %result1: reg<amdgpu.vgpr x8>, %result2: reg<amdgpu.vgpr x8>):
+  low.br ^exit(%next0: reg<test.i32 x8>, %next1: reg<test.i32 x8>, %next2: reg<test.i32 x8>)
+^exit(%result0: reg<test.i32 x8>, %result1: reg<test.i32 x8>, %result2: reg<test.i32 x8>):
   return %result0, %result1, %result2
 }
 
 // ----
 low-allocation @loop_fragmentation
-target: target
-descriptor_set: amdgpu.rdna3.core
+target: test_target
+descriptor_set: test.low.core
 mode: virtual
 assignments: 25
 remarks: 0
 spills: 0
 copies: coalesced=0 materialized=0
 classes:
-  amdgpu.vgpr: assignments=24 units=161 target_ids=0 physical=49 spill_slots=0 unassigned=0
-  amdgpu.scc: assignments=1 units=1 target_ids=0 physical=1 spill_slots=0 unassigned=0
+  test.i32: assignments=24 units=161 target_ids=49 physical=0 spill_slots=0 unassigned=0
+  test.ptr: assignments=1 units=1 target_ids=1 physical=0 spill_slots=0 unassigned=0

--- a/loom/src/loom/codegen/low/test/allocation_fragmentation.loom-test
+++ b/loom/src/loom/codegen/low/test/allocation_fragmentation.loom-test
@@ -1,0 +1,55 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// The summary tracks the zero-spill contract without pinning an exact coloring.
+// RUN: emit low-allocation @loop_fragmentation amdgpu.vgpr=52
+
+amdgpu.target<gfx1100> @target {subgroup_size = 32}
+
+low.func.def target<amdgpu.rdna3.core>(@target) @loop_fragmentation(
+    %address: reg<amdgpu.vgpr>,
+    %condition: reg<amdgpu.scc>,
+    %rhs0: reg<amdgpu.vgpr x8>,
+    %rhs1: reg<amdgpu.vgpr x8>,
+    %acc0: reg<amdgpu.vgpr x8>,
+    %acc1: reg<amdgpu.vgpr x8>,
+    %acc2: reg<amdgpu.vgpr x8>) ->
+    (reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>) asm {
+  low.br ^loop(%acc0: reg<amdgpu.vgpr x8>, %acc1: reg<amdgpu.vgpr x8>, %acc2: reg<amdgpu.vgpr x8>)
+^loop(%carried0: reg<amdgpu.vgpr x8>, %carried1: reg<amdgpu.vgpr x8>, %carried2: reg<amdgpu.vgpr x8>):
+  %lhs0_low = ds_read_b128 %address
+  %lhs0_high = ds_read_b128 %address {offset = 16}
+  %lhs0 = concat(%lhs0_low, %lhs0_high) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
+  %next0 = v_wmma_f32_16x16x16_f16 %lhs0, %rhs0, %carried0
+  %lhs1_low = ds_read_b128 %address {offset = 32}
+  %lhs1_high = ds_read_b128 %address {offset = 48}
+  %lhs1 = concat(%lhs1_low, %lhs1_high) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
+  %next1 = v_wmma_f32_16x16x16_f16 %lhs1, %rhs1, %carried1
+  %lhs2_low = ds_read_b128 %address {offset = 64}
+  %lhs2_high = ds_read_b128 %address {offset = 80}
+  %lhs2 = concat(%lhs2_low, %lhs2_high) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
+  %next2 = v_wmma_f32_16x16x16_f16 %lhs2, %rhs0, %carried2
+  low.cond_br %condition, ^backedge, ^exit_edge : reg<amdgpu.scc>
+^backedge:
+  low.br ^loop(%next0: reg<amdgpu.vgpr x8>, %next1: reg<amdgpu.vgpr x8>, %next2: reg<amdgpu.vgpr x8>)
+^exit_edge:
+  low.br ^exit(%next0: reg<amdgpu.vgpr x8>, %next1: reg<amdgpu.vgpr x8>, %next2: reg<amdgpu.vgpr x8>)
+^exit(%result0: reg<amdgpu.vgpr x8>, %result1: reg<amdgpu.vgpr x8>, %result2: reg<amdgpu.vgpr x8>):
+  return %result0, %result1, %result2
+}
+
+// ----
+low-allocation @loop_fragmentation
+target: target
+descriptor_set: amdgpu.rdna3.core
+mode: virtual
+assignments: 25
+remarks: 0
+spills: 0
+copies: coalesced=0 materialized=0
+classes:
+  amdgpu.vgpr: assignments=24 units=161 target_ids=0 physical=49 spill_slots=0 unassigned=0
+  amdgpu.scc: assignments=1 units=1 target_ids=0 physical=1 spill_slots=0 unassigned=0

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/low_allocation_fragmentation.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/low_allocation_fragmentation.loom-test
@@ -1,0 +1,57 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// This retains the gfx11 load and destructive-accumulate shape behind the
+// AMDGPU target boundary. The summary tracks the zero-spill contract without
+// pinning an exact coloring.
+// RUN: emit low-allocation @loop_fragmentation amdgpu.vgpr=52
+
+amdgpu.target<gfx1100> @target {subgroup_size = 32}
+
+low.func.def target<amdgpu.rdna3.core>(@target) @loop_fragmentation(
+    %address: reg<amdgpu.vgpr>,
+    %condition: reg<amdgpu.scc>,
+    %rhs0: reg<amdgpu.vgpr x8>,
+    %rhs1: reg<amdgpu.vgpr x8>,
+    %acc0: reg<amdgpu.vgpr x8>,
+    %acc1: reg<amdgpu.vgpr x8>,
+    %acc2: reg<amdgpu.vgpr x8>) ->
+    (reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>) asm {
+  low.br ^loop(%acc0: reg<amdgpu.vgpr x8>, %acc1: reg<amdgpu.vgpr x8>, %acc2: reg<amdgpu.vgpr x8>)
+^loop(%carried0: reg<amdgpu.vgpr x8>, %carried1: reg<amdgpu.vgpr x8>, %carried2: reg<amdgpu.vgpr x8>):
+  %lhs0_low = ds_read_b128 %address
+  %lhs0_high = ds_read_b128 %address {offset = 16}
+  %lhs0 = concat(%lhs0_low, %lhs0_high) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
+  %next0 = v_wmma_f32_16x16x16_f16 %lhs0, %rhs0, %carried0
+  %lhs1_low = ds_read_b128 %address {offset = 32}
+  %lhs1_high = ds_read_b128 %address {offset = 48}
+  %lhs1 = concat(%lhs1_low, %lhs1_high) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
+  %next1 = v_wmma_f32_16x16x16_f16 %lhs1, %rhs1, %carried1
+  %lhs2_low = ds_read_b128 %address {offset = 64}
+  %lhs2_high = ds_read_b128 %address {offset = 80}
+  %lhs2 = concat(%lhs2_low, %lhs2_high) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
+  %next2 = v_wmma_f32_16x16x16_f16 %lhs2, %rhs0, %carried2
+  low.cond_br %condition, ^backedge, ^exit_edge : reg<amdgpu.scc>
+^backedge:
+  low.br ^loop(%next0: reg<amdgpu.vgpr x8>, %next1: reg<amdgpu.vgpr x8>, %next2: reg<amdgpu.vgpr x8>)
+^exit_edge:
+  low.br ^exit(%next0: reg<amdgpu.vgpr x8>, %next1: reg<amdgpu.vgpr x8>, %next2: reg<amdgpu.vgpr x8>)
+^exit(%result0: reg<amdgpu.vgpr x8>, %result1: reg<amdgpu.vgpr x8>, %result2: reg<amdgpu.vgpr x8>):
+  return %result0, %result1, %result2
+}
+
+// ----
+low-allocation @loop_fragmentation
+target: target
+descriptor_set: amdgpu.rdna3.core
+mode: virtual
+assignments: 25
+remarks: 0
+spills: 0
+copies: coalesced=0 materialized=0
+classes:
+  amdgpu.vgpr: assignments=24 units=161 target_ids=0 physical=49 spill_slots=0 unassigned=0
+  amdgpu.scc: assignments=1 units=1 target_ids=0 physical=1 spill_slots=0 unassigned=0


### PR DESCRIPTION
Low register allocation now retries a fragmented first-fit result with a second whole-function coloring that separates unit-width values from overlapping wide intervals. This prevents a feasible coloring from being lost when an early scalar occupies an interior span later required by a loop-carried or transient aggregate.

The initial first-fit allocation remains the stable path. A retry happens only after a spill, uses isolated target-extent and storage-lease state, and is committed only if it removes every spill. Placement affinity remains primary, and retry candidates pass through the same fixed-location, reserved-range, storage-lease, coalescing, residency, and loop-edge pipeline as ordinary allocation.

The allocator invariant is covered independently of AMDGPU through a `test.low.core` graph with the same 52-unit register-class pressure: three loop-carried eight-unit accumulators, two long-lived eight-unit fragments, three paired-load aggregates, and one long-lived scalar. The generic test continues to build when AMDGPU is compiled out. The exact gfx11 source-Low reduction remains separately in the AMDGPU target suite, where its target record, VGPR class, LDS reads, and WMMA constraints are registered only when that target is enabled.

## Reviewer Notes

The key review surfaces are the transactional retry boundary in `allocation.c`, the pressure-frontier location ordering in `search.c`, the target-neutral allocation fixture, and the gfx11 integration fixture under `target/arch/amdgpu`.
