### PR TITLE
[Loom] Make required-inline CFG composition linear

### DIFF
--- a/loom/src/loom/ir/module.c
+++ b/loom/src/loom/ir/module.c
@@ -509,18 +509,20 @@ void loom_module_update_op_direct_summaries(loom_module_t* module,
   loom_module_adjust_poison_op_count(module, poison_delta);
 }
 
-static iree_status_t loom_region_blocks_ensure_capacity(loom_module_t* module,
-                                                        loom_region_t* region) {
-  if (region->block_count < region->block_capacity) return iree_ok_status();
-  if (region->block_capacity == UINT16_MAX) {
+iree_status_t loom_region_reserve_block_capacity(
+    loom_module_t* module, loom_region_t* region,
+    iree_host_size_t minimum_capacity) {
+  if (minimum_capacity <= region->block_capacity) return iree_ok_status();
+  if (minimum_capacity > UINT16_MAX) {
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "region block count exceeds UINT16_MAX");
   }
 
   iree_host_size_t old_capacity = region->block_capacity;
-  iree_host_size_t new_capacity =
-      old_capacity > 0 ? old_capacity * 2 : (iree_host_size_t)4;
-  if (new_capacity > UINT16_MAX) new_capacity = UINT16_MAX;
+  iree_host_size_t new_capacity = old_capacity > 0 ? old_capacity : 4;
+  while (new_capacity < minimum_capacity) {
+    new_capacity = iree_min(new_capacity * 2, (iree_host_size_t)UINT16_MAX);
+  }
 
   loom_block_t** new_blocks = NULL;
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(&module->arena, new_capacity,
@@ -535,6 +537,16 @@ static iree_status_t loom_region_blocks_ensure_capacity(loom_module_t* module,
   region->blocks = new_blocks;
   region->block_capacity = (uint16_t)new_capacity;
   return iree_ok_status();
+}
+
+static iree_status_t loom_region_blocks_ensure_capacity(loom_module_t* module,
+                                                        loom_region_t* region) {
+  if (region->block_count == UINT16_MAX) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "region block count exceeds UINT16_MAX");
+  }
+  return loom_region_reserve_block_capacity(
+      module, region, (iree_host_size_t)region->block_count + 1);
 }
 
 //===----------------------------------------------------------------------===//

--- a/loom/src/loom/ir/module.h
+++ b/loom/src/loom/ir/module.h
@@ -646,6 +646,13 @@ iree_status_t loom_module_allocate_region(loom_module_t* module,
                                           uint16_t block_count,
                                           loom_region_t** out_region);
 
+// Ensures that |region|'s block pointer table can hold at least
+// |minimum_capacity| blocks without allocating any block objects. Existing
+// block pointers and ordinals are preserved.
+iree_status_t loom_region_reserve_block_capacity(
+    loom_module_t* module, loom_region_t* region,
+    iree_host_size_t minimum_capacity);
+
 // Appends a new block to |region| and returns it in |*out_block|. Existing
 // block objects are never relocated; only the region's block pointer table may
 // grow.

--- a/loom/src/loom/rewrite/callable.c
+++ b/loom/src/loom/rewrite/callable.c
@@ -168,7 +168,7 @@ static iree_status_t loom_callable_validate_single_block_body(
 
 bool loom_callable_body_is_linear(const loom_module_t* module,
                                   loom_func_like_t callee) {
-  if (!module || !loom_func_like_isa(callee)) return false;
+  if (!loom_func_like_isa(callee)) return false;
   loom_region_t* body = loom_func_like_body(callee);
   if (!body || body->block_count != 1) return false;
   const loom_block_t* entry_block = loom_region_const_entry_block(body);
@@ -185,7 +185,7 @@ bool loom_callable_body_is_linear(const loom_module_t* module,
 
 bool loom_callable_call_site_allows_cfg_splice(const loom_module_t* module,
                                                const loom_op_t* call_op) {
-  if (!module || !call_op || !call_op->parent_block || !call_op->parent_op ||
+  if (!call_op || !call_op->parent_block || !call_op->parent_op ||
       iree_any_bit_set(call_op->flags, LOOM_OP_FLAG_DEAD)) {
     return false;
   }
@@ -755,9 +755,159 @@ iree_status_t loom_callable_inline_call(loom_rewriter_t* rewriter,
                                                loom_cfg_br_build);
 }
 
-iree_status_t loom_callable_inline_consuming_call(
+static iree_status_t loom_callable_collect_return_ops(
+    const loom_callable_cfg_body_t* body, loom_op_t** return_ops) {
+  uint16_t return_index = 0;
+  for (uint16_t block_index = 0; block_index < body->region->block_count;
+       ++block_index) {
+    loom_op_t* terminator =
+        loom_region_block(body->region, block_index)->last_op;
+    if (terminator->kind != body->return_op_kind) continue;
+    if (return_index >= body->return_count) {
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "callee return count changed before move");
+    }
+    return_ops[return_index++] = terminator;
+  }
+  if (return_index != body->return_count) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "callee return count changed before move");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_callable_inline_consuming_cfg_call(
+    loom_rewriter_t* rewriter, loom_op_t* call_op, loom_func_like_t callee,
+    loom_call_like_t call, const loom_callable_cfg_body_t* body,
+    loom_callable_build_branch_fn_t build_branch) {
+  if (!build_branch) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "multi-block callable inlining requires a branch builder");
+  }
+  if (!loom_callable_call_site_allows_cfg_splice(rewriter->module, call_op)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "multi-block callable inlining requires a CFG-capable caller region");
+  }
+  loom_block_t* caller_block = call_op->parent_block;
+  loom_region_t* caller_region = caller_block->parent_region;
+  uint16_t caller_block_index = 0;
+  if (!caller_region || !loom_region_try_block_index(
+                            caller_region, caller_block, &caller_block_index)) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "call op is not in a live caller region");
+  }
+  iree_host_size_t final_block_count = 0;
+  if (!iree_host_size_checked_add(caller_region->block_count,
+                                  body->region->block_count,
+                                  &final_block_count) ||
+      !iree_host_size_checked_add(final_block_count, 1, &final_block_count) ||
+      final_block_count > UINT16_MAX) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "inlined caller block count exceeds UINT16_MAX");
+  }
+
+  loom_op_t** return_ops = NULL;
+  if (body->return_count > 0) {
+    IREE_RETURN_IF_ERROR(
+        iree_arena_allocate_array(rewriter->arena, body->return_count,
+                                  sizeof(*return_ops), (void**)&return_ops));
+    IREE_RETURN_IF_ERROR(loom_callable_collect_return_ops(body, return_ops));
+  }
+  const loom_value_slice_t call_operands = loom_call_like_operands(call);
+  loom_value_id_t* entry_arguments = NULL;
+  if (call_operands.count > 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        rewriter->arena, call_operands.count, sizeof(*entry_arguments),
+        (void**)&entry_arguments));
+    memcpy(entry_arguments, call_operands.values,
+           (iree_host_size_t)call_operands.count * sizeof(*entry_arguments));
+  }
+  const loom_value_slice_t call_results = loom_call_like_results(call);
+  loom_value_id_t* continuation_arguments = NULL;
+  if (call_results.count > 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        rewriter->arena, call_results.count, sizeof(*continuation_arguments),
+        (void**)&continuation_arguments));
+  }
+  IREE_RETURN_IF_ERROR(loom_region_reserve_block_capacity(
+      rewriter->module, caller_region, final_block_count));
+
+  const uint16_t moved_block_count = body->region->block_count;
+  const uint16_t moved_block_index = caller_block_index + 1;
+  const loom_location_id_t call_location = call_op->location;
+  loom_op_t* caller_parent_op = call_op->parent_op;
+  const loom_value_id_t value_checkpoint =
+      loom_rewriter_value_checkpoint(rewriter);
+  loom_builder_ip_t saved_ip = loom_builder_save(&rewriter->builder);
+  rewriter->builder.ip.parent_op = caller_parent_op;
+  loom_block_t* moved_entry_block = NULL;
+  iree_status_t status = loom_rewriter_move_region_blocks(
+      rewriter, body->region, callee.op, caller_region, moved_block_index,
+      caller_parent_op, &moved_entry_block);
+  loom_block_t* continuation_block = NULL;
+  if (iree_status_is_ok(status)) {
+    status = loom_region_insert_block(rewriter->module, caller_region,
+                                      moved_block_index + moved_block_count,
+                                      &continuation_block);
+  }
+  for (uint16_t i = 0; i < call_results.count && iree_status_is_ok(status);
+       ++i) {
+    status = loom_builder_define_block_arg(
+        &rewriter->builder, continuation_block,
+        loom_module_value_type(rewriter->module, call_results.values[i]),
+        &continuation_arguments[i]);
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_callable_preserve_call_result_names(
+        rewriter, call, continuation_arguments, call_results.count,
+        value_checkpoint);
+  }
+
+  loom_op_t* tail_op = call_op->next_op;
+  while (iree_status_is_ok(status) && tail_op) {
+    loom_op_t* next_op = tail_op->next_op;
+    status = loom_rewriter_move_to_block_end(
+        rewriter, tail_op, continuation_block, caller_parent_op);
+    tail_op = next_op;
+  }
+  for (uint16_t i = 0; i < body->return_count && iree_status_is_ok(status);
+       ++i) {
+    loom_op_t* return_op = return_ops[i];
+    loom_builder_set_before(&rewriter->builder, return_op);
+    loom_op_t* continuation_branch = NULL;
+    status = build_branch(&rewriter->builder, continuation_block,
+                          loom_op_const_operands(return_op),
+                          return_op->operand_count, return_op->location,
+                          &continuation_branch);
+    if (iree_status_is_ok(status)) {
+      status = loom_rewriter_erase(rewriter, return_op);
+    }
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_rewriter_replace_all_uses_and_erase(
+        rewriter, call_op, continuation_arguments, call_results.count);
+  }
+  if (iree_status_is_ok(status)) {
+    loom_builder_set_block(&rewriter->builder, caller_block);
+    rewriter->builder.ip.parent_op = caller_parent_op;
+    loom_op_t* entry_branch = NULL;
+    status =
+        build_branch(&rewriter->builder, moved_entry_block, entry_arguments,
+                     call_operands.count, call_location, &entry_branch);
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_rewriter_erase(rewriter, callee.op);
+  }
+  loom_builder_restore(&rewriter->builder, saved_ip);
+  return status;
+}
+
+iree_status_t loom_callable_inline_consuming_call_with_branch(
     loom_rewriter_t* rewriter, const loom_availability_analysis_t* availability,
-    loom_op_t* call_op, loom_func_like_t callee) {
+    loom_op_t* call_op, loom_func_like_t callee,
+    loom_callable_build_branch_fn_t build_branch) {
   if (!call_op->parent_block ||
       iree_any_bit_set(call_op->flags, LOOM_OP_FLAG_DEAD)) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
@@ -771,10 +921,16 @@ iree_status_t loom_callable_inline_consuming_call(
   IREE_RETURN_IF_ERROR(
       loom_callable_get_whole_call(rewriter->module, call_op, &call));
 
-  loom_block_t* entry_block = NULL;
-  loom_op_t* terminator_op = NULL;
-  IREE_RETURN_IF_ERROR(loom_callable_validate_single_block_body(
-      rewriter->module, call_op, callee, &entry_block, &terminator_op));
+  loom_callable_cfg_body_t body = {0};
+  IREE_RETURN_IF_ERROR(loom_callable_validate_cfg_body(
+      rewriter->module, call_op, callee, call, &body));
+  if (!availability ||
+      !loom_callable_body_is_linear(rewriter->module, callee)) {
+    return loom_callable_inline_consuming_cfg_call(rewriter, call_op, callee,
+                                                   call, &body, build_branch);
+  }
+  loom_block_t* entry_block = body.entry_block;
+  loom_op_t* terminator_op = entry_block->last_op;
 
   loom_ir_remap_options_t remap_options = {
       .allow_unmapped_values = true,
@@ -805,6 +961,13 @@ iree_status_t loom_callable_inline_consuming_call(
   IREE_RETURN_IF_ERROR(loom_rewriter_replace_all_uses_and_erase(
       rewriter, call_op, replacements, call_results.count));
   return loom_rewriter_erase(rewriter, callee.op);
+}
+
+iree_status_t loom_callable_inline_consuming_call(
+    loom_rewriter_t* rewriter, const loom_availability_analysis_t* availability,
+    loom_op_t* call_op, loom_func_like_t callee) {
+  return loom_callable_inline_consuming_call_with_branch(
+      rewriter, availability, call_op, callee, loom_cfg_br_build);
 }
 
 iree_status_t loom_callable_inline_direct_call(loom_rewriter_t* rewriter,

--- a/loom/src/loom/rewrite/callable.h
+++ b/loom/src/loom/rewrite/callable.h
@@ -82,11 +82,17 @@ iree_status_t loom_callable_inline_direct_call(loom_rewriter_t* rewriter,
 // reference plan proving that the callee is private and that the selected call
 // will be the final live reference outside of the callee's own defining
 // attribute. This helper does not rediscover that global ownership by scanning
-// the module. |availability| must cover the caller region and remain valid
-// across the topology-preserving body move. The callee body must satisfy the
-// same single-block terminator shape as clone inlining. On success body ops are
-// moved before the call, call results are replaced by remapped terminator
-// operands, the call is erased, and the consumed callee op is erased.
+// the module. A linear body moves its operations through |availability| when
+// it is non-NULL. A CFG body, or a linear body with no current availability
+// analysis, moves its blocks through the same entry/continuation splice used by
+// clone inlining and requires |build_branch|. On success the call and consumed
+// callee definition are erased.
+iree_status_t loom_callable_inline_consuming_call_with_branch(
+    loom_rewriter_t* rewriter, const loom_availability_analysis_t* availability,
+    loom_op_t* call_op, loom_func_like_t callee,
+    loom_callable_build_branch_fn_t build_branch);
+
+// Consuming inline using cfg.br for CFG bodies.
 iree_status_t loom_callable_inline_consuming_call(
     loom_rewriter_t* rewriter, const loom_availability_analysis_t* availability,
     loom_op_t* call_op, loom_func_like_t callee);

--- a/loom/src/loom/rewrite/callable_test.cc
+++ b/loom/src/loom/rewrite/callable_test.cc
@@ -577,6 +577,159 @@ TEST_F(CallableInlineTest, ConsumingInlineMovesBodyAndErasesCallee) {
       IREE_SV("call_result")));
 }
 
+TEST_F(CallableInlineTest, ConsumingInlineMovesCfgBlocksAndErasesCallee) {
+  const loom_type_t i32 = loom_type_scalar(LOOM_SCALAR_TYPE_I32);
+  const loom_symbol_ref_t callee_ref = MakeSymbol(IREE_SV("forward"));
+  const loom_symbol_ref_t caller_ref = MakeSymbol(IREE_SV("caller"));
+
+  loom_op_t* callee_op = nullptr;
+  IREE_ASSERT_OK(loom_func_def_build(
+      &module_builder_, 0, 0, 0, 0, 0, 0, 0, loom_symbol_ref_null(), 0,
+      loom_named_attr_slice_empty(), LOOM_STRING_ID_INVALID,
+      loom_named_attr_slice_empty(), callee_ref, &i32, 1, &i32, 1, nullptr, 0,
+      nullptr, 0, LOOM_LOCATION_UNKNOWN, &callee_op));
+  loom_func_like_t callee = loom_func_like_cast(module_, callee_op);
+  uint16_t callee_arg_count = 0;
+  const loom_value_id_t* callee_args =
+      loom_func_like_arg_ids(callee, &callee_arg_count);
+  ASSERT_EQ(callee_arg_count, 1u);
+  loom_region_t* callee_body = loom_func_like_body(callee);
+  loom_block_t* old_entry = loom_region_entry_block(callee_body);
+  const iree_string_view_t entry_comments[] = {IREE_SV(" moved entry")};
+  IREE_ASSERT_OK(loom_module_attach_block_comments(
+      module_, old_entry, entry_comments, IREE_ARRAYSIZE(entry_comments)));
+  loom_block_t* exit_block = nullptr;
+  IREE_ASSERT_OK(loom_region_append_block(module_, callee_body, &exit_block));
+  loom_builder_t callee_builder = BodyBuilder(callee_op);
+  loom_value_id_t forwarded = LOOM_VALUE_ID_INVALID;
+  IREE_ASSERT_OK(loom_builder_define_block_arg(&callee_builder, exit_block, i32,
+                                               &forwarded));
+  loom_op_t* entry_branch = nullptr;
+  IREE_ASSERT_OK(loom_cfg_br_build(&callee_builder, exit_block, callee_args, 1,
+                                   LOOM_LOCATION_UNKNOWN, &entry_branch));
+  loom_builder_set_block(&callee_builder, exit_block);
+  loom_op_t* callee_return = nullptr;
+  IREE_ASSERT_OK(loom_func_return_build(&callee_builder, &forwarded, 1,
+                                        LOOM_LOCATION_UNKNOWN, &callee_return));
+
+  loom_op_t* call_op = nullptr;
+  loom_op_t* caller_op = BuildCaller(caller_ref, callee_ref, i32, &call_op);
+  loom_func_like_t caller = loom_func_like_cast(module_, caller_op);
+  uint16_t caller_arg_count = 0;
+  const loom_value_id_t* caller_args =
+      loom_func_like_arg_ids(caller, &caller_arg_count);
+  ASSERT_EQ(caller_arg_count, 1u);
+
+  loom_rewriter_t rewriter = {};
+  IREE_ASSERT_OK(
+      loom_rewriter_initialize(&rewriter, module_, &rewriter_arena_));
+  loom_availability_analysis_t availability = InitializeAvailability();
+  IREE_ASSERT_OK(loom_callable_inline_consuming_call(&rewriter, &availability,
+                                                     call_op, callee));
+  loom_rewriter_deinitialize(&rewriter);
+
+  EXPECT_TRUE(iree_any_bit_set(call_op->flags, LOOM_OP_FLAG_DEAD));
+  EXPECT_TRUE(iree_any_bit_set(callee_op->flags, LOOM_OP_FLAG_DEAD));
+  EXPECT_TRUE(iree_any_bit_set(callee_return->flags, LOOM_OP_FLAG_DEAD));
+  ASSERT_EQ(callee_body->block_count, 1u);
+  EXPECT_EQ(loom_region_entry_block(callee_body), old_entry);
+  EXPECT_EQ(old_entry->op_count, 0u);
+  EXPECT_EQ(old_entry->arg_count, 0u);
+
+  loom_region_t* caller_body = loom_func_like_body(caller);
+  ASSERT_EQ(caller_body->block_count, 4u);
+  loom_block_t* caller_entry = loom_region_block(caller_body, 0);
+  loom_block_t* moved_entry = loom_region_block(caller_body, 1);
+  loom_block_t* moved_exit = loom_region_block(caller_body, 2);
+  loom_block_t* continuation = loom_region_block(caller_body, 3);
+  EXPECT_NE(moved_entry, old_entry);
+  EXPECT_EQ(moved_exit, exit_block);
+  iree_host_size_t moved_comment_count = 0;
+  const iree_string_view_t* moved_comments =
+      loom_module_block_comments(module_, moved_entry, &moved_comment_count);
+  ASSERT_EQ(moved_comment_count, IREE_ARRAYSIZE(entry_comments));
+  ASSERT_NE(moved_comments, nullptr);
+  EXPECT_TRUE(iree_string_view_equal(moved_comments[0], entry_comments[0]));
+  EXPECT_EQ(moved_entry->last_op, entry_branch);
+  EXPECT_EQ(entry_branch->parent_op, caller_op);
+  EXPECT_EQ(loom_cfg_br_dest(caller_entry->last_op), moved_entry);
+  EXPECT_EQ(loom_cfg_br_args(caller_entry->last_op).values[0], caller_args[0]);
+  EXPECT_EQ(loom_cfg_br_dest(entry_branch), moved_exit);
+  EXPECT_EQ(loom_cfg_br_args(entry_branch).values[0],
+            loom_block_arg_id(moved_entry, 0));
+  ASSERT_TRUE(loom_cfg_br_isa(moved_exit->last_op));
+  EXPECT_EQ(loom_cfg_br_dest(moved_exit->last_op), continuation);
+  ASSERT_EQ(continuation->arg_count, 1u);
+  const loom_value_id_t continuation_value = loom_block_arg_id(continuation, 0);
+  EXPECT_TRUE(iree_string_view_equal(
+      module_->strings
+          .entries[loom_module_value(module_, continuation_value)->name_id],
+      IREE_SV("call_result")));
+  ASSERT_TRUE(loom_func_return_isa(continuation->last_op));
+  EXPECT_EQ(loom_func_return_operands(continuation->last_op).values[0],
+            continuation_value);
+
+  const loom_verify_options_t verify_options = {};
+  loom_verify_result_t verify_result = {};
+  IREE_ASSERT_OK(loom_verify_module(module_, &verify_options, &verify_result));
+  EXPECT_EQ(verify_result.error_count, 0u);
+}
+
+TEST_F(CallableInlineTest, ConsumingInlineRetargetsMovedEntrySelfLoop) {
+  const loom_symbol_ref_t callee_ref = MakeSymbol(IREE_SV("spin"));
+  const loom_symbol_ref_t caller_ref = MakeSymbol(IREE_SV("caller"));
+  loom_op_t* callee_op = nullptr;
+  IREE_ASSERT_OK(loom_func_def_build(
+      &module_builder_, 0, 0, 0, 0, 0, 0, 0, loom_symbol_ref_null(), 0,
+      loom_named_attr_slice_empty(), LOOM_STRING_ID_INVALID,
+      loom_named_attr_slice_empty(), callee_ref, nullptr, 0, nullptr, 0,
+      nullptr, 0, nullptr, 0, LOOM_LOCATION_UNKNOWN, &callee_op));
+  loom_func_like_t callee = loom_func_like_cast(module_, callee_op);
+  loom_region_t* callee_body = loom_func_like_body(callee);
+  loom_block_t* old_entry = loom_region_entry_block(callee_body);
+  loom_builder_t callee_builder = BodyBuilder(callee_op);
+  loom_op_t* loop_branch = nullptr;
+  IREE_ASSERT_OK(loom_cfg_br_build(&callee_builder, old_entry, nullptr, 0,
+                                   LOOM_LOCATION_UNKNOWN, &loop_branch));
+
+  loom_op_t* caller_op = nullptr;
+  IREE_ASSERT_OK(loom_func_def_build(
+      &module_builder_, 0, 0, 0, 0, 0, 0, 0, loom_symbol_ref_null(), 0,
+      loom_named_attr_slice_empty(), LOOM_STRING_ID_INVALID,
+      loom_named_attr_slice_empty(), caller_ref, nullptr, 0, nullptr, 0,
+      nullptr, 0, nullptr, 0, LOOM_LOCATION_UNKNOWN, &caller_op));
+  loom_builder_t caller_builder = BodyBuilder(caller_op);
+  loom_op_t* call_op = nullptr;
+  IREE_ASSERT_OK(loom_func_call_build(&caller_builder, 0, 0, 0, 0, callee_ref,
+                                      nullptr, 0, nullptr, 0, nullptr, 0,
+                                      LOOM_LOCATION_UNKNOWN, &call_op));
+  loom_op_t* return_op = nullptr;
+  IREE_ASSERT_OK(loom_func_return_build(&caller_builder, nullptr, 0,
+                                        LOOM_LOCATION_UNKNOWN, &return_op));
+
+  loom_rewriter_t rewriter = {};
+  IREE_ASSERT_OK(
+      loom_rewriter_initialize(&rewriter, module_, &rewriter_arena_));
+  loom_availability_analysis_t availability = InitializeAvailability();
+  IREE_ASSERT_OK(loom_callable_inline_consuming_call(&rewriter, &availability,
+                                                     call_op, callee));
+  loom_rewriter_deinitialize(&rewriter);
+
+  loom_region_t* caller_body =
+      loom_func_like_body(loom_func_like_cast(module_, caller_op));
+  ASSERT_EQ(caller_body->block_count, 3u);
+  loom_block_t* moved_entry = loom_region_block(caller_body, 1);
+  EXPECT_NE(moved_entry, old_entry);
+  EXPECT_EQ(moved_entry->last_op, loop_branch);
+  EXPECT_EQ(loom_cfg_br_dest(loop_branch), moved_entry);
+  EXPECT_EQ(loop_branch->parent_op, caller_op);
+
+  const loom_verify_options_t verify_options = {};
+  loom_verify_result_t verify_result = {};
+  IREE_ASSERT_OK(loom_verify_module(module_, &verify_options, &verify_result));
+  EXPECT_EQ(verify_result.error_count, 0u);
+}
+
 TEST_F(CallableInlineTest, InlinesExactTemplateCall) {
   loom_type_t i32 = loom_type_scalar(LOOM_SCALAR_TYPE_I32);
   loom_symbol_ref_t callee_ref = MakeSymbol(IREE_SV("template_negate"));

--- a/loom/src/loom/rewrite/rewriter.c
+++ b/loom/src/loom/rewrite/rewriter.c
@@ -693,7 +693,7 @@ static bool loom_rewriter_op_is_ancestor_of(const loom_op_t* ancestor,
 
 static bool loom_rewriter_op_belongs_to_module(const loom_module_t* module,
                                                const loom_op_t* op) {
-  if (!module || !op) return false;
+  if (!op) return false;
   const loom_op_t* root_op = op;
   while (root_op->parent_op != NULL) root_op = root_op->parent_op;
   return root_op->parent_block != NULL &&
@@ -703,7 +703,7 @@ static bool loom_rewriter_op_belongs_to_module(const loom_module_t* module,
 static bool loom_rewriter_parent_owns_block(const loom_module_t* module,
                                             const loom_op_t* parent_op,
                                             const loom_block_t* block) {
-  if (!module || !block || !block->parent_region) return false;
+  if (!block || !block->parent_region) return false;
   uint16_t block_index = 0;
   if (!loom_region_try_block_index(block->parent_region, block, &block_index)) {
     return false;
@@ -733,6 +733,223 @@ static void loom_rewriter_record_subtree_summaries(loom_module_t* module,
       }
     }
   }
+}
+
+iree_status_t loom_rewriter_move_region_blocks(
+    loom_rewriter_t* rewriter, loom_region_t* source_region,
+    loom_op_t* source_parent_op, loom_region_t* target_region,
+    uint16_t target_block_index, loom_op_t* target_parent_op,
+    loom_block_t** out_moved_entry_block) {
+  *out_moved_entry_block = NULL;
+  if (source_region == target_region) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "source and target regions must be distinct");
+  }
+  if (source_region->block_count == 0 || target_region->block_count == 0 ||
+      source_region->blocks[0] != &source_region->entry_block) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "region move requires source and target entry blocks and an embedded "
+        "source entry");
+  }
+  if (target_block_index > target_region->block_count ||
+      (target_region->block_count > 0 && target_block_index == 0)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "target block insertion index %u is outside the movable range for %u "
+        "blocks",
+        (unsigned)target_block_index, (unsigned)target_region->block_count);
+  }
+
+  iree_host_size_t final_block_count = 0;
+  if (!iree_host_size_checked_add(target_region->block_count,
+                                  source_region->block_count,
+                                  &final_block_count) ||
+      final_block_count > UINT16_MAX) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "moved region block count exceeds UINT16_MAX");
+  }
+  if (!loom_rewriter_parent_owns_block(rewriter->module, source_parent_op,
+                                       source_region->blocks[0]) ||
+      !loom_rewriter_parent_owns_block(rewriter->module, target_parent_op,
+                                       target_region->blocks[0])) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "source and target regions must belong to their declared parents");
+  }
+  if (source_parent_op != target_parent_op &&
+      loom_rewriter_op_is_ancestor_of(source_parent_op, target_parent_op)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "cannot move a region into one of its owning op's descendants");
+  }
+  for (uint16_t block_index = 0; block_index < source_region->block_count;
+       ++block_index) {
+    loom_block_t* block = source_region->blocks[block_index];
+    if (!block || block->parent_region != source_region ||
+        block->region_index != block_index) {
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "source region block ownership is malformed");
+    }
+    for (uint16_t arg_index = 0; arg_index < block->arg_count; ++arg_index) {
+      const loom_value_id_t value_id = loom_block_arg_id(block, arg_index);
+      if (value_id >= rewriter->module->values.count) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "source block argument is out of range");
+      }
+      const loom_value_t* value = loom_module_value(rewriter->module, value_id);
+      if (!loom_value_is_block_arg(value) ||
+          loom_value_def_block(value) != block) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "source block argument definition does not match its block");
+      }
+    }
+    loom_op_t* op = NULL;
+    loom_block_for_each_op(block, op) {
+      if (op->parent_block != block || op->parent_op != source_parent_op ||
+          iree_any_bit_set(op->flags, LOOM_OP_FLAG_DEAD)) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "source block operation ownership is malformed");
+      }
+    }
+  }
+
+  loom_block_t* moved_entry_block = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_module_allocate_block(rewriter->module, &moved_entry_block));
+  iree_host_size_t entry_comment_count = 0;
+  const iree_string_view_t* entry_comments = loom_module_block_comments(
+      rewriter->module, &source_region->entry_block, &entry_comment_count);
+  if (entry_comment_count > 0) {
+    IREE_RETURN_IF_ERROR(
+        loom_module_attach_block_comments(rewriter->module, moved_entry_block,
+                                          entry_comments, entry_comment_count));
+  }
+
+  const bool use_source_storage =
+      source_region->block_capacity > target_region->block_capacity;
+  loom_region_t* storage_region =
+      use_source_storage ? source_region : target_region;
+  IREE_RETURN_IF_ERROR(loom_region_reserve_block_capacity(
+      rewriter->module, storage_region, final_block_count));
+
+  for (uint16_t block_index = 0; block_index < source_region->block_count;
+       ++block_index) {
+    loom_op_t* op = NULL;
+    loom_block_for_each_op(source_region->blocks[block_index], op) {
+      IREE_RETURN_IF_ERROR(loom_rewriter_add_to_worklist(rewriter, op));
+    }
+  }
+  if (source_parent_op != NULL) {
+    IREE_RETURN_IF_ERROR(
+        loom_rewriter_add_to_worklist(rewriter, source_parent_op));
+  }
+  if (target_parent_op != NULL && target_parent_op != source_parent_op) {
+    IREE_RETURN_IF_ERROR(
+        loom_rewriter_add_to_worklist(rewriter, target_parent_op));
+  }
+  IREE_RETURN_IF_ERROR(loom_rewriter_add_parent_summary_ops_to_worklist(
+      rewriter, source_parent_op));
+  IREE_RETURN_IF_ERROR(loom_rewriter_add_parent_summary_ops_to_worklist(
+      rewriter, target_parent_op));
+
+  const uint16_t source_block_count = source_region->block_count;
+  const uint16_t target_block_count = target_region->block_count;
+  const loom_region_instance_flags_t source_flags = source_region->flags;
+  loom_block_t* old_entry_block = &source_region->entry_block;
+  *moved_entry_block = *old_entry_block;
+  moved_entry_block->label_id = LOOM_STRING_ID_INVALID;
+  source_region->blocks[0] = moved_entry_block;
+
+  for (uint16_t block_index = 0; block_index < source_block_count;
+       ++block_index) {
+    loom_block_t* block = source_region->blocks[block_index];
+    loom_op_t* op = NULL;
+    loom_block_for_each_op(block, op) {
+      loom_module_drop_op_summaries(rewriter->module, op);
+    }
+  }
+
+  loom_block_t** moved_blocks = source_region->blocks;
+  loom_block_t** target_blocks = target_region->blocks;
+  loom_block_t** combined_blocks = storage_region->blocks;
+  const uint16_t combined_capacity = storage_region->block_capacity;
+  if (storage_region == source_region) {
+    memmove(combined_blocks + target_block_index, moved_blocks,
+            (iree_host_size_t)source_block_count * sizeof(*combined_blocks));
+    if (target_block_index > 0) {
+      memcpy(combined_blocks, target_blocks,
+             (iree_host_size_t)target_block_index * sizeof(*combined_blocks));
+    }
+    const uint16_t target_tail_count = target_block_count - target_block_index;
+    if (target_tail_count > 0) {
+      memcpy(combined_blocks + target_block_index + source_block_count,
+             target_blocks + target_block_index,
+             (iree_host_size_t)target_tail_count * sizeof(*combined_blocks));
+    }
+  } else {
+    const uint16_t target_tail_count = target_block_count - target_block_index;
+    if (target_tail_count > 0) {
+      memmove(combined_blocks + target_block_index + source_block_count,
+              combined_blocks + target_block_index,
+              (iree_host_size_t)target_tail_count * sizeof(*combined_blocks));
+    }
+    memcpy(combined_blocks + target_block_index, moved_blocks,
+           (iree_host_size_t)source_block_count * sizeof(*combined_blocks));
+  }
+
+  memset(old_entry_block, 0, sizeof(*old_entry_block));
+  old_entry_block->label_id = LOOM_STRING_ID_INVALID;
+  old_entry_block->region_index = 0;
+  old_entry_block->parent_region = source_region;
+  source_region->block_count = 1;
+  source_region->block_capacity = 1;
+  source_region->flags = 0;
+  source_region->blocks = source_region->inline_blocks;
+  source_region->inline_blocks[0] = old_entry_block;
+
+  target_region->block_count = (uint16_t)final_block_count;
+  target_region->block_capacity = combined_capacity;
+  target_region->blocks = combined_blocks;
+  target_region->flags |= source_flags;
+  for (uint16_t block_index = target_block_index;
+       block_index < target_region->block_count; ++block_index) {
+    loom_block_t* block = target_region->blocks[block_index];
+    block->parent_region = target_region;
+    block->region_index = block_index;
+  }
+  for (uint16_t block_index = target_block_index;
+       block_index < target_block_index + source_block_count; ++block_index) {
+    loom_block_t* block = target_region->blocks[block_index];
+    block->label_id = LOOM_STRING_ID_INVALID;
+    for (uint16_t arg_index = 0; arg_index < block->arg_count; ++arg_index) {
+      loom_value_t* value = loom_module_value(
+          rewriter->module, loom_block_arg_id(block, arg_index));
+      value->def = loom_value_def_make_block(block, arg_index);
+    }
+    loom_op_t* op = NULL;
+    loom_block_for_each_op(block, op) {
+      op->parent_block = block;
+      op->parent_op = target_parent_op;
+      loom_block_t** successors = loom_op_successors(op);
+      for (uint8_t successor_index = 0; successor_index < op->successor_count;
+           ++successor_index) {
+        if (successors[successor_index] == old_entry_block) {
+          successors[successor_index] = moved_entry_block;
+        }
+      }
+      loom_rewriter_record_subtree_summaries(rewriter->module, op);
+    }
+  }
+
+  IREE_ASSERT_EQ(source_region->read_effect_count, 0u);
+  IREE_ASSERT_EQ(source_region->write_effect_count, 0u);
+  IREE_ASSERT_EQ(source_region->convergent_effect_count, 0u);
+  rewriter->flags |= LOOM_REWRITER_FLAG_CHANGED;
+  *out_moved_entry_block = moved_entry_block;
+  return iree_ok_status();
 }
 
 iree_status_t loom_rewriter_move_before(loom_rewriter_t* rewriter,

--- a/loom/src/loom/rewrite/rewriter.h
+++ b/loom/src/loom/rewrite/rewriter.h
@@ -323,6 +323,24 @@ iree_status_t loom_rewriter_move_to_block_end(loom_rewriter_t* rewriter,
                                               loom_block_t* target_block,
                                               loom_op_t* target_parent_op);
 
+// Moves every block payload from |source_region| into |target_region| at
+// |target_block_index| without cloning SSA values or operations.
+//
+// The source and target regions must be owned by |source_parent_op| and
+// |target_parent_op| in the rewrite module. The source region is consumed and
+// left with one empty embedded entry block so its parent can be erased. The
+// moved entry payload is copied into one fresh block because a region's entry
+// block has inline storage; every other block and all operations retain their
+// identity. Successors targeting the old embedded entry are repaired, block
+// argument definitions and operation ancestry are reparented, region-local
+// block labels are cleared, and comments and semantic summaries are preserved.
+// All fallible allocation and ownership checks complete before payloads move.
+iree_status_t loom_rewriter_move_region_blocks(
+    loom_rewriter_t* rewriter, loom_region_t* source_region,
+    loom_op_t* source_parent_op, loom_region_t* target_region,
+    uint16_t target_block_index, loom_op_t* target_parent_op,
+    loom_block_t** out_moved_entry_block);
+
 // Replaces one operand of an op. Adds the op to the worklist.
 iree_status_t loom_rewriter_set_operand(loom_rewriter_t* rewriter,
                                         loom_op_t* op, uint16_t operand_index,

--- a/loom/src/loom/transforms/symbol/BUILD.bazel
+++ b/loom/src/loom/transforms/symbol/BUILD.bazel
@@ -198,6 +198,24 @@ loom_cc_library(
     ],
 )
 
+loom_cc_benchmark(
+    name = "inline_callables_benchmark",
+    srcs = ["inline_callables_benchmark.cc"],
+    deps = [
+        ":inline_callables",
+        "//loom/src/loom/format/text:parser",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/ops:op_defs",
+        "//loom/src/loom/pass:types",
+        "//loom/src/loom/rewrite:module_projection",
+        "//loom/src/loom/testing:module_ptr",
+        "//loom/src/loom/tooling/context",
+        "//loom/src/loom/verify",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/testing:benchmark_main",
+    ],
+)
+
 loom_cc_library(
     name = "refine_boundaries",
     srcs = ["refine_boundaries.c"],

--- a/loom/src/loom/transforms/symbol/CMakeLists.txt
+++ b/loom/src/loom/transforms/symbol/CMakeLists.txt
@@ -217,6 +217,26 @@ loom_cc_library(
   PUBLIC
 )
 
+loom_cc_benchmark(
+  NAME
+    inline_callables_benchmark
+  SRCS
+    "inline_callables_benchmark.cc"
+  DEPS
+    ::inline_callables
+    iree::base::internal::arena
+    iree::testing::benchmark_main
+    loom::format::text::parser
+    loom::ir
+    loom::ops::op_defs
+    loom::pass::types
+    loom::rewrite::module_projection
+    loom::testing::module_ptr
+    loom::tooling::context
+    loom::verify
+  TESTONLY
+)
+
 loom_cc_library(
   NAME
     refine_boundaries

--- a/loom/src/loom/transforms/symbol/inline_callables.c
+++ b/loom/src/loom/transforms/symbol/inline_callables.c
@@ -232,10 +232,6 @@ typedef struct loom_inline_plan_entry_t {
   loom_inline_plan_action_t action;
   // Stable blocker code for ACTION_ERROR.
   loom_inline_blocker_t blocker;
-  // Erase the private callee after clone inlining the final live reference.
-  bool erase_callee_after_clone;
-  // Execution order ordinal assigned after SCC ordering.
-  uint32_t execution_ordinal;
 } loom_inline_plan_entry_t;
 
 typedef struct loom_inline_component_entries_t {
@@ -600,7 +596,6 @@ static iree_status_t loom_inline_build_plan(loom_inline_state_t* state) {
     entry->callee_temperature = loom_func_like_temperature(entry->callee);
     entry->effective_temperature = loom_inline_effective_temperature(
         entry->callee_temperature, entry->call_temperature);
-    entry->execution_ordinal = UINT32_MAX;
 
     loom_inline_resolve_entry_policy(state, entry);
     loom_inline_add_required_graph_edge(state, entry_index);
@@ -1021,23 +1016,6 @@ static iree_status_t loom_inline_emit_blockers(loom_inline_state_t* state) {
 // Execution planning
 //===----------------------------------------------------------------------===//
 
-static void loom_inline_assign_execution_order(loom_inline_state_t* state) {
-  uint32_t execution_ordinal = 0;
-  for (iree_host_size_t component_index = 0;
-       component_index < state->sccs.count; ++component_index) {
-    for (uint32_t entry_index =
-             state->component_entries[component_index].first_entry;
-         entry_index != LOOM_INLINE_PLAN_ENTRY_INVALID;
-         entry_index = state->entries[entry_index].next_required_in_component) {
-      loom_inline_plan_entry_t* entry = &state->entries[entry_index];
-      if (entry->action != LOOM_INLINE_PLAN_ACTION_REQUIRED) {
-        continue;
-      }
-      entry->execution_ordinal = execution_ordinal++;
-    }
-  }
-}
-
 static bool loom_inline_symbol_can_transfer(const loom_inline_state_t* state,
                                             loom_symbol_id_t symbol_id) {
   if (symbol_id >= state->module->symbols.count) {
@@ -1069,8 +1047,7 @@ static bool loom_inline_symbol_can_transfer(const loom_inline_state_t* state,
 }
 
 static iree_status_t loom_inline_select_transfer_actions(
-    loom_inline_state_t* state, uint32_t* out_transfer_count) {
-  *out_transfer_count = 0;
+    loom_inline_state_t* state) {
   uint32_t* final_entry_by_symbol = NULL;
   if (state->module->symbols.count > 0) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
@@ -1081,20 +1058,17 @@ static iree_status_t loom_inline_select_transfer_actions(
     }
   }
 
-  for (uint32_t entry_index = 0; entry_index < state->entry_count;
-       ++entry_index) {
-    loom_inline_plan_entry_t* entry = &state->entries[entry_index];
-    if (entry->action != LOOM_INLINE_PLAN_ACTION_REQUIRED) {
-      continue;
-    }
-    if (!loom_inline_symbol_can_transfer(state, entry->target_symbol_id)) {
-      continue;
-    }
-    uint32_t previous_index = final_entry_by_symbol[entry->target_symbol_id];
-    if (previous_index == LOOM_INLINE_PLAN_ENTRY_INVALID ||
-        state->entries[previous_index].execution_ordinal <
-            entry->execution_ordinal) {
-      final_entry_by_symbol[entry->target_symbol_id] = entry_index;
+  for (iree_host_size_t component_index = 0;
+       component_index < state->sccs.count; ++component_index) {
+    for (uint32_t entry_index =
+             state->component_entries[component_index].first_entry;
+         entry_index != LOOM_INLINE_PLAN_ENTRY_INVALID;
+         entry_index = state->entries[entry_index].next_required_in_component) {
+      loom_inline_plan_entry_t* entry = &state->entries[entry_index];
+      if (entry->action == LOOM_INLINE_PLAN_ACTION_REQUIRED &&
+          loom_inline_symbol_can_transfer(state, entry->target_symbol_id)) {
+        final_entry_by_symbol[entry->target_symbol_id] = entry_index;
+      }
     }
   }
 
@@ -1105,13 +1079,7 @@ static iree_status_t loom_inline_select_transfer_actions(
       continue;
     }
     if (final_entry_by_symbol[entry->target_symbol_id] == entry_index) {
-      if (state->symbols[entry->target_symbol_id].body_will_be_linear) {
-        entry->action = LOOM_INLINE_PLAN_ACTION_TRANSFER;
-        ++*out_transfer_count;
-      } else {
-        entry->action = LOOM_INLINE_PLAN_ACTION_CLONE;
-        entry->erase_callee_after_clone = true;
-      }
+      entry->action = LOOM_INLINE_PLAN_ACTION_TRANSFER;
     } else {
       entry->action = LOOM_INLINE_PLAN_ACTION_CLONE;
     }
@@ -1122,42 +1090,44 @@ static iree_status_t loom_inline_select_transfer_actions(
 static iree_status_t loom_inline_execute_entry(
     loom_inline_state_t* state, loom_rewriter_t* rewriter,
     const loom_availability_analysis_t* transfer_availability,
-    loom_inline_plan_entry_t* entry) {
+    loom_inline_plan_entry_t* entry, bool* out_changed_cfg_topology) {
+  *out_changed_cfg_topology = false;
   switch (entry->action) {
     case LOOM_INLINE_PLAN_ACTION_CLONE: {
+      const bool body_is_linear =
+          loom_callable_body_is_linear(state->module, entry->callee);
       const loom_callable_build_branch_fn_t build_branch =
           loom_call_like_kind(entry->call) == LOOM_CALL_LIKE_KIND_LOW_INTERNAL
               ? loom_low_br_build
               : loom_cfg_br_build;
       IREE_RETURN_IF_ERROR(loom_callable_inline_call_with_branch(
           rewriter, entry->call_op, entry->callee, build_branch));
-      if (entry->erase_callee_after_clone) {
-        loom_function_version_t* version =
-            loom_target_function_version_snapshot_handle_at(
-                &state->target_versions, entry->target_symbol_id);
-        IREE_RETURN_IF_ERROR(loom_rewriter_erase(rewriter, entry->callee.op));
-        if (version != NULL) {
-          ++state->erased_version_count;
-        }
-        ++state->statistics->symbols_transferred;
-      }
       loom_pass_mark_changed(state->pass);
       ++state->statistics->calls_cloned;
+      *out_changed_cfg_topology = !body_is_linear;
       return iree_ok_status();
     }
     case LOOM_INLINE_PLAN_ACTION_TRANSFER: {
-      IREE_ASSERT(transfer_availability);
+      const bool body_is_linear =
+          loom_callable_body_is_linear(state->module, entry->callee);
+      const bool use_linear_move = body_is_linear && transfer_availability;
       loom_function_version_t* version =
           loom_target_function_version_snapshot_handle_at(
               &state->target_versions, entry->target_symbol_id);
-      IREE_RETURN_IF_ERROR(loom_callable_inline_consuming_call(
-          rewriter, transfer_availability, entry->call_op, entry->callee));
+      const loom_callable_build_branch_fn_t build_branch =
+          loom_call_like_kind(entry->call) == LOOM_CALL_LIKE_KIND_LOW_INTERNAL
+              ? loom_low_br_build
+              : loom_cfg_br_build;
+      IREE_RETURN_IF_ERROR(loom_callable_inline_consuming_call_with_branch(
+          rewriter, transfer_availability, entry->call_op, entry->callee,
+          build_branch));
       if (version != NULL) {
         ++state->erased_version_count;
       }
       loom_pass_mark_changed(state->pass);
       ++state->statistics->calls_transferred;
       ++state->statistics->symbols_transferred;
+      *out_changed_cfg_topology = !use_linear_move;
       return iree_ok_status();
     }
     default:
@@ -1199,27 +1169,16 @@ static iree_host_size_t loom_inline_prune_erased_function_versions(
 // semantics.
 static iree_status_t loom_inline_materialize_locked_low_schedules(
     loom_inline_state_t* state, loom_rewriter_t* rewriter) {
-  uint8_t* normalized_symbols = NULL;
-  if (state->module->symbols.count > 0) {
-    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        state->pass->arena, state->module->symbols.count,
-        sizeof(*normalized_symbols), (void**)&normalized_symbols));
-    memset(normalized_symbols, 0,
-           state->module->symbols.count * sizeof(*normalized_symbols));
-  }
-
   for (uint32_t entry_index = 0; entry_index < state->entry_count;
        ++entry_index) {
     const loom_inline_plan_entry_t* entry = &state->entries[entry_index];
     if ((entry->action != LOOM_INLINE_PLAN_ACTION_CLONE &&
          entry->action != LOOM_INLINE_PLAN_ACTION_TRANSFER) ||
         loom_call_like_kind(entry->call) != LOOM_CALL_LIKE_KIND_LOW_INTERNAL ||
-        normalized_symbols[entry->target_symbol_id] != 0 ||
         loom_low_func_def_schedule(entry->callee.op) !=
             LOOM_LOW_SCHEDULE_LOCKED) {
       continue;
     }
-    normalized_symbols[entry->target_symbol_id] = 1;
 
     loom_region_t* body = loom_func_like_body(entry->callee);
     for (uint16_t block_index = 0; block_index < body->block_count;
@@ -1248,33 +1207,201 @@ static iree_status_t loom_inline_materialize_locked_low_schedules(
   return iree_ok_status();
 }
 
-static iree_status_t loom_inline_execute_plan(loom_inline_state_t* state,
-                                              uint32_t transfer_count) {
+static bool loom_inline_action_executes(loom_inline_plan_action_t action) {
+  return action == LOOM_INLINE_PLAN_ACTION_CLONE ||
+         action == LOOM_INLINE_PLAN_ACTION_TRANSFER;
+}
+
+typedef struct loom_inline_execution_symbol_t {
+  // Executing call edges whose original caller is this symbol.
+  uint32_t remaining_outgoing_count;
+  // Clone uses that must observe this symbol before its consuming use.
+  uint32_t remaining_clone_count;
+  // Head of the clone-use list targeting this symbol.
+  uint32_t first_clone_entry;
+  // Unique consuming use targeting this symbol, when present.
+  uint32_t transfer_entry;
+} loom_inline_execution_symbol_t;
+
+typedef struct loom_inline_execution_entry_t {
+  // Next clone use targeting the same symbol.
+  uint32_t next_clone_entry;
+  // Topology-preserving entry stored in this ready-stack slot.
+  uint32_t linear_ready_entry;
+  // CFG-mutating entry stored in this ready-stack slot.
+  uint32_t cfg_ready_entry;
+} loom_inline_execution_entry_t;
+
+static void loom_inline_enqueue_ready_entry(
+    const loom_inline_state_t* state,
+    loom_inline_execution_entry_t* execution_entries, uint32_t entry_index,
+    uint32_t* inout_linear_ready_count, uint32_t* inout_cfg_ready_count) {
+  const loom_inline_plan_entry_t* entry = &state->entries[entry_index];
+  if (loom_callable_body_is_linear(state->module, entry->callee)) {
+    execution_entries[(*inout_linear_ready_count)++].linear_ready_entry =
+        entry_index;
+  } else {
+    execution_entries[(*inout_cfg_ready_count)++].cfg_ready_entry = entry_index;
+  }
+}
+
+// Executes required edges without repeatedly cloning a growing callee closure.
+// A clone waits for the target's outgoing edges so it observes the complete
+// flattened body. The target's unique transfer waits for all clone uses, but
+// otherwise may move a single-use wrapper outward before flattening calls now
+// carried by that wrapper. Linear ready edges run before CFG edges so their
+// topology-preserving move can share one availability analysis and so a CFG
+// parent carries its linear producers when it moves.
+static iree_status_t loom_inline_execute_plan(loom_inline_state_t* state) {
+  uint32_t execution_count = 0;
+  for (uint32_t entry_index = 0; entry_index < state->entry_count;
+       ++entry_index) {
+    if (loom_inline_action_executes(state->entries[entry_index].action)) {
+      ++execution_count;
+    }
+  }
+  if (execution_count == 0) return iree_ok_status();
+
   loom_rewriter_t rewriter = {0};
   IREE_RETURN_IF_ERROR(
       loom_rewriter_initialize(&rewriter, state->module, state->pass->arena));
 
-  loom_availability_analysis_t transfer_availability = {0};
   iree_status_t status =
       loom_inline_materialize_locked_low_schedules(state, &rewriter);
-  if (iree_status_is_ok(status) && transfer_count != 0) {
-    status = loom_availability_analysis_initialize(
-        state->module, state->pass->arena, &transfer_availability);
+  const iree_host_size_t symbol_count = state->module->symbols.count;
+  loom_inline_execution_symbol_t* execution_symbols = NULL;
+  loom_inline_execution_entry_t* execution_entries = NULL;
+  if (iree_status_is_ok(status) && symbol_count > 0) {
+    status = iree_arena_allocate_array(state->pass->arena, symbol_count,
+                                       sizeof(*execution_symbols),
+                                       (void**)&execution_symbols);
   }
-  const loom_availability_analysis_t* transfer_availability_ptr =
-      transfer_count > 0 ? &transfer_availability : NULL;
+  if (iree_status_is_ok(status) && state->entry_count > 0) {
+    status = iree_arena_allocate_array(state->pass->arena, state->entry_count,
+                                       sizeof(*execution_entries),
+                                       (void**)&execution_entries);
+  }
+  if (iree_status_is_ok(status)) {
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      execution_symbols[i] = (loom_inline_execution_symbol_t){
+          .first_clone_entry = LOOM_INLINE_PLAN_ENTRY_INVALID,
+          .transfer_entry = LOOM_INLINE_PLAN_ENTRY_INVALID,
+      };
+    }
+    for (uint32_t i = 0; i < state->entry_count; ++i) {
+      execution_entries[i].next_clone_entry = LOOM_INLINE_PLAN_ENTRY_INVALID;
+    }
+  }
+
+  for (uint32_t entry_index = 0;
+       iree_status_is_ok(status) && entry_index < state->entry_count;
+       ++entry_index) {
+    loom_inline_plan_entry_t* entry = &state->entries[entry_index];
+    if (!loom_inline_action_executes(entry->action)) continue;
+    IREE_ASSERT_LT(entry->source_symbol_id, symbol_count);
+    IREE_ASSERT_LT(entry->target_symbol_id, symbol_count);
+    ++execution_symbols[entry->source_symbol_id].remaining_outgoing_count;
+    if (entry->action == LOOM_INLINE_PLAN_ACTION_CLONE) {
+      loom_inline_execution_symbol_t* target =
+          &execution_symbols[entry->target_symbol_id];
+      ++target->remaining_clone_count;
+      execution_entries[entry_index].next_clone_entry =
+          target->first_clone_entry;
+      target->first_clone_entry = entry_index;
+    } else {
+      loom_inline_execution_symbol_t* target =
+          &execution_symbols[entry->target_symbol_id];
+      IREE_ASSERT_EQ(target->transfer_entry, LOOM_INLINE_PLAN_ENTRY_INVALID);
+      target->transfer_entry = entry_index;
+    }
+  }
+
+  uint32_t linear_ready_count = 0;
+  uint32_t cfg_ready_count = 0;
   for (iree_host_size_t component_index = 0;
        iree_status_is_ok(status) && component_index < state->sccs.count;
        ++component_index) {
     for (uint32_t entry_index =
              state->component_entries[component_index].first_entry;
-         iree_status_is_ok(status) &&
          entry_index != LOOM_INLINE_PLAN_ENTRY_INVALID;
          entry_index = state->entries[entry_index].next_required_in_component) {
-      loom_inline_plan_entry_t* entry = &state->entries[entry_index];
-      status = loom_inline_execute_entry(state, &rewriter,
-                                         transfer_availability_ptr, entry);
+      const loom_inline_plan_entry_t* entry = &state->entries[entry_index];
+      if (!loom_inline_action_executes(entry->action)) continue;
+      const loom_inline_execution_symbol_t* target =
+          &execution_symbols[entry->target_symbol_id];
+      const bool ready = entry->action == LOOM_INLINE_PLAN_ACTION_CLONE
+                             ? target->remaining_outgoing_count == 0
+                             : target->remaining_clone_count == 0;
+      if (ready) {
+        loom_inline_enqueue_ready_entry(state, execution_entries, entry_index,
+                                        &linear_ready_count, &cfg_ready_count);
+      }
     }
+  }
+
+  loom_availability_analysis_t transfer_availability = {0};
+  bool transfer_availability_valid = false;
+  bool cfg_topology_changed = false;
+  uint32_t executed_count = 0;
+  while (iree_status_is_ok(status) &&
+         (linear_ready_count > 0 || cfg_ready_count > 0)) {
+    const uint32_t entry_index =
+        linear_ready_count > 0
+            ? execution_entries[--linear_ready_count].linear_ready_entry
+            : execution_entries[--cfg_ready_count].cfg_ready_entry;
+    loom_inline_plan_entry_t* entry = &state->entries[entry_index];
+    const bool body_is_linear =
+        entry->action == LOOM_INLINE_PLAN_ACTION_TRANSFER &&
+        loom_callable_body_is_linear(state->module, entry->callee);
+    if (body_is_linear && !transfer_availability_valid &&
+        !cfg_topology_changed) {
+      status = loom_availability_analysis_initialize(
+          state->module, state->pass->arena, &transfer_availability);
+      if (!iree_status_is_ok(status)) break;
+      transfer_availability_valid = true;
+    }
+    bool changed_cfg_topology = false;
+    const loom_availability_analysis_t* availability =
+        body_is_linear && transfer_availability_valid ? &transfer_availability
+                                                      : NULL;
+    status = loom_inline_execute_entry(state, &rewriter, availability, entry,
+                                       &changed_cfg_topology);
+    if (!iree_status_is_ok(status)) break;
+    ++executed_count;
+    if (changed_cfg_topology) {
+      transfer_availability_valid = false;
+      cfg_topology_changed = true;
+    }
+
+    loom_inline_execution_symbol_t* source =
+        &execution_symbols[entry->source_symbol_id];
+    IREE_ASSERT_GT(source->remaining_outgoing_count, 0u);
+    if (--source->remaining_outgoing_count == 0) {
+      for (uint32_t clone_index = source->first_clone_entry;
+           clone_index != LOOM_INLINE_PLAN_ENTRY_INVALID;
+           clone_index = execution_entries[clone_index].next_clone_entry) {
+        loom_inline_enqueue_ready_entry(state, execution_entries, clone_index,
+                                        &linear_ready_count, &cfg_ready_count);
+      }
+    }
+    if (entry->action == LOOM_INLINE_PLAN_ACTION_CLONE) {
+      loom_inline_execution_symbol_t* target =
+          &execution_symbols[entry->target_symbol_id];
+      IREE_ASSERT_GT(target->remaining_clone_count, 0u);
+      if (--target->remaining_clone_count == 0) {
+        if (target->transfer_entry != LOOM_INLINE_PLAN_ENTRY_INVALID) {
+          loom_inline_enqueue_ready_entry(
+              state, execution_entries, target->transfer_entry,
+              &linear_ready_count, &cfg_ready_count);
+        }
+      }
+    }
+  }
+  if (iree_status_is_ok(status) && executed_count != execution_count) {
+    status = iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "inline execution dependencies stalled after %u of %u calls",
+        (unsigned)executed_count, (unsigned)execution_count);
   }
 
   const iree_host_size_t removed_version_count =
@@ -1326,11 +1453,8 @@ iree_status_t loom_inline_callables_run(loom_pass_t* pass,
     return iree_ok_status();
   }
 
-  loom_inline_assign_execution_order(&state);
-  uint32_t transfer_count = 0;
-  IREE_RETURN_IF_ERROR(
-      loom_inline_select_transfer_actions(&state, &transfer_count));
-  IREE_RETURN_IF_ERROR(loom_inline_execute_plan(&state, transfer_count));
+  IREE_RETURN_IF_ERROR(loom_inline_select_transfer_actions(&state));
+  IREE_RETURN_IF_ERROR(loom_inline_execute_plan(&state));
   if (!pass->changed) {
     return iree_ok_status();
   }

--- a/loom/src/loom/transforms/symbol/inline_callables_benchmark.cc
+++ b/loom/src/loom/transforms/symbol/inline_callables_benchmark.cc
@@ -72,7 +72,7 @@ std::string BuildSingleUseCfgChainSource(uint32_t helper_count) {
 class InlineCallablesBenchmarkFixture {
  public:
   explicit InlineCallablesBenchmarkFixture(uint32_t helper_count)
-      : expected_output_block_count_(helper_count * 2u + 2u) {
+      : expected_output_block_count_(4) {
     iree_arena_block_pool_initialize(64 * 1024, iree_allocator_system(),
                                      &block_pool_);
     loom_context_initialize(iree_allocator_system(), &context_);
@@ -150,7 +150,7 @@ class InlineCallablesBenchmarkFixture {
   }
 
  private:
-  // Number of live blocks and operations expected after complete inlining.
+  // Live blocks/ops after all single-use wrappers collapse into the CFG leaf.
   uint32_t expected_output_block_count_;
   // Shared arena block pool used by source and per-iteration module arenas.
   iree_arena_block_pool_t block_pool_ = {};

--- a/loom/src/loom/transforms/symbol/inline_callables_benchmark.cc
+++ b/loom/src/loom/transforms/symbol/inline_callables_benchmark.cc
@@ -1,0 +1,219 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Benchmarks complete required-inline callable composition over verified
+// modules. Source construction, parsing, verification, and per-iteration
+// module cloning happen outside the timed region; each measurement contains
+// only the production inline-callables pass over a fresh module.
+
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "iree/base/internal/arena.h"
+#include "loom/format/text/parser.h"
+#include "loom/ir/context.h"
+#include "loom/ir/module.h"
+#include "loom/ops/op_defs.h"
+#include "loom/pass/types.h"
+#include "loom/rewrite/module_projection.h"
+#include "loom/testing/module_ptr.h"
+#include "loom/tooling/context/context.h"
+#include "loom/transforms/symbol/inline_callables.h"
+#include "loom/verify/verify.h"
+
+namespace loom {
+namespace {
+
+using ModulePtr = ::loom::testing::ModulePtr;
+
+std::string BuildSingleUseCfgChainSource(uint32_t helper_count) {
+  if (helper_count == 0) std::abort();
+  std::string source;
+  source.reserve(static_cast<size_t>(helper_count) * 220u + 256u);
+
+  const uint32_t leaf_index = helper_count - 1;
+  source.append("func.def inline @helper_");
+  source.append(std::to_string(leaf_index));
+  source.append(
+      "(%value: i32) -> (i32) {\n"
+      "  cfg.br ^exit(%value: i32)\n"
+      "^exit(%forwarded: i32):\n"
+      "  func.return %forwarded : i32\n"
+      "}\n\n");
+
+  for (uint32_t callee_index = leaf_index; callee_index > 0; --callee_index) {
+    const uint32_t caller_index = callee_index - 1;
+    source.append("func.def inline @helper_");
+    source.append(std::to_string(caller_index));
+    source.append(
+        "(%value: i32) -> (i32) {\n"
+        "  %result = func.call @helper_");
+    source.append(std::to_string(callee_index));
+    source.append(
+        "(%value) : (i32) -> (i32)\n"
+        "  func.return %result : i32\n"
+        "}\n\n");
+  }
+
+  source.append(
+      "func.def public @entry(%value: i32) -> (i32) {\n"
+      "  %result = func.call @helper_0(%value) : (i32) -> (i32)\n"
+      "  func.return %result : i32\n"
+      "}\n");
+  return source;
+}
+
+class InlineCallablesBenchmarkFixture {
+ public:
+  explicit InlineCallablesBenchmarkFixture(uint32_t helper_count)
+      : expected_output_block_count_(helper_count * 2u + 2u) {
+    iree_arena_block_pool_initialize(64 * 1024, iree_allocator_system(),
+                                     &block_pool_);
+    loom_context_initialize(iree_allocator_system(), &context_);
+    IREE_CHECK_OK(loom_tooling_context_register_tool_dialects(&context_));
+    IREE_CHECK_OK(loom_context_finalize(&context_));
+
+    const std::string source = BuildSingleUseCfgChainSource(helper_count);
+    loom_module_t* module = nullptr;
+    const loom_text_parse_options_t parse_options = {};
+    IREE_CHECK_OK(
+        loom_text_parse(iree_make_string_view(source.data(), source.size()),
+                        IREE_SV("inline_callables_benchmark.loom"), &context_,
+                        &block_pool_, &parse_options, &module));
+    source_module_.reset(module);
+
+    loom_verify_options_t verify_options = {};
+    loom_verify_result_t verify_result = {};
+    IREE_CHECK_OK(loom_verify_module(source_module_.get(), &verify_options,
+                                     &verify_result));
+    IREE_ASSERT_EQ(verify_result.error_count, 0u);
+  }
+
+  InlineCallablesBenchmarkFixture(const InlineCallablesBenchmarkFixture&) =
+      delete;
+  InlineCallablesBenchmarkFixture& operator=(
+      const InlineCallablesBenchmarkFixture&) = delete;
+
+  ~InlineCallablesBenchmarkFixture() {
+    source_module_.reset();
+    loom_context_deinitialize(&context_);
+    iree_arena_block_pool_deinitialize(&block_pool_);
+  }
+
+  loom_module_t* CloneModule() {
+    iree_arena_allocator_t scratch_arena;
+    iree_arena_initialize(&block_pool_, &scratch_arena);
+    loom_ir_module_projection_t projection = {};
+    loom_module_t* module = nullptr;
+    IREE_CHECK_OK(loom_ir_module_clone(
+        source_module_.get(), /*options=*/nullptr, &block_pool_, &scratch_arena,
+        iree_allocator_system(), &projection, &module));
+    iree_arena_deinitialize(&scratch_arena);
+    return module;
+  }
+
+  iree_host_size_t ValidateOutput(const loom_module_t* module) const {
+    if (module->symbols.count != 1) std::abort();
+    const loom_string_id_t entry_name_id =
+        loom_module_lookup_string(module, IREE_SV("entry"));
+    if (entry_name_id == LOOM_STRING_ID_INVALID) std::abort();
+    const loom_symbol_id_t entry_symbol_id =
+        loom_module_find_symbol(module, entry_name_id);
+    if (entry_symbol_id == LOOM_SYMBOL_ID_INVALID) std::abort();
+    const loom_func_like_t entry = loom_func_like_cast(
+        module, module->symbols.entries[entry_symbol_id].defining_op);
+    if (!loom_func_like_isa(entry)) std::abort();
+
+    const loom_region_t* body = loom_func_like_body(entry);
+    if (body == nullptr || body->block_count != expected_output_block_count_) {
+      std::abort();
+    }
+    iree_host_size_t output_op_count = 0;
+    for (uint16_t block_index = 0; block_index < body->block_count;
+         ++block_index) {
+      output_op_count += loom_region_const_block(body, block_index)->op_count;
+    }
+    if (output_op_count != expected_output_block_count_) std::abort();
+    return output_op_count;
+  }
+
+  iree_arena_block_pool_t* block_pool() { return &block_pool_; }
+
+  uint32_t expected_output_block_count() const {
+    return expected_output_block_count_;
+  }
+
+ private:
+  // Number of live blocks and operations expected after complete inlining.
+  uint32_t expected_output_block_count_;
+  // Shared arena block pool used by source and per-iteration module arenas.
+  iree_arena_block_pool_t block_pool_ = {};
+  // Dialect context shared by the immutable source and cloned modules.
+  loom_context_t context_ = {};
+  // Verified immutable module cloned outside each timed interval.
+  ModulePtr source_module_;
+};
+
+void BM_InlineSingleUseCfgChain(benchmark::State& state) {
+  const uint32_t helper_count = static_cast<uint32_t>(state.range(0));
+  InlineCallablesBenchmarkFixture fixture(helper_count);
+  iree_host_size_t output_op_count = 0;
+  iree_host_size_t output_used_bytes = 0;
+  for (auto _ : state) {
+    state.PauseTiming();
+    loom_module_t* module = fixture.CloneModule();
+    iree_arena_allocator_t pass_arena;
+    iree_arena_initialize(fixture.block_pool(), &pass_arena);
+    const loom_pass_info_t* pass_info = loom_inline_callables_pass_info();
+    std::vector<uint8_t> statistic_storage(
+        pass_info->statistic_layout->storage_size, 0);
+    loom_pass_t pass = {};
+    pass.info = pass_info;
+    pass.module_run = loom_inline_callables_run;
+    pass.instance_arena = &pass_arena;
+    pass.arena = &pass_arena;
+    pass.statistic_storage = statistic_storage.data();
+    IREE_CHECK_OK(loom_inline_callables_create(&pass, IREE_SV("")));
+    state.ResumeTiming();
+
+    IREE_CHECK_OK(loom_inline_callables_run(&pass, module));
+    benchmark::DoNotOptimize(module);
+    benchmark::ClobberMemory();
+
+    state.PauseTiming();
+    output_op_count = fixture.ValidateOutput(module);
+    output_used_bytes = module->arena.used_allocation_size;
+    iree_arena_deinitialize(&pass_arena);
+    loom_module_free(module);
+    state.ResumeTiming();
+  }
+
+  state.SetItemsProcessed(state.iterations() * output_op_count);
+  state.SetComplexityN(helper_count);
+  state.counters["helpers"] = static_cast<double>(helper_count);
+  state.counters["output_blocks"] =
+      static_cast<double>(fixture.expected_output_block_count());
+  state.counters["output_ops"] = static_cast<double>(output_op_count);
+  state.counters["output_used_bytes"] = static_cast<double>(output_used_bytes);
+}
+
+static void RegisterCfgChainScales(benchmark::Benchmark* benchmark) {
+  benchmark->ArgName("helpers");
+  for (int64_t scale : {1, 4, 16, 64, 256, 1024}) {
+    benchmark->Arg(scale);
+  }
+}
+
+BENCHMARK(BM_InlineSingleUseCfgChain)
+    ->Apply(RegisterCfgChainScales)
+    ->Unit(benchmark::kMicrosecond)
+    ->Complexity();
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
+++ b/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
@@ -650,22 +650,22 @@ func.def public @nested_linear_cfg_entry(%entry_value: i32) -> (i32) {
 // a dominated outer block instead of being forwarded as its block argument.
 test.target<low_core> @nested_cfg_target
 
-low.func.def inline target<test.low.core>(@nested_cfg_target) @nested_cfg_child(%child_value: reg<test.i32>) -> (reg<test.i32>) {
+low.func.def inline target<test.low.core>(@nested_cfg_target) @nested_cfg_child(%child_value: reg<test.i32>) -> (reg<test.i32>) asm {
   low.br ^child_exit(%child_value: reg<test.i32>)
 ^child_exit(%child_forwarded: reg<test.i32>):
-  low.return %child_forwarded : reg<test.i32>
+  return %child_forwarded
 }
 
-low.func.def inline target<test.low.core>(@nested_cfg_target) @nested_cfg_parent(%parent_value: reg<test.i32>) -> (reg<test.i32>) {
+low.func.def inline target<test.low.core>(@nested_cfg_target) @nested_cfg_parent(%parent_value: reg<test.i32>) -> (reg<test.i32>) asm {
   %parent_result = low.func.call @nested_cfg_child(%parent_value) : (reg<test.i32>) -> (reg<test.i32>)
   low.br ^parent_exit
 ^parent_exit:
-  low.return %parent_result : reg<test.i32>
+  return %parent_result
 }
 
-low.func.def public target<test.low.core>(@nested_cfg_target) @nested_cfg_entry(%entry_value: reg<test.i32>) -> (reg<test.i32>) {
+low.func.def public target<test.low.core>(@nested_cfg_target) @nested_cfg_entry(%entry_value: reg<test.i32>) -> (reg<test.i32>) asm {
   %entry_result = low.func.call @nested_cfg_parent(%entry_value) : (reg<test.i32>) -> (reg<test.i32>)
-  low.return %entry_result : reg<test.i32>
+  return %entry_result
 }
 
 // ----

--- a/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
+++ b/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
@@ -485,8 +485,8 @@ test.target<low_core> @target
 low.func.def public target<test.low.core>(@target) @low_cfg_entry(%condition$4: reg<test.i32>, %arg: reg<test.i32>) -> (reg<test.i32>) {
   %prefix = low.copy %arg : reg<test.i32> -> reg<test.i32>
   low.br ^_bb1(%condition$4: reg<test.i32>, %prefix: reg<test.i32>)
-^_bb1(%condition$10: reg<test.i32>, %value: reg<test.i32>):
-  low.cond_br %condition$10, ^_bb2, ^_bb3 : reg<test.i32>
+^_bb1(%condition$0: reg<test.i32>, %value: reg<test.i32>):
+  low.cond_br %condition$0, ^_bb2, ^_bb3 : reg<test.i32>
 ^_bb2:
   low.br ^_bb5(%value: reg<test.i32>)
 ^_bb3:
@@ -575,9 +575,9 @@ low.func.def public target<test.low.core>(@target) @retain_locked(%value: reg<te
 
 // RUN: pass inline-callables
 
-// Required-inline CFG shape propagates through the complete closure. Although
-// the middle helper begins with one block, flattening its CFG leaf makes it a
-// CFG callee before the outer edge executes.
+// Required-inline CFG shape propagates through the complete closure for
+// preflight. Execution moves the single-use wrapper outward before consuming
+// its CFG leaf, so the wrapper disappears without cloning an expanded body.
 func.def inline @closure_cfg_leaf(%value: i32) -> (i32) {
   cfg.br ^exit(%value: i32)
 ^exit(%forwarded: i32):
@@ -597,16 +597,151 @@ func.def public @closure_cfg_entry(%value: i32) -> (i32) {
 // ----
 func.def public @closure_cfg_entry(%value$6: i32) -> (i32) {
   cfg.br ^_bb1(%value$6: i32)
-^_bb1(%value$12: i32):
-  cfg.br ^_bb2(%value$12: i32)
-^_bb2(%value$13: i32):
-  cfg.br ^_bb3(%value$13: i32)
-^_bb3(%forwarded: i32):
-  cfg.br ^_bb4(%forwarded: i32)
-^_bb4(%result$15: i32):
-  cfg.br ^_bb5(%result$15: i32)
-^_bb5(%result$16: i32):
-  func.return %result$16 : i32
+^_bb1(%value$0: i32):
+  cfg.br ^_bb2(%value$0: i32)
+^_bb2(%forwarded: i32):
+  cfg.br ^_bb3(%forwarded: i32)
+^_bb3(%result: i32):
+  func.return %result : i32
+}
+
+// ====
+
+// RUN: pass inline-callables
+
+// A linear nested call is transferred before its CFG parent moves. This keeps
+// the topology-preserving path available and carries the producer with the
+// parent CFG instead of manufacturing another pair of blocks.
+func.def inline @nested_linear_double(%nested_value: i32) -> (i32) {
+  %nested_doubled = test.addi %nested_value, %nested_value : i32
+  func.return %nested_doubled : i32
+}
+
+func.def inline @outer_cfg_compose(%outer_value: i32) -> (i32) {
+  %outer_doubled = func.call @nested_linear_double(%outer_value) : (i32) -> (i32)
+  cfg.br ^exit(%outer_doubled: i32)
+^exit(%outer_forwarded: i32):
+  func.return %outer_forwarded : i32
+}
+
+func.def public @nested_linear_cfg_entry(%entry_value: i32) -> (i32) {
+  %entry_result = func.call @outer_cfg_compose(%entry_value) : (i32) -> (i32)
+  func.return %entry_result : i32
+}
+
+// ----
+func.def public @nested_linear_cfg_entry(%entry_value: i32) -> (i32) {
+  cfg.br ^_bb1(%entry_value: i32)
+^_bb1(%outer_value: i32):
+  %nested_doubled = test.addi %outer_value, %outer_value : i32
+  cfg.br ^_bb2(%nested_doubled: i32)
+^_bb2(%outer_forwarded: i32):
+  cfg.br ^_bb3(%outer_forwarded: i32)
+^_bb3(%entry_result: i32):
+  func.return %entry_result : i32
+}
+
+// ====
+
+// RUN: pass inline-callables
+
+// Nested CFG blocks are inserted immediately after their call block. This
+// preserves definition-before-use ordering when a result is used directly in
+// a dominated outer block instead of being forwarded as its block argument.
+test.target<low_core> @nested_cfg_target
+
+low.func.def inline target<test.low.core>(@nested_cfg_target) @nested_cfg_child(%child_value: reg<test.i32>) -> (reg<test.i32>) {
+  low.br ^child_exit(%child_value: reg<test.i32>)
+^child_exit(%child_forwarded: reg<test.i32>):
+  low.return %child_forwarded : reg<test.i32>
+}
+
+low.func.def inline target<test.low.core>(@nested_cfg_target) @nested_cfg_parent(%parent_value: reg<test.i32>) -> (reg<test.i32>) {
+  %parent_result = low.func.call @nested_cfg_child(%parent_value) : (reg<test.i32>) -> (reg<test.i32>)
+  low.br ^parent_exit
+^parent_exit:
+  low.return %parent_result : reg<test.i32>
+}
+
+low.func.def public target<test.low.core>(@nested_cfg_target) @nested_cfg_entry(%entry_value: reg<test.i32>) -> (reg<test.i32>) {
+  %entry_result = low.func.call @nested_cfg_parent(%entry_value) : (reg<test.i32>) -> (reg<test.i32>)
+  low.return %entry_result : reg<test.i32>
+}
+
+// ----
+test.target<low_core> @nested_cfg_target
+
+low.func.def public target<test.low.core>(@nested_cfg_target) @nested_cfg_entry(%entry_value: reg<test.i32>) -> (reg<test.i32>) {
+  low.br ^_bb1(%entry_value: reg<test.i32>)
+^_bb1(%parent_value: reg<test.i32>):
+  low.br ^_bb2(%parent_value: reg<test.i32>)
+^_bb2(%child_value: reg<test.i32>):
+  low.br ^_bb3(%child_value: reg<test.i32>)
+^_bb3(%child_forwarded: reg<test.i32>):
+  low.br ^_bb4(%child_forwarded: reg<test.i32>)
+^_bb4(%parent_result: reg<test.i32>):
+  low.br ^_bb5
+^_bb5:
+  low.br ^_bb6(%parent_result: reg<test.i32>)
+^_bb6(%entry_result: reg<test.i32>):
+  low.return %entry_result : reg<test.i32>
+}
+
+// ====
+
+// RUN: pass inline-callables
+
+// A shared CFG wrapper exercises both execution dependencies. Its nested leaf
+// must be flattened before the wrapper is cloned, and the clone must complete
+// before the final use consumes and erases the wrapper definition.
+func.def inline @shared_cfg_leaf(%leaf_value: i32) -> (i32) {
+  cfg.br ^exit(%leaf_value: i32)
+^exit(%leaf_forwarded: i32):
+  func.return %leaf_forwarded : i32
+}
+
+func.def inline @shared_cfg_wrapper(%wrapper_value: i32) -> (i32) {
+  %wrapper_result = func.call @shared_cfg_leaf(%wrapper_value) : (i32) -> (i32)
+  func.return %wrapper_result : i32
+}
+
+func.def public @clone_cfg_wrapper(%clone_value: i32) -> (i32) {
+  %clone_result = func.call @shared_cfg_wrapper(%clone_value) : (i32) -> (i32)
+  func.return %clone_result : i32
+}
+
+func.def public @consume_cfg_wrapper(%consume_value: i32) -> (i32) {
+  %consume_result = func.call @shared_cfg_wrapper(%consume_value) : (i32) -> (i32)
+  func.return %consume_result : i32
+}
+
+// ----
+func.def public @clone_cfg_wrapper(%clone_value: i32) -> (i32) {
+  cfg.br ^_bb1(%clone_value: i32)
+^_bb1(%wrapper_value: i32):
+  cfg.br ^_bb2(%wrapper_value: i32)
+^_bb2(%leaf_value: i32):
+  cfg.br ^_bb3(%leaf_value: i32)
+^_bb3(%leaf_forwarded: i32):
+  cfg.br ^_bb4(%leaf_forwarded: i32)
+^_bb4(%wrapper_result: i32):
+  cfg.br ^_bb5(%wrapper_result: i32)
+^_bb5(%clone_result: i32):
+  func.return %clone_result : i32
+}
+
+func.def public @consume_cfg_wrapper(%consume_value: i32) -> (i32) {
+  cfg.br ^_bb1(%consume_value: i32)
+^_bb1(%wrapper_value: i32):
+  cfg.br ^_bb2(%wrapper_value: i32)
+^_bb2(%leaf_value: i32):
+  cfg.br ^_bb3(%leaf_value: i32)
+^_bb3(%leaf_forwarded: i32):
+  cfg.br ^_bb4(%leaf_forwarded: i32)
+^_bb4(%wrapper_result: i32):
+  cfg.br ^_bb5(%wrapper_result: i32)
+^_bb5(%consume_result: i32):
+  func.return %consume_result : i32
 }
 
 // ====


### PR DESCRIPTION
Single-use required-inline chains that end in a CFG helper now compile by moving the unique final-use body instead of cloning an ever-growing closure. At 1,024 helpers, the checked-in benchmark drops from 298.204 ms to 0.962 ms mean time while the final caller contracts from 2,050 blocks to 4. This keeps ordinary `func.call` and target-forced `low.func.call` composition compact without changing authored inline policy.

## What this enables efficiently

Existing authored code keeps the same shape:

```loom
func.def inline @cfg_leaf(%value: i32) -> (i32) {
  cfg.br ^exit(%value: i32)
^exit(%forwarded: i32):
  func.return %forwarded : i32
}

func.def inline @compose(%value: i32) -> (i32) {
  %result = func.call @cfg_leaf(%value) : (i32) -> (i32)
  func.return %result : i32
}

func.def public @entry(%value: i32) -> (i32) {
  %result = func.call @compose(%value) : (i32) -> (i32)
  func.return %result : i32
}
```

Required inlining now consumes the single-use wrappers before expanding the CFG leaf, producing one entry branch, the leaf CFG, one continuation, and the public return. The same execution policy applies to Low helper closures when the target requires their calls to inline; Low branch construction and locked-schedule normalization remain in the Low-aware layer.

## Compiler design

### Generic consuming CFG splice

`loom_rewriter_move_region_blocks` moves a source region's block payloads into a caller without cloning SSA values or operations. It preserves non-entry block identity, copies the embedded entry payload into stable storage, repairs entry backedges, reparents block arguments and operations, retains comments and semantic summaries, and transfers CFG flags. The source is left as one empty valid region so its private definition can be erased.

The callable layer builds the normal call-site split around that mover: operands branch to the moved entry, every return branches to one continuation with result block arguments, call results are replaced by those arguments, and the consumed callee is erased. Dialect-provided branch builders keep this machinery independent of `cfg.br`, `low.br`, and target operation identities. Moved blocks are inserted immediately after the call block because Loom's serialized SSA contract requires definitions to precede direct cross-block uses.

### Dependency-scheduled closure execution

The pass now separates clone and transfer dependencies:

- A clone waits until the target's outgoing required-inline edges are complete, so every clone observes a fully flattened body.
- A target's unique consuming transfer waits until all clone uses are complete, so no later use can observe an erased definition.
- Otherwise, a single-use wrapper may move outward before its nested CFG is expanded. Linear-ready edges run first, preserving the availability-based move fast path and carrying linear producers with a CFG parent.

Each call edge enters a ready stack once, so execution bookkeeping is linear in symbols plus call edges. Locked Low schedules are materialized once as per-block fences before any body crosses a callable boundary.

## Performance

The benchmark uses a verified 1,024-helper single-use chain with a two-block CFG leaf. Source construction, parsing, verification, and fresh-module cloning are outside the timed region.

| Metric | Previous execution | Consuming execution | Change |
| --- | ---: | ---: | ---: |
| Mean time | 298.204 ms | 0.962 ms | 310x faster |
| Median time | 304.538 ms | 0.932 ms | 327x faster |
| Live output blocks / ops | 2,050 / 2,050 | 4 / 4 | compact closure |
| Module arena | 255.38 MB | 1.38149 MB | 185x lower |
| Complexity fit | `O(N^2)` | `O(N)` | linearized |

## Reviewer notes

The highest-value review surfaces are the pointer-table ownership transfer in `rewrite/rewriter.c`, the entry/continuation construction in `rewrite/callable.c`, and the clone/transfer readiness invariants in `transforms/symbol/inline_callables.c`. Focused coverage includes embedded-entry self-loops, entry comments, result names, nested linear and CFG closure order, shared clone-plus-transfer users, Low definition-before-use ordering, and locked Low schedules.