### PR TITLE
[Loom] Restore semantic physical register types

### DIFF
--- a/loom/py/loom/error/target.py
+++ b/loom/py/loom/error/target.py
@@ -1410,30 +1410,6 @@ ERR_TARGET_076 = ErrorDef(
     ),
 )
 
-# ERR_TARGET_077: Physical Low register carries a semantic value type.
-ERR_TARGET_077 = ErrorDef(
-    domain=ErrorDomain.TARGET,
-    code=77,
-    severity=Severity.ERROR,
-    summary="Physical Low register carries a semantic value type.",
-    message=(
-        "low function '@{function_name}' {value_kind} '{value_name}' has "
-        "type {actual_type}, but register class '{register_class}' represents "
-        "target-visible physical storage"
-    ),
-    params=(
-        ErrorParam("function_name", ParamKind.STRING),
-        ErrorParam("value_kind", ParamKind.STRING),
-        ErrorParam("value_name", ParamKind.STRING),
-        ErrorParam("actual_type", ParamKind.TYPE),
-        ErrorParam("register_class", ParamKind.STRING),
-    ),
-    fix_hint=(
-        "Use the canonical carrier-only register type for physical storage; "
-        "retain source semantic constraints as verified predicates and facts"
-    ),
-)
-
 # ERR_TARGET_078: Low invocation helper precondition is not proven.
 ERR_TARGET_078 = ErrorDef(
     domain=ErrorDomain.TARGET,
@@ -1527,6 +1503,5 @@ ALL_TARGET_ERRORS = (
     ERR_TARGET_074,
     ERR_TARGET_075,
     ERR_TARGET_076,
-    ERR_TARGET_077,
     ERR_TARGET_078,
 )

--- a/loom/src/loom/codegen/low/descriptors.h
+++ b/loom/src/loom/codegen/low/descriptors.h
@@ -165,9 +165,9 @@ typedef uint32_t loom_low_register_part_mask_t;
 
 // Register class is virtual-only and has no physical register inventory.
 #define LOOM_LOW_REG_CLASS_FLAG_VIRTUAL_ONLY ((uint16_t)1u << 0)
-// Register class represents target-visible physical storage. Values in a
-// physical class use carrier-only register types; semantic domains remain in
-// predicates and facts rather than typed register payloads.
+// Register class represents target-visible physical storage and participates
+// in physical allocation. This does not constrain whether values carry a
+// semantic value type.
 #define LOOM_LOW_REG_CLASS_FLAG_PHYSICAL ((uint16_t)1u << 1)
 // Register class contains reference-counted or GC-visible references.
 #define LOOM_LOW_REG_CLASS_FLAG_REFERENCE ((uint16_t)1u << 2)

--- a/loom/src/loom/codegen/low/verify.c
+++ b/loom/src/loom/codegen/low/verify.c
@@ -1190,42 +1190,6 @@ static iree_status_t loom_low_verify_emit_unresolved_register_class(
                               params, IREE_ARRAYSIZE(params), NULL, 0);
 }
 
-static iree_status_t loom_low_verify_physical_register_value_type(
-    loom_low_function_verify_state_t* function_state, const loom_op_t* op,
-    iree_string_view_t value_kind, iree_string_view_t placeholder,
-    loom_value_id_t value_id) {
-  const loom_module_t* module = function_state->state->module;
-  const loom_type_t type = loom_module_value_type(module, value_id);
-  if (!loom_low_type_is_register(type) ||
-      !loom_type_register_has_value_type(type)) {
-    return iree_ok_status();
-  }
-
-  uint16_t descriptor_register_class_id = LOOM_LOW_REG_CLASS_NONE;
-  const loom_low_reg_class_t* descriptor_register_class = NULL;
-  if (!loom_low_register_type_resolver_try_resolve(
-          &function_state->register_type_resolver, type,
-          &descriptor_register_class_id, &descriptor_register_class) ||
-      !iree_any_bit_set(descriptor_register_class->flags,
-                        LOOM_LOW_REG_CLASS_FLAG_PHYSICAL)) {
-    return iree_ok_status();
-  }
-
-  const iree_string_view_t register_class = loom_low_descriptor_set_string(
-      function_state->target->descriptor_set,
-      descriptor_register_class->name_string_offset);
-  const loom_diagnostic_param_t params[] = {
-      loom_param_string(function_state->function_name),
-      loom_param_string(value_kind),
-      loom_param_string(loom_low_verify_value_name_or_placeholder(
-          module, value_id, placeholder)),
-      loom_param_type(type),
-      loom_param_string(register_class),
-  };
-  return loom_low_verify_emit(function_state->state, op, LOOM_ERR_TARGET_077,
-                              params, IREE_ARRAYSIZE(params), NULL, 0);
-}
-
 static iree_status_t loom_low_verify_register_value_class(
     loom_low_function_verify_state_t* function_state, const loom_op_t* op,
     iree_string_view_t value_kind, iree_string_view_t placeholder,
@@ -1236,14 +1200,13 @@ static iree_status_t loom_low_verify_register_value_class(
     return iree_ok_status();
   }
   uint16_t descriptor_register_class_id = LOOM_LOW_REG_CLASS_NONE;
-  const loom_low_reg_class_t* descriptor_register_class = NULL;
   bool found_descriptor_register_class =
       loom_low_register_type_resolver_try_resolve(
           &function_state->register_type_resolver, type,
-          &descriptor_register_class_id, &descriptor_register_class);
+          &descriptor_register_class_id,
+          /*out_descriptor_register_class=*/NULL);
   if (found_descriptor_register_class) {
-    return loom_low_verify_physical_register_value_type(
-        function_state, op, value_kind, placeholder, value_id);
+    return iree_ok_status();
   }
   return loom_low_verify_emit_unresolved_register_class(
       function_state, op, value_kind,
@@ -1277,37 +1240,6 @@ static iree_status_t loom_low_verify_function_register_values(
       IREE_RETURN_IF_ERROR(loom_low_verify_register_value_class(
           function_state, op, IREE_SV("argument"), IREE_SV("argument"),
           loom_block_arg_id(block, i)));
-    }
-  }
-  return iree_ok_status();
-}
-
-static iree_status_t loom_low_verify_region_register_value_types(
-    loom_low_function_verify_state_t* function_state, const loom_op_t* owner_op,
-    loom_region_t* region, bool verify_block_arguments) {
-  loom_block_t* block = NULL;
-  loom_region_for_each_block(region, block) {
-    if (verify_block_arguments) {
-      for (uint16_t i = 0; i < block->arg_count; ++i) {
-        IREE_RETURN_IF_ERROR(loom_low_verify_physical_register_value_type(
-            function_state, owner_op, IREE_SV("block argument"),
-            IREE_SV("block argument"), loom_block_arg_id(block, i)));
-      }
-    }
-    loom_op_t* op = NULL;
-    loom_block_for_each_op(block, op) {
-      const loom_value_id_t* results = loom_op_const_results(op);
-      for (uint16_t i = 0; i < op->result_count; ++i) {
-        IREE_RETURN_IF_ERROR(loom_low_verify_physical_register_value_type(
-            function_state, op, IREE_SV("result"), IREE_SV("result"),
-            results[i]));
-      }
-      loom_region_t** regions = loom_op_regions(op);
-      for (uint8_t i = 0; i < op->region_count; ++i) {
-        if (regions[i] == NULL) continue;
-        IREE_RETURN_IF_ERROR(loom_low_verify_region_register_value_types(
-            function_state, op, regions[i], /*verify_block_arguments=*/true));
-      }
     }
   }
   return iree_ok_status();
@@ -2128,11 +2060,6 @@ static iree_status_t loom_low_verify_function(loom_low_verify_state_t* state,
       loom_low_register_type_resolver_for_descriptor_set(target.descriptor_set);
   IREE_RETURN_IF_ERROR(loom_low_verify_function_register_values(
       &function_state, low_func_op, body));
-  if (body != NULL) {
-    IREE_RETURN_IF_ERROR(loom_low_verify_region_register_value_types(
-        &function_state, low_func_op, body,
-        /*verify_block_arguments=*/false));
-  }
   if (loom_low_verify_should_stop(state)) {
     return iree_ok_status();
   }

--- a/loom/src/loom/ops/function_contract_verify.c
+++ b/loom/src/loom/ops/function_contract_verify.c
@@ -162,9 +162,9 @@ static iree_status_t loom_function_contract_verify_predicates(
             module, op, emitter, predicate_index, argument_index);
       }
       const loom_type_t value_type = loom_module_value_type(module, value_id);
-      // Registers without a semantic value type do not expose a numeric domain
-      // to this target-independent verifier. The target-bound Low verifier
-      // decides whether that register form is canonical for its register class.
+      // Carrier-only registers do not expose a numeric domain to this
+      // target-independent verifier. Boundaries that map semantic source values
+      // to carrier-only contracts prove predicates against the source values.
       // Ordinary source values and typed registers retain the strict domain
       // check here.
       const bool has_verifiable_semantic_type =

--- a/loom/src/loom/ops/function_contract_verify.h
+++ b/loom/src/loom/ops/function_contract_verify.h
@@ -20,9 +20,10 @@ extern "C" {
 // Verifies generic function signature and target contracts. Predicate values
 // must belong to the function signature. Source values and typed target
 // registers must satisfy the predicate kind's semantic value domain. Registers
-// without semantic types defer domain validation to the target-bound verifier,
-// which owns the canonical register representation. Dialect-specific verifiers
-// should call this before checking dialect-local function rules.
+// without semantic types expose only their target-owned carrier identity;
+// boundaries that bind semantic values to those contracts must prove the
+// predicates against the source values. Dialect-specific verifiers should call
+// this before checking dialect-local function rules.
 iree_status_t loom_function_contract_verify(const loom_module_t* module,
                                             const loom_op_t* op,
                                             iree_diagnostic_emitter_t emitter);

--- a/loom/src/loom/ops/low/test/target_verify.loom-test
+++ b/loom/src/loom/ops/low/test/target_verify.loom-test
@@ -139,6 +139,17 @@ low.func.def target<test.low.core>(@test_target) @typed_structural_identities(%s
 // ====
 
 test.target<low_core> @test_target
+low.func.def target<test.low.core>(@test_target) @physical_register_semantics(%raw: reg<test.phys>, %typed: reg<test.phys : i32>) -> (reg<test.phys>, reg<test.phys : i32>) {
+  %raw_copy = low.copy %raw : reg<test.phys> -> reg<test.phys>
+  %typed_copy = low.copy %typed : reg<test.phys : i32> -> reg<test.phys : i32>
+  low.br ^exit(%raw_copy: reg<test.phys>, %typed_copy: reg<test.phys : i32>)
+^exit(%raw_result: reg<test.phys>, %typed_result: reg<test.phys : i32>):
+  low.return %raw_result, %typed_result : reg<test.phys>, reg<test.phys : i32>
+}
+
+// ====
+
+test.target<low_core> @test_target
 low.func.def target<test.low.core>(@test_target) @typed_copy_rejects_semantic_retyping(%value: reg<test.i32 : i32>) {
   // ERROR@+1: TYPE/017 {op_name="low.copy", source_type="reg<test.i32 : i32>", result_type="reg<test.i32 : f32>"}
   %copy = low.copy %value : reg<test.i32 : i32> -> reg<test.i32 : f32>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/low_verify_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/low_verify_diagnostics.loom-test
@@ -11,9 +11,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) @return_type_mismatch(%p
 
 amdgpu.target<gfx11-generic> @target
 
-// Physical register classes are carrier-only in canonical Low IR. Semantic
-// constraints belong in predicates and facts rather than the register type.
-// ERROR@+1: TARGET/077 {function_name="typed_physical_carrier", value_kind="argument", value_name="value", actual_type="reg<amdgpu.sgpr : index>", register_class="amdgpu.sgpr"}
-low.func.def target<amdgpu.gfx11.generic.core>(@target) @typed_physical_carrier(%value: reg<amdgpu.sgpr : index>) asm {
-  return
+// Physical allocation and semantic value identity are orthogonal. The target
+// allocator uses the SGPR carrier while semantic-preserving operations retain
+// the known index type.
+low.func.def target<amdgpu.gfx11.generic.core>(@target) @typed_physical_carrier(%value: reg<amdgpu.sgpr : index>) -> (reg<amdgpu.sgpr : index>) asm {
+  return %value
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_invoke.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_invoke.loom-test
@@ -175,8 +175,10 @@ low.kernel.def target<amdgpu.rdna3_5.core>(@caller_target) workgroup_size(1, 1, 
 // ====
 
 // A targetless helper inherits compatibility from its representation contract
-// alone. This form is useful when the same helper body is valid for every
-// concrete target represented by the generic descriptor set.
+// alone. The caller retains its semantic vector type while AMDGPU target
+// mapping selects the helper's carrier-only VGPR contract. This form is useful
+// when the same helper body is valid for every concrete target represented by
+// the generic descriptor set.
 amdgpu.target<gfx1151> @caller_target
 
 low.func.def target<amdgpu.gfx11.generic.core> @identity_helper(%value: reg<amdgpu.vgpr>) -> (reg<amdgpu.vgpr>) asm {


### PR DESCRIPTION
Physical register classes again describe allocation and target-visible storage only. Semantic register payloads remain an orthogonal refinement: `reg<C>` carries opaque target bits, while `reg<C : T>` preserves a known program value type through calls, branches, rewriting, and serialization.

This corrects the generic verifier rule introduced in #513 and retires `TARGET/077` without renumbering later diagnostics. Carrier-only authored helpers remain valid, and `low.invoke` still requires exact agreement with the caller target's mapped Low representation; this does not add a generic typed-to-carrier coercion.

Regression coverage accepts raw and typed physical registers across signatures, copy results, and block arguments, retains AMDGPU's semantic source-to-carrier helper path, and leaves existing unproved semantic retyping diagnostics intact.

## Reviewer Notes

- `PHYSICAL` has no semantic-type policy after this change.
- `low.invoke` type matching is intentionally unchanged.