### PR TITLE
[Loom] Make target selection universal in loom-link

### DIFF
--- a/loom/build_tools/bazel/loom_linking.bzl
+++ b/loom/build_tools/bazel/loom_linking.bzl
@@ -109,7 +109,7 @@ def _declare_linked_module(
         args.add("--config=%s=%s" % (key, configs[key]))
     if target_profile:
         args.add(
-            "--target-profile=%s:%s" % (
+            "--target=%s:%s" % (
                 target_profile.family,
                 target_profile.selector,
             ),

--- a/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
@@ -99,7 +99,7 @@ def _test_kernel_binary_roots_direct_library_exports_impl(env, target):
         "--mode=link",
         "--strip-check",
         "--require-resolved-config",
-        "--target-profile=amdgpu:gfx11-generic",
+        "--target=amdgpu:gfx11-generic",
         "--to=bc",
     ]:
         if expected_arg not in link_action.argv:
@@ -159,7 +159,7 @@ def _test_kernel_binary_sources_are_an_implicit_library_impl(env, target):
     )
 
     link_action = _find_action(env, actions, "LoomBinaryLink")
-    if "--target-profile=amdgpu:gfx11-generic" not in link_action.argv:
+    if "--target=amdgpu:gfx11-generic" not in link_action.argv:
         env.fail(
             "expected target profile in link arguments %r" %
             link_action.argv,
@@ -275,7 +275,7 @@ def _test_command_binary_emits_composite_product_impl(env, target):
 
     actions = target[TestingAspectInfo].actions
     link_action = _find_action(env, actions, "LoomBinaryLink")
-    if "--target-profile=amdgpu:gfx11-generic" not in link_action.argv:
+    if "--target=amdgpu:gfx11-generic" not in link_action.argv:
         env.fail(
             "expected target profile in link arguments %r" %
             link_action.argv,

--- a/loom/docs/examples/elementwise-transform/run.sh
+++ b/loom/docs/examples/elementwise-transform/run.sh
@@ -50,7 +50,7 @@ loom_example_run_tool loom-link "${loom_link}" \
   --library=motif.loom \
   --mode=link \
   --root=@elementwise_transform \
-  --target-profile="amdgpu:${LOOM_EXAMPLE_TARGET}" \
+  --target="amdgpu:${LOOM_EXAMPLE_TARGET}" \
   --to=text \
   --output="${output_dir}/elementwise-transform.loom"
 

--- a/loom/docs/src/getting-started/source-to-artifacts.md
+++ b/loom/docs/src/getting-started/source-to-artifacts.md
@@ -283,7 +283,7 @@ loom/docs/examples/elementwise-transform/run.sh \
 The resulting directory contains the closed target-specialized
 `elementwise-transform.loom` module, the GFX11 HSACO, a command manifest, one
 portable `.loomcmd`, and the captured target Low IR. The
-`--target-profile=amdgpu:gfx11-generic` link argument makes subgroup facts
+`--target=amdgpu:gfx11-generic` link argument makes subgroup facts
 available before template-provider pruning, so the wave32 implementation is
 selected without pulling the portable alternative into the product. The
 documentation build invokes the same script and regenerates the views below;

--- a/loom/docs/src/workflows/build-with-bazel.md
+++ b/loom/docs/src/workflows/build-with-bazel.md
@@ -188,7 +188,7 @@ changing the product graph.
 The Bazel rules orchestrate the public tools; they do not add a second linkage
 model. `loom_library` corresponds to a strict relocatable merge. A kernel or
 command binary first performs a root-selected `loom-link --mode=link` with the
-selected `--target-profile`, then invokes the appropriate `loom-compile`
+selected `--target`, then invokes the appropriate `loom-compile`
 backend on that one closed module. A VM binary performs the same selective
 link without a device profile. The command product invokes the command and
 AMDGPU emitters over the same linked input.

--- a/loom/docs/src/workflows/link-and-package.md
+++ b/loom/docs/src/workflows/link-and-package.md
@@ -111,7 +111,7 @@ loom-link model.loom \
   --library=motif.loom \
   --mode=link \
   --root=@elementwise_transform \
-  --target-profile=amdgpu:gfx11-generic \
+  --target=amdgpu:gfx11-generic \
   --to=bc \
   --output=elementwise-gfx11.loombc
 ```

--- a/loom/py/loom/gen/target/arch/amdgpu/amdgpu_target_info.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/amdgpu_target_info.py
@@ -1099,6 +1099,21 @@ def _emit_header(descriptor_sets: Sequence[AmdgpuDescriptorSetInfo]) -> str:
         [
             f"#define LOOM_AMDGPU_DESCRIPTOR_SET_ORDINAL_COUNT {_u16_expr(len(descriptor_sets))}",
             "",
+            "#ifdef __cplusplus",
+            'extern "C" {',
+            "#endif",
+            "",
+            "// Address-stable generated compiler target rows in target-kind order.",
+            "//",
+            "// Target-owned immutable aggregates use these addresses in constant",
+            "// initializers. Runtime lookup uses the checked target-info accessors.",
+            "extern const loom_amdgpu_target_info_t",
+            "    loom_amdgpu_target_info_target_infos[];",
+            "",
+            "#ifdef __cplusplus",
+            '}  // extern "C"',
+            "#endif",
+            "",
         ]
     )
     lines.extend(
@@ -1138,8 +1153,6 @@ def _emit_tables_header() -> str:
         "extern const iree_host_size_t",
         "    loom_amdgpu_target_info_processor_info_count;",
         "",
-        "extern const loom_amdgpu_target_info_t",
-        "    loom_amdgpu_target_info_target_infos[];",
         "extern const iree_host_size_t",
         "    loom_amdgpu_target_info_target_info_count;",
         "",

--- a/loom/py/loom/gen/target/arch/amdgpu/amdgpu_target_info_test.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/amdgpu_target_info_test.py
@@ -149,6 +149,15 @@ def test_target_info_table_source_is_data_only() -> None:
     assert "loom_amdgpu_target_info_physical_target_infos[]" in source
 
 
+def test_target_info_headers_keep_address_stable_target_rows_public() -> None:
+    public_header = amdgpu_target_info._emit_header(amdgpu_target_info.sorted_descriptor_set_infos())
+    private_header = amdgpu_target_info._emit_tables_header()
+
+    assert "loom_amdgpu_target_info_target_infos[]" in public_header
+    assert "loom_amdgpu_target_info_target_infos[]" not in private_header
+    assert "loom_amdgpu_target_info_target_info_count" in private_header
+
+
 def test_overlay_and_physical_targets_generate_data_rows_only() -> None:
     descriptor_set_info = amdgpu_target_info.sorted_descriptor_set_infos()[0]
     descriptor_row = amdgpu_target_info._AmdgpuDescriptorSetRow(

--- a/loom/py/loom/gen/target/arch/amdgpu/records/amdgpu_target_records.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/records/amdgpu_target_records.py
@@ -18,12 +18,21 @@ from loom.gen.support.files import write_text_file
 from loom.gen.support.generated_file import line_comment_header
 from loom.target.arch.amdgpu.target_info import (
     AMDGPU_DESCRIPTOR_SET_ORDINAL_NONE,
+    AMDGPU_TARGET_ID_FEATURE_SUPPORT_SRAMECC,
+    AMDGPU_TARGET_ID_FEATURE_SUPPORT_XNACK,
     AmdgpuDescriptorSetInfo,
     AmdgpuProcessorInfo,
     AmdgpuTargetInfo,
     amdgpu_descriptor_set_ordinal,
     amdgpu_target_descriptor_set_key,
 )
+
+_TARGET_PROFILE_SUPPORTED_FEATURE_STATES = (
+    ("Any", "LOOM_AMDGPU_TARGET_FEATURE_ANY"),
+    ("Off", "LOOM_AMDGPU_TARGET_FEATURE_OFF"),
+    ("On", "LOOM_AMDGPU_TARGET_FEATURE_ON"),
+)
+_TARGET_PROFILE_UNSUPPORTED_FEATURE_STATES = (("Unsupported", "LOOM_AMDGPU_TARGET_FEATURE_UNSUPPORTED"),)
 
 
 @dataclass(frozen=True, slots=True)
@@ -169,6 +178,13 @@ def _default_record_rows_by_ordinal(
     return {row.descriptor_set_ordinal: row for row in rows if row.info.default_for_descriptor_set}
 
 
+def _target_profile_feature_states(
+    supported_features: int,
+    feature: int,
+) -> tuple[tuple[str, str], ...]:
+    return _TARGET_PROFILE_SUPPORTED_FEATURE_STATES if supported_features & feature else _TARGET_PROFILE_UNSUPPORTED_FEATURE_STATES
+
+
 def _emit_tables(rows: Sequence[_AmdgpuTargetRecordRow]) -> str:
     descriptor_sets = _descriptor_sets_from_rows(rows)
     default_rows_by_ordinal = _default_record_rows_by_ordinal(rows)
@@ -190,6 +206,8 @@ def _emit_tables(rows: Sequence[_AmdgpuTargetRecordRow]) -> str:
         "//       wavefront_size, max_workgroup_storage_bytes)",
         "//   LOOM_AMDGPU_TARGET_RECORD_INFO(record_suffix, target_kind, target,",
         "//       descriptor_set_ordinal, bundle_suffix)",
+        "//   LOOM_AMDGPU_TARGET_PROFILE(profile_suffix, target_kind,",
+        "//       bundle_suffix, sramecc_state, xnack_state)",
         "//   LOOM_AMDGPU_TARGET_RECORD_DEFAULT(descriptor_set_ordinal, record_suffix)",
         "//   LOOM_AMDGPU_TARGET_RECORD_DEFAULT_ABSENT(descriptor_set_ordinal)",
         "",
@@ -223,6 +241,23 @@ def _emit_tables(rows: Sequence[_AmdgpuTargetRecordRow]) -> str:
         for row in rows
     )
     lines.extend(["#endif  // LOOM_AMDGPU_TARGET_RECORD_INFO", ""])
+
+    lines.append("#ifdef LOOM_AMDGPU_TARGET_PROFILE")
+    for row in rows:
+        supported_features = row.processor.target_id.supported_features
+        sramecc_states = _target_profile_feature_states(
+            supported_features,
+            AMDGPU_TARGET_ID_FEATURE_SUPPORT_SRAMECC,
+        )
+        xnack_states = _target_profile_feature_states(
+            supported_features,
+            AMDGPU_TARGET_ID_FEATURE_SUPPORT_XNACK,
+        )
+        for sramecc_suffix, sramecc_state in sramecc_states:
+            for xnack_suffix, xnack_state in xnack_states:
+                profile_suffix = f"{_c_symbol_suffix(row.info.target)}Sramecc{sramecc_suffix}Xnack{xnack_suffix}"
+                lines.append(f"LOOM_AMDGPU_TARGET_PROFILE({profile_suffix}, {_u32_expr(row.info.enum_value)}, {_c_symbol_suffix(row.descriptor_set.generator_target)}, {sramecc_state}, {xnack_state})")
+    lines.extend(["#endif  // LOOM_AMDGPU_TARGET_PROFILE", ""])
 
     lines.append("#if defined(LOOM_AMDGPU_TARGET_RECORD_DEFAULT) && defined(LOOM_AMDGPU_TARGET_RECORD_DEFAULT_ABSENT)")
     for descriptor_set_ordinal in range(max_descriptor_set_ordinal + 1):

--- a/loom/py/loom/gen/target/arch/amdgpu/records/amdgpu_target_records_test.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/records/amdgpu_target_records_test.py
@@ -15,6 +15,8 @@ from loom.target.arch.amdgpu.target_info import (
     AMDGPU_DEFAULT_MAX_WORKGROUP_STORAGE_BYTES,
     AMDGPU_DESCRIPTOR_SET_INFO_FLAG_DESCRIPTOR_PACKET_ENCODING,
     AMDGPU_SOPP_OPCODE_INFO_RDNA,
+    AMDGPU_TARGET_ID_FEATURE_SUPPORT_SRAMECC,
+    AMDGPU_TARGET_ID_FEATURE_SUPPORT_XNACK,
     AmdgpuDescriptorSetInfo,
     AmdgpuDescriptorSetIsaInfo,
     AmdgpuTargetInfo,
@@ -101,6 +103,18 @@ def test_target_records_materialize_current_rows() -> None:
         assert (f'LOOM_AMDGPU_TARGET_RECORD_INFO({suffix}, UINT32_C({row.info.enum_value}), "{row.info.target}", UINT16_C({row.descriptor_set_ordinal}), {descriptor_suffix})') in source
         if row.info.default_for_descriptor_set:
             assert (f"LOOM_AMDGPU_TARGET_RECORD_DEFAULT(UINT16_C({row.descriptor_set_ordinal}), {suffix})") in source
+
+    assert "LOOM_AMDGPU_TARGET_PROFILE(Gfx942SrameccAnyXnackAny, UINT32_C(1), Cdna3, LOOM_AMDGPU_TARGET_FEATURE_ANY, LOOM_AMDGPU_TARGET_FEATURE_ANY)" in source
+    assert "LOOM_AMDGPU_TARGET_PROFILE(Gfx942SrameccOnXnackOff, UINT32_C(1), Cdna3, LOOM_AMDGPU_TARGET_FEATURE_ON, LOOM_AMDGPU_TARGET_FEATURE_OFF)" in source
+    assert "LOOM_AMDGPU_TARGET_PROFILE(Gfx1151SrameccUnsupportedXnackUnsupported, UINT32_C(15), Rdna35, LOOM_AMDGPU_TARGET_FEATURE_UNSUPPORTED, LOOM_AMDGPU_TARGET_FEATURE_UNSUPPORTED)" in source
+
+    expected_profile_count = 0
+    for row in rows:
+        supported_features = row.processor.target_id.supported_features
+        sramecc_state_count = 3 if supported_features & AMDGPU_TARGET_ID_FEATURE_SUPPORT_SRAMECC else 1
+        xnack_state_count = 3 if supported_features & AMDGPU_TARGET_ID_FEATURE_SUPPORT_XNACK else 1
+        expected_profile_count += sramecc_state_count * xnack_state_count
+    assert source.count("\nLOOM_AMDGPU_TARGET_PROFILE(") == expected_profile_count
 
     rows_by_target = {row.info.target: row for row in rows}
     assert rows_by_target["gfx1250"].descriptor_set.key == "amdgpu.rdna4.gfx125x.core"

--- a/loom/src/loom/target/BUILD.bazel
+++ b/loom/src/loom/target/BUILD.bazel
@@ -254,6 +254,26 @@ loom_cc_library(
 )
 
 loom_cc_library(
+    name = "selection",
+    srcs = ["selection.c"],
+    hdrs = ["selection.h"],
+    deps = [
+        ":provider",
+        "//runtime/src/iree/base",
+    ],
+)
+
+loom_cc_test(
+    name = "selection_test",
+    srcs = ["selection_test.cc"],
+    deps = [
+        ":selection",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_library(
     name = "residency",
     srcs = ["residency.c"],
     hdrs = ["residency.h"],

--- a/loom/src/loom/target/CMakeLists.txt
+++ b/loom/src/loom/target/CMakeLists.txt
@@ -286,6 +286,30 @@ loom_cc_library(
 
 loom_cc_library(
   NAME
+    selection
+  HDRS
+    "selection.h"
+  SRCS
+    "selection.c"
+  DEPS
+    ::provider
+    iree::base
+  PUBLIC
+)
+
+loom_cc_test(
+  NAME
+    selection_test
+  SRCS
+    "selection_test.cc"
+  DEPS
+    ::selection
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+loom_cc_library(
+  NAME
     residency
   HDRS
     "residency.h"

--- a/loom/src/loom/target/arch/amdgpu/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/BUILD.bazel
@@ -276,10 +276,12 @@ loom_cc_library(
         ]
     ),
     deps = [
+        ":artifact_key",
         ":facts",
         ":target_info",
         "//loom/src/loom/target:profile",
         "//loom/src/loom/target/arch/amdgpu/records:target_records",
+        "//loom/src/loom/target/arch/amdgpu/records:target_records_tables",
         "//runtime/src/iree/base",
     ],
 )
@@ -288,6 +290,7 @@ loom_cc_test(
     name = "profile_test",
     srcs = ["profile_test.cc"],
     deps = [
+        ":artifact_key",
         ":profile",
         ":target_info",
         "//loom/src/loom/target/arch/amdgpu/records:target_records",

--- a/loom/src/loom/target/arch/amdgpu/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/CMakeLists.txt
@@ -218,10 +218,12 @@ loom_cc_library(
   SRCS
     "profile.c"
   DEPS
+    ::artifact_key
     ::facts
     ::target_info
     iree::base
     loom::target::arch::amdgpu::records::target_records
+    loom::target::arch::amdgpu::records::target_records_tables
     loom::target::profile
   PUBLIC
 )
@@ -234,6 +236,7 @@ loom_cc_test(
   SRCS
     "profile_test.cc"
   DEPS
+    ::artifact_key
     ::profile
     ::target_info
     iree::base::internal::arena

--- a/loom/src/loom/target/arch/amdgpu/profile.c
+++ b/loom/src/loom/target/arch/amdgpu/profile.c
@@ -6,8 +6,18 @@
 
 #include "loom/target/arch/amdgpu/profile.h"
 
+#include "loom/target/arch/amdgpu/artifact_key.h"
 #include "loom/target/arch/amdgpu/records/target_records.h"
 #include "loom/target/arch/amdgpu/target_info.h"
+
+// Target bundles are defined by target_records.c and intentionally remain an
+// implementation detail shared with this generated preset table.
+#define LOOM_AMDGPU_TARGET_DESCRIPTOR_SET(                                \
+    symbol_suffix, bundle_name, snapshot_name, key, descriptor_set_flags, \
+    wavefront_size, workgroup_storage_byte_limit)                         \
+  extern const loom_target_bundle_t kAmdgpuLowTargetBundle##symbol_suffix##Core;
+#include "loom/target/arch/amdgpu/target_records_tables.inl"
+#undef LOOM_AMDGPU_TARGET_DESCRIPTOR_SET
 
 static iree_status_t loom_amdgpu_target_profile_project_facts(
     const loom_target_profile_t* base_profile, iree_arena_allocator_t* arena,
@@ -30,6 +40,38 @@ const loom_target_profile_type_t loom_amdgpu_target_profile_type = {
     .fact_type = &loom_amdgpu_target_fact_type,
     .project_facts = loom_amdgpu_target_profile_project_facts,
 };
+
+// clang-format off
+#define LOOM_AMDGPU_TARGET_PROFILE(                                      \
+    profile_suffix, target_kind_value, bundle_suffix, sramecc_state,    \
+    xnack_state)                                                        \
+  static const loom_amdgpu_target_profile_t                             \
+      kAmdgpuTargetProfile##profile_suffix = {                          \
+          .base = {                                                     \
+              .type = &loom_amdgpu_target_profile_type,                 \
+              .target_bundle = &kAmdgpuLowTargetBundle##bundle_suffix##Core, \
+          },                                                            \
+          .identity = {                                                 \
+              .target = &loom_amdgpu_target_info_target_infos[          \
+                  (target_kind_value) - UINT32_C(1)],                    \
+              .amdhsa_features = {                                      \
+                  .sramecc = sramecc_state,                             \
+                  .xnack = xnack_state,                                 \
+              },                                                        \
+          },                                                            \
+      };
+#include "loom/target/arch/amdgpu/target_records_tables.inl"
+#undef LOOM_AMDGPU_TARGET_PROFILE
+
+static const loom_amdgpu_target_profile_t* const kAmdgpuTargetProfiles[] = {
+#define LOOM_AMDGPU_TARGET_PROFILE(                                      \
+    profile_suffix, target_kind_value, bundle_suffix, sramecc_state,    \
+    xnack_state)                                                        \
+  &kAmdgpuTargetProfile##profile_suffix,
+#include "loom/target/arch/amdgpu/target_records_tables.inl"
+#undef LOOM_AMDGPU_TARGET_PROFILE
+};
+// clang-format on
 
 static iree_status_t loom_amdgpu_target_profile_normalize_feature(
     const loom_amdgpu_processor_info_t* processor, iree_string_view_t name,
@@ -106,9 +148,6 @@ iree_status_t loom_amdgpu_target_profile_initialize(
         identity->target->descriptor_set_key.data);
   }
 
-  loom_amdgpu_target_properties_t properties = {0};
-  loom_amdgpu_target_properties_resolve(&normalized_identity, target_bundle,
-                                        &properties);
   *out_profile = (loom_amdgpu_target_profile_t){
       .base =
           {
@@ -116,7 +155,27 @@ iree_status_t loom_amdgpu_target_profile_initialize(
               .target_bundle = target_bundle,
           },
       .identity = normalized_identity,
-      .properties = properties,
   };
   return iree_ok_status();
+}
+
+iree_status_t loom_amdgpu_target_profile_select(
+    iree_string_view_t selector,
+    const loom_amdgpu_target_profile_t** out_profile) {
+  IREE_ASSERT_ARGUMENT(out_profile);
+  *out_profile = NULL;
+
+  loom_amdgpu_target_identity_t identity = {0};
+  IREE_RETURN_IF_ERROR(loom_amdgpu_artifact_key_parse(selector, &identity));
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(kAmdgpuTargetProfiles); ++i) {
+    const loom_amdgpu_target_profile_t* profile = kAmdgpuTargetProfiles[i];
+    if (loom_amdgpu_target_identity_equal(&profile->identity, &identity)) {
+      *out_profile = profile;
+      return iree_ok_status();
+    }
+  }
+  return iree_make_status(
+      IREE_STATUS_FAILED_PRECONDITION,
+      "AMDGPU target selector '%.*s' has no generated profile preset",
+      (int)selector.size, selector.data);
 }

--- a/loom/src/loom/target/arch/amdgpu/profile.h
+++ b/loom/src/loom/target/arch/amdgpu/profile.h
@@ -27,15 +27,20 @@ typedef struct loom_amdgpu_target_profile_t {
 
   // Structured target and AMDHSA feature identity.
   loom_amdgpu_target_identity_t identity;
-
-  // Compiler-semantic projection resolved from |identity|.
-  loom_amdgpu_target_properties_t properties;
 } loom_amdgpu_target_profile_t;
 
 // Initializes an AMDGPU profile and its target-neutral bundle projection.
 iree_status_t loom_amdgpu_target_profile_initialize(
     const loom_amdgpu_target_identity_t* identity,
     loom_amdgpu_target_profile_t* out_profile);
+
+// Selects the immutable profile matching one AMDGPU target selector.
+//
+// The returned profile has process lifetime. Target names and target-ID feature
+// suffixes use the same syntax as AMDGPU artifact keys.
+iree_status_t loom_amdgpu_target_profile_select(
+    iree_string_view_t selector,
+    const loom_amdgpu_target_profile_t** out_profile);
 
 // Returns |profile| as an AMDGPU profile, or NULL for another family.
 static inline const loom_amdgpu_target_profile_t*

--- a/loom/src/loom/target/arch/amdgpu/profile_test.cc
+++ b/loom/src/loom/target/arch/amdgpu/profile_test.cc
@@ -9,6 +9,7 @@
 #include "iree/base/internal/arena.h"
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
+#include "loom/target/arch/amdgpu/artifact_key.h"
 #include "loom/target/arch/amdgpu/records/target_records.h"
 
 namespace loom {
@@ -23,9 +24,6 @@ static const loom_amdgpu_target_info_t* LookupTarget(const char* name) {
 
 TEST(AmdgpuTargetProfileTest, PreservesStructuredTargetFacts) {
   const loom_amdgpu_target_info_t* target = LookupTarget("gfx942");
-  const loom_amdgpu_processor_info_t* processor =
-      loom_amdgpu_target_info_target_processor(target);
-  ASSERT_NE(processor, nullptr);
   const loom_amdgpu_target_identity_t identity = {
       /*.target=*/target,
       /*.amdhsa_features=*/
@@ -47,14 +45,6 @@ TEST(AmdgpuTargetProfileTest, PreservesStructuredTargetFacts) {
   EXPECT_EQ(loom_target_profile_bundle(&profile.base),
             loom_amdgpu_target_bundle_for_descriptor_set(
                 target->descriptor_set_ordinal));
-  EXPECT_EQ(profile.properties.target, target);
-  EXPECT_EQ(profile.properties.processor, &processor->properties);
-  EXPECT_EQ(profile.properties.common,
-            loom_target_profile_bundle(&profile.base));
-  EXPECT_EQ(profile.properties.amdhsa_features.sramecc,
-            LOOM_AMDGPU_TARGET_FEATURE_ON);
-  EXPECT_EQ(profile.properties.amdhsa_features.xnack,
-            LOOM_AMDGPU_TARGET_FEATURE_OFF);
 }
 
 TEST(AmdgpuTargetProfileTest, ProjectsCompilerOwnedTypedFacts) {
@@ -115,9 +105,8 @@ TEST(AmdgpuTargetProfileTest, SelectsTargetLocalDescriptorContract) {
 
   EXPECT_NE(loom_target_profile_bundle(&b0_profile.base),
             loom_target_profile_bundle(&a0_profile.base));
-  EXPECT_EQ(b0_profile.properties.processor, a0_profile.properties.processor);
-  EXPECT_EQ(b0_profile.properties.target, gfx1250);
-  EXPECT_EQ(a0_profile.properties.target, gfx1250_a0);
+  EXPECT_EQ(b0_profile.identity.target, gfx1250);
+  EXPECT_EQ(a0_profile.identity.target, gfx1250_a0);
 }
 
 TEST(AmdgpuTargetProfileTest, RejectsUnsupportedTargetFeatures) {
@@ -174,16 +163,95 @@ TEST(AmdgpuTargetProfileTest, ResolvesEveryGeneratedTargetRow) {
     loom_amdgpu_target_profile_t profile = {};
     IREE_ASSERT_OK(loom_amdgpu_target_profile_initialize(&identity, &profile));
     EXPECT_EQ(profile.identity.target, target);
-    EXPECT_EQ(profile.properties.target, target);
-    EXPECT_EQ(profile.properties.instruction_constraints,
-              properties.instruction_constraints);
-    EXPECT_EQ(profile.properties.lds_bank_service_model_set_ordinal,
-              properties.lds_bank_service_model_set_ordinal);
-    EXPECT_EQ(profile.properties.kernel_metadata_extensions.entries,
-              properties.kernel_metadata_extensions.entries);
-    EXPECT_EQ(profile.properties.kernel_metadata_extensions.count,
-              properties.kernel_metadata_extensions.count);
   }
+}
+
+TEST(AmdgpuTargetProfileTest, SelectsImmutableGeneratedProfiles) {
+  const loom_amdgpu_target_profile_t* profile = nullptr;
+  IREE_ASSERT_OK(loom_amdgpu_target_profile_select(
+      IREE_SV("gfx942:xnack-:sramecc+"), &profile));
+  ASSERT_NE(profile, nullptr);
+  EXPECT_TRUE(iree_string_view_equal(profile->identity.target->name,
+                                     IREE_SV("gfx942")));
+  EXPECT_EQ(profile->identity.amdhsa_features.sramecc,
+            LOOM_AMDGPU_TARGET_FEATURE_ON);
+  EXPECT_EQ(profile->identity.amdhsa_features.xnack,
+            LOOM_AMDGPU_TARGET_FEATURE_OFF);
+
+  const loom_amdgpu_target_profile_t* repeated_profile = nullptr;
+  IREE_ASSERT_OK(loom_amdgpu_target_profile_select(
+      IREE_SV("gfx942:sramecc+:xnack-"), &repeated_profile));
+  EXPECT_EQ(repeated_profile, profile);
+}
+
+TEST(AmdgpuTargetProfileTest, SelectsEveryValidFeatureCombination) {
+  static const loom_amdgpu_target_feature_state_t kSupportedStates[] = {
+      LOOM_AMDGPU_TARGET_FEATURE_ANY,
+      LOOM_AMDGPU_TARGET_FEATURE_OFF,
+      LOOM_AMDGPU_TARGET_FEATURE_ON,
+  };
+  static const loom_amdgpu_target_feature_state_t kUnsupportedStates[] = {
+      LOOM_AMDGPU_TARGET_FEATURE_UNSUPPORTED,
+  };
+  const iree_host_size_t target_count = loom_amdgpu_target_info_target_count();
+  for (iree_host_size_t target_ordinal = 0; target_ordinal < target_count;
+       ++target_ordinal) {
+    const loom_amdgpu_target_info_t* target =
+        loom_amdgpu_target_info_target_at(target_ordinal);
+    ASSERT_NE(target, nullptr);
+    const loom_amdgpu_processor_info_t* processor =
+        loom_amdgpu_target_info_target_processor(target);
+    ASSERT_NE(processor, nullptr);
+
+    const bool supports_sramecc =
+        iree_all_bits_set(processor->target_id.supported_features,
+                          LOOM_AMDGPU_TARGET_ID_FEATURE_SUPPORT_SRAMECC);
+    const bool supports_xnack =
+        iree_all_bits_set(processor->target_id.supported_features,
+                          LOOM_AMDGPU_TARGET_ID_FEATURE_SUPPORT_XNACK);
+    const loom_amdgpu_target_feature_state_t* sramecc_states =
+        supports_sramecc ? kSupportedStates : kUnsupportedStates;
+    const iree_host_size_t sramecc_state_count =
+        supports_sramecc ? IREE_ARRAYSIZE(kSupportedStates)
+                         : IREE_ARRAYSIZE(kUnsupportedStates);
+    const loom_amdgpu_target_feature_state_t* xnack_states =
+        supports_xnack ? kSupportedStates : kUnsupportedStates;
+    const iree_host_size_t xnack_state_count =
+        supports_xnack ? IREE_ARRAYSIZE(kSupportedStates)
+                       : IREE_ARRAYSIZE(kUnsupportedStates);
+    for (iree_host_size_t sramecc_ordinal = 0;
+         sramecc_ordinal < sramecc_state_count; ++sramecc_ordinal) {
+      for (iree_host_size_t xnack_ordinal = 0;
+           xnack_ordinal < xnack_state_count; ++xnack_ordinal) {
+        const loom_amdgpu_target_identity_t identity = {
+            /*.target=*/target,
+            /*.amdhsa_features=*/
+            {
+                /*.sramecc=*/sramecc_states[sramecc_ordinal],
+                /*.xnack=*/xnack_states[xnack_ordinal],
+            },
+        };
+        char selector_storage[128];
+        iree_string_view_t selector = iree_string_view_empty();
+        IREE_ASSERT_OK(loom_amdgpu_artifact_key_format(
+            &identity, sizeof(selector_storage), selector_storage, &selector));
+
+        const loom_amdgpu_target_profile_t* profile = nullptr;
+        IREE_ASSERT_OK(loom_amdgpu_target_profile_select(selector, &profile));
+        ASSERT_NE(profile, nullptr);
+        EXPECT_TRUE(
+            loom_amdgpu_target_identity_equal(&profile->identity, &identity));
+      }
+    }
+  }
+}
+
+TEST(AmdgpuTargetProfileTest, RejectsInvalidProfileSelectors) {
+  const loom_amdgpu_target_profile_t* profile = nullptr;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_amdgpu_target_profile_select(IREE_SV("gfx1151:xnack+"), &profile));
+  EXPECT_EQ(profile, nullptr);
 }
 
 TEST(AmdgpuTargetProfileTest, ExhaustsTargetFeatureSatisfactionRelation) {

--- a/loom/src/loom/target/arch/amdgpu/provider.c
+++ b/loom/src/loom/target/arch/amdgpu/provider.c
@@ -111,6 +111,14 @@ static iree_status_t loom_amdgpu_provider_contribute_pipeline(
       NULL, &where_op);
 }
 
+static iree_status_t loom_amdgpu_provider_select_profile(
+    iree_string_view_t selector, const loom_target_profile_t** out_profile) {
+  const loom_amdgpu_target_profile_t* profile = NULL;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_target_profile_select(selector, &profile));
+  *out_profile = profile ? &profile->base : NULL;
+  return iree_ok_status();
+}
+
 const loom_target_provider_t loom_amdgpu_target_provider = {
     .profile_type = &loom_amdgpu_target_profile_type,
     .materialize_definition = loom_amdgpu_target_materialize_definition,
@@ -150,6 +158,7 @@ const loom_target_provider_t loom_amdgpu_target_provider = {
     .pass_registry = &loom_amdgpu_pass_registry,
     .contribute_pipeline = loom_amdgpu_provider_contribute_pipeline,
     .target_fact_type = &loom_amdgpu_target_fact_type,
+    .select_profile = loom_amdgpu_provider_select_profile,
 };
 
 static const loom_target_provider_t* const kLoomAmdgpuTargetProviders[] = {

--- a/loom/src/loom/target/arch/amdgpu/records/target_records.c
+++ b/loom/src/loom/target/arch/amdgpu/records/target_records.c
@@ -73,7 +73,7 @@ static const loom_target_export_plan_t kAmdgpuHalExportPlan = {
 #define LOOM_AMDGPU_TARGET_DESCRIPTOR_SET(                                  \
     symbol_suffix, bundle_name, snapshot_name, key, descriptor_set_flags,   \
     wavefront_size, workgroup_storage_byte_limit)                           \
-  static const loom_target_bundle_t kAmdgpuLowTargetBundle##symbol_suffix##Core = { \
+  const loom_target_bundle_t kAmdgpuLowTargetBundle##symbol_suffix##Core = { \
     .name = IREE_SVL(bundle_name), \
     .snapshot = &kAmdgpu##symbol_suffix##Snapshot, \
     .export_plan = &kAmdgpuHalExportPlan, \

--- a/loom/src/loom/target/arch/spirv/BUILD.bazel
+++ b/loom/src/loom/target/arch/spirv/BUILD.bazel
@@ -229,6 +229,7 @@ loom_cc_library(
     deps = [
         ":facts",
         "//loom/src/loom/target:profile",
+        "//loom/src/loom/target/arch/spirv/records:target_records",
         "//runtime/src/iree/base",
     ],
 )

--- a/loom/src/loom/target/arch/spirv/CMakeLists.txt
+++ b/loom/src/loom/target/arch/spirv/CMakeLists.txt
@@ -236,6 +236,7 @@ loom_cc_library(
   DEPS
     ::facts
     iree::base
+    loom::target::arch::spirv::records::target_records
     loom::target::profile
   PUBLIC
 )

--- a/loom/src/loom/target/arch/spirv/profile.c
+++ b/loom/src/loom/target/arch/spirv/profile.c
@@ -8,6 +8,8 @@
 
 #include <string.h>
 
+#include "loom/target/arch/spirv/records/target_records.h"
+
 static iree_status_t loom_spirv_target_profile_allocate_copy(
     iree_arena_allocator_t* arena, const void* source,
     iree_host_size_t byte_length, void** out_copy) {
@@ -136,6 +138,14 @@ const loom_target_profile_type_t loom_spirv_target_profile_type = {
     .project_facts = loom_spirv_target_profile_project_facts,
 };
 
+static const loom_spirv_target_profile_t kSpirvVulkan13BdaTargetProfile = {
+    .base =
+        {
+            .type = &loom_spirv_target_profile_type,
+            .target_bundle = &loom_spirv_low_target_bundle_vulkan1_3,
+        },
+};
+
 void loom_spirv_target_profile_initialize(
     const loom_target_bundle_t* target_bundle,
     const loom_spirv_cooperative_property_set_t* cooperative_properties,
@@ -149,4 +159,19 @@ void loom_spirv_target_profile_initialize(
           },
       .cooperative_properties = cooperative_properties,
   };
+}
+
+iree_status_t loom_spirv_target_profile_select(
+    iree_string_view_t selector,
+    const loom_spirv_target_profile_t** out_profile) {
+  IREE_ASSERT_ARGUMENT(out_profile);
+  *out_profile = NULL;
+  if (!iree_string_view_equal(selector, IREE_SV("vulkan1.3+bda"))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "unknown SPIR-V target selector '%.*s'; expected vulkan1.3+bda",
+        (int)selector.size, selector.data);
+  }
+  *out_profile = &kSpirvVulkan13BdaTargetProfile;
+  return iree_ok_status();
 }

--- a/loom/src/loom/target/arch/spirv/profile.h
+++ b/loom/src/loom/target/arch/spirv/profile.h
@@ -35,6 +35,15 @@ void loom_spirv_target_profile_initialize(
     const loom_spirv_cooperative_property_set_t* cooperative_properties,
     loom_spirv_target_profile_t* out_profile);
 
+// Selects the immutable profile matching one SPIR-V target selector.
+//
+// The returned profile has process lifetime. Named profiles model static API
+// environments; device-discovered profiles may additionally carry dynamic
+// cooperative operation rows through |loom_spirv_target_profile_initialize|.
+iree_status_t loom_spirv_target_profile_select(
+    iree_string_view_t selector,
+    const loom_spirv_target_profile_t** out_profile);
+
 // Returns |profile| as a SPIR-V profile, or NULL for another family.
 static inline const loom_spirv_target_profile_t* loom_spirv_target_profile_cast(
     const loom_target_profile_t* profile) {

--- a/loom/src/loom/target/arch/spirv/profile_test.cc
+++ b/loom/src/loom/target/arch/spirv/profile_test.cc
@@ -111,6 +111,29 @@ TEST(SpirvTargetProfileTest, ProjectsOwnedCooperativePropertyFacts) {
   iree_arena_block_pool_deinitialize(&block_pool);
 }
 
+TEST(SpirvTargetProfileTest, SelectsImmutableVulkanProfile) {
+  const loom_spirv_target_profile_t* profile = nullptr;
+  IREE_ASSERT_OK(
+      loom_spirv_target_profile_select(IREE_SV("vulkan1.3+bda"), &profile));
+  ASSERT_NE(profile, nullptr);
+  EXPECT_EQ(profile->base.target_bundle,
+            &loom_spirv_low_target_bundle_vulkan1_3);
+  EXPECT_EQ(profile->cooperative_properties, nullptr);
+
+  const loom_spirv_target_profile_t* repeated_profile = nullptr;
+  IREE_ASSERT_OK(loom_spirv_target_profile_select(IREE_SV("vulkan1.3+bda"),
+                                                  &repeated_profile));
+  EXPECT_EQ(repeated_profile, profile);
+}
+
+TEST(SpirvTargetProfileTest, RejectsUnknownNamedProfile) {
+  const loom_spirv_target_profile_t* profile = nullptr;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_spirv_target_profile_select(IREE_SV("vulkan1.2"), &profile));
+  EXPECT_EQ(profile, nullptr);
+}
+
 TEST(SpirvTargetProfileTest, CheckedCastRejectsAnotherFamily) {
   static const loom_target_profile_type_t kOtherProfileType = {
       /*.name=*/IREE_SVL("other"),

--- a/loom/src/loom/target/arch/spirv/provider.c
+++ b/loom/src/loom/target/arch/spirv/provider.c
@@ -25,6 +25,14 @@ static const loom_target_legalizer_provider_t* const
         &loom_spirv_target_legalizer_provider_storage,
 };
 
+static iree_status_t loom_spirv_provider_select_profile(
+    iree_string_view_t selector, const loom_target_profile_t** out_profile) {
+  const loom_spirv_target_profile_t* profile = NULL;
+  IREE_RETURN_IF_ERROR(loom_spirv_target_profile_select(selector, &profile));
+  *out_profile = profile ? &profile->base : NULL;
+  return iree_ok_status();
+}
+
 const loom_target_provider_t loom_spirv_target_provider = {
     .profile_type = &loom_spirv_target_profile_type,
     .materialize_definition = loom_spirv_target_materialize_definition,
@@ -47,6 +55,7 @@ const loom_target_provider_t loom_spirv_target_provider = {
             .values = kLoomSpirvLowVerifyProviders,
         },
     .target_fact_type = &loom_spirv_target_fact_type,
+    .select_profile = loom_spirv_provider_select_profile,
 };
 
 static const loom_target_provider_t* const kLoomSpirvTargetProviders[] = {

--- a/loom/src/loom/target/emit/native/amdgpu/hsaco_hsa_test.cc
+++ b/loom/src/loom/target/emit/native/amdgpu/hsaco_hsa_test.cc
@@ -1081,7 +1081,7 @@ iree_status_t EmitRuntimeGlobalKernelForAmdgpu(const AmdgpuHsaTarget& target,
       CodeObjectTargetIdForIdentity(target_profile.identity);
   loom_amdgpu_hsaco_kernel_t revisioned_kernel = kernel;
   revisioned_kernel.metadata.target_extensions =
-      target_profile.properties.kernel_metadata_extensions;
+      target_profile.identity.target->kernel_metadata_extensions;
   const loom_amdgpu_hsaco_file_t file = {
       /*.target=*/iree_make_string_view(target_id.data(), target_id.size()),
       /*.processor=*/processor->name,

--- a/loom/src/loom/target/emit/native/amdgpu/hsaco_test.cc
+++ b/loom/src/loom/target/emit/native/amdgpu/hsaco_test.cc
@@ -799,8 +799,7 @@ TEST(AmdgpuHsacoTest, WritesEveryTargetCodeObjectFlags) {
     loom_amdgpu_target_profile_t target_profile = {};
     IREE_ASSERT_OK(
         loom_amdgpu_target_profile_initialize(&identity, &target_profile));
-    metadata.target_extensions =
-        target_profile.properties.kernel_metadata_extensions;
+    metadata.target_extensions = target->kernel_metadata_extensions;
     const loom_amdgpu_hsaco_kernel_t kernel = {
         /*.metadata=*/metadata,
         /*.descriptor_options=*/{},

--- a/loom/src/loom/target/provider.h
+++ b/loom/src/loom/target/provider.h
@@ -268,6 +268,14 @@ typedef struct loom_target_pipeline_contribution_t {
 typedef iree_status_t (*loom_target_provider_pipeline_contribution_fn_t)(
     const loom_target_pipeline_contribution_t* contribution);
 
+// Selects one immutable process-lifetime profile by family-owned selector.
+//
+// The returned profile is borrowed and requires no release. Providers without
+// a finite static selector space leave this NULL while still accepting
+// embedding-owned structured profiles through |profile_type|.
+typedef iree_status_t (*loom_target_provider_select_profile_fn_t)(
+    iree_string_view_t selector, const loom_target_profile_t** out_profile);
+
 // Target-owned compiler capability contribution linked into a tool or driver.
 struct loom_target_provider_t {
   // Target-family profile representation owned by this provider, or NULL when
@@ -315,6 +323,8 @@ struct loom_target_provider_t {
   // for providers with authored target definitions but no structured profile.
   // When |profile_type| is also present, both must name the same fact type.
   const loom_target_fact_type_t* target_fact_type;
+  // Optional allocation-free named-profile selector.
+  loom_target_provider_select_profile_fn_t select_profile;
 };
 
 // Static target provider table linked into a binary or embedding.

--- a/loom/src/loom/target/selection.c
+++ b/loom/src/loom/target/selection.c
@@ -1,0 +1,96 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/selection.h"
+
+static bool loom_target_selection_bundle_is_complete(
+    const loom_target_bundle_t* bundle) {
+  return bundle != NULL && bundle->snapshot != NULL &&
+         bundle->export_plan != NULL && bundle->config != NULL;
+}
+
+iree_status_t loom_target_specification_parse(
+    iree_string_view_t value, loom_target_specification_t* out_specification) {
+  IREE_ASSERT_ARGUMENT(out_specification);
+  *out_specification = (loom_target_specification_t){0};
+
+  const iree_string_view_t specification = iree_string_view_trim(value);
+  iree_string_view_t family = iree_string_view_empty();
+  iree_string_view_t selector = iree_string_view_empty();
+  if (iree_string_view_split(specification, ':', &family, &selector) < 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "target '%.*s' must use family:selector syntax",
+                            (int)specification.size, specification.data);
+  }
+  family = iree_string_view_trim(family);
+  selector = iree_string_view_trim(selector);
+  if (iree_string_view_is_empty(family) ||
+      iree_string_view_is_empty(selector)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "target '%.*s' must name a non-empty family and selector",
+        (int)specification.size, specification.data);
+  }
+
+  *out_specification = (loom_target_specification_t){
+      .family = family,
+      .selector = selector,
+  };
+  return iree_ok_status();
+}
+
+iree_status_t loom_target_environment_select_profile(
+    const loom_target_environment_t* environment,
+    const loom_target_specification_t* specification,
+    const loom_target_profile_t** out_profile) {
+  IREE_ASSERT_ARGUMENT(environment);
+  IREE_ASSERT_ARGUMENT(specification);
+  IREE_ASSERT_ARGUMENT(out_profile);
+  *out_profile = NULL;
+
+  const loom_target_provider_t* selected_provider = NULL;
+  const loom_target_provider_set_t* provider_set = environment->provider_set;
+  for (iree_host_size_t i = 0; i < provider_set->provider_count; ++i) {
+    const loom_target_provider_t* provider = provider_set->providers[i];
+    if (provider == NULL || provider->profile_type == NULL ||
+        !iree_string_view_equal(provider->profile_type->name,
+                                specification->family)) {
+      continue;
+    }
+    if (selected_provider != NULL) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "target family '%.*s' has multiple configured providers",
+          (int)specification->family.size, specification->family.data);
+    }
+    selected_provider = provider;
+  }
+  if (selected_provider == NULL) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "target family '%.*s' is not available in this binary",
+        (int)specification->family.size, specification->family.data);
+  }
+  if (selected_provider->select_profile == NULL) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "target family '%.*s' does not expose named profiles",
+        (int)specification->family.size, specification->family.data);
+  }
+
+  const loom_target_profile_t* profile = NULL;
+  IREE_RETURN_IF_ERROR(
+      selected_provider->select_profile(specification->selector, &profile));
+  if (profile == NULL || profile->type != selected_provider->profile_type ||
+      !loom_target_selection_bundle_is_complete(profile->target_bundle)) {
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "target family '%.*s' selected an invalid profile",
+                            (int)specification->family.size,
+                            specification->family.data);
+  }
+  *out_profile = profile;
+  return iree_ok_status();
+}

--- a/loom/src/loom/target/selection.h
+++ b/loom/src/loom/target/selection.h
@@ -1,0 +1,45 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Allocation-free target specification parsing and profile selection.
+
+#ifndef LOOM_TARGET_SELECTION_H_
+#define LOOM_TARGET_SELECTION_H_
+
+#include "iree/base/api.h"
+#include "loom/target/provider.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Borrowed components of a public `family:selector` target specification.
+typedef struct loom_target_specification_t {
+  // Target profile family name.
+  iree_string_view_t family;
+  // Family-owned selector spelling.
+  iree_string_view_t selector;
+} loom_target_specification_t;
+
+// Parses |value| as `family:selector` without allocating or copying it.
+iree_status_t loom_target_specification_parse(
+    iree_string_view_t value, loom_target_specification_t* out_specification);
+
+// Selects a borrowed process-lifetime profile from a configured environment.
+//
+// Exactly one linked provider must own |specification.family| and expose named
+// profile selection. The selected profile must have that provider's profile
+// type and a complete target bundle.
+iree_status_t loom_target_environment_select_profile(
+    const loom_target_environment_t* environment,
+    const loom_target_specification_t* specification,
+    const loom_target_profile_t** out_profile);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TARGET_SELECTION_H_

--- a/loom/src/loom/target/selection_test.cc
+++ b/loom/src/loom/target/selection_test.cc
@@ -1,0 +1,229 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/selection.h"
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace loom {
+namespace {
+
+static const loom_target_snapshot_t kTargetSnapshot = {
+    /*.name=*/IREE_SVL("fake.snapshot"),
+};
+static const loom_target_export_plan_t kTargetExportPlan = {
+    /*.name=*/IREE_SVL("fake.export"),
+};
+static const loom_target_config_t kTargetConfig = {
+    /*.name=*/IREE_SVL("fake.config"),
+};
+static const loom_target_bundle_t kTargetBundle = {
+    /*.name=*/IREE_SVL("fake.bundle"),
+    /*.snapshot=*/&kTargetSnapshot,
+    /*.export_plan=*/&kTargetExportPlan,
+    /*.config=*/&kTargetConfig,
+};
+static const loom_target_fact_type_t kTargetFactType = {
+    /*.name=*/IREE_SVL("fake"),
+    /*.storage_size=*/sizeof(loom_target_facts_t),
+};
+
+static iree_status_t ProjectTargetFacts(const loom_target_profile_t* profile,
+                                        iree_arena_allocator_t* arena,
+                                        loom_target_facts_t* out_facts) {
+  (void)profile;
+  (void)arena;
+  (void)out_facts;
+  return iree_ok_status();
+}
+
+static const loom_target_profile_type_t kTargetProfileType = {
+    /*.name=*/IREE_SVL("fake"),
+    /*.fact_type=*/&kTargetFactType,
+    /*.project_facts=*/ProjectTargetFacts,
+};
+static const loom_target_profile_t kTargetProfile = {
+    /*.type=*/&kTargetProfileType,
+    /*.target_bundle=*/&kTargetBundle,
+};
+static const loom_target_fact_type_t kOtherTargetFactType = {
+    /*.name=*/IREE_SVL("other"),
+    /*.storage_size=*/sizeof(loom_target_facts_t),
+};
+static const loom_target_profile_type_t kOtherTargetProfileType = {
+    /*.name=*/IREE_SVL("other"),
+    /*.fact_type=*/&kOtherTargetFactType,
+    /*.project_facts=*/ProjectTargetFacts,
+};
+static const loom_target_profile_t kOtherTargetProfile = {
+    /*.type=*/&kOtherTargetProfileType,
+    /*.target_bundle=*/&kTargetBundle,
+};
+
+static iree_status_t SelectFakeProfile(
+    iree_string_view_t selector, const loom_target_profile_t** out_profile) {
+  *out_profile = nullptr;
+  if (!iree_string_view_equal(selector, IREE_SV("target-123"))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "unknown fake target selector");
+  }
+  *out_profile = &kTargetProfile;
+  return iree_ok_status();
+}
+
+static iree_status_t SelectOtherProfile(
+    iree_string_view_t selector, const loom_target_profile_t** out_profile) {
+  (void)selector;
+  *out_profile = &kOtherTargetProfile;
+  return iree_ok_status();
+}
+
+TEST(TargetSpecificationTest, ParsesBorrowedFamilyAndSelector) {
+  loom_target_specification_t specification = {};
+  IREE_ASSERT_OK(loom_target_specification_parse(
+      IREE_SV("  fake : target-123:feature+  "), &specification));
+
+  EXPECT_TRUE(iree_string_view_equal(specification.family, IREE_SV("fake")));
+  EXPECT_TRUE(iree_string_view_equal(specification.selector,
+                                     IREE_SV("target-123:feature+")));
+}
+
+TEST(TargetSpecificationTest, RejectsMalformedSpecifications) {
+  loom_target_specification_t specification = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_target_specification_parse(IREE_SV("target-123"), &specification));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_target_specification_parse(IREE_SV(":target-123"), &specification));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_target_specification_parse(IREE_SV("fake:"), &specification));
+}
+
+TEST(TargetSelectionTest, SelectsBorrowedProfile) {
+  loom_target_provider_t provider = {};
+  provider.profile_type = &kTargetProfileType;
+  provider.select_profile = SelectFakeProfile;
+  const loom_target_provider_t* providers[] = {&provider};
+  const loom_target_provider_set_t provider_set =
+      loom_target_provider_set_make(providers, IREE_ARRAYSIZE(providers));
+  loom_target_environment_t environment = {};
+  IREE_ASSERT_OK(
+      loom_target_environment_initialize(&provider_set, &environment));
+
+  const loom_target_specification_t specification = {
+      /*.family=*/IREE_SVL("fake"),
+      /*.selector=*/IREE_SVL("target-123"),
+  };
+  const loom_target_profile_t* profile = nullptr;
+  IREE_ASSERT_OK(loom_target_environment_select_profile(
+      &environment, &specification, &profile));
+  EXPECT_EQ(profile, &kTargetProfile);
+
+  loom_target_environment_deinitialize(&environment);
+}
+
+TEST(TargetSelectionTest, RejectsUnknownFamily) {
+  const loom_target_provider_set_t provider_set =
+      loom_target_provider_set_make(nullptr, 0);
+  loom_target_environment_t environment = {};
+  IREE_ASSERT_OK(
+      loom_target_environment_initialize(&provider_set, &environment));
+
+  const loom_target_specification_t specification = {
+      /*.family=*/IREE_SVL("missing"),
+      /*.selector=*/IREE_SVL("target-123"),
+  };
+  const loom_target_profile_t* profile = nullptr;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        loom_target_environment_select_profile(
+                            &environment, &specification, &profile));
+  EXPECT_EQ(profile, nullptr);
+
+  loom_target_environment_deinitialize(&environment);
+}
+
+TEST(TargetSelectionTest, RejectsFamilyWithoutNamedProfiles) {
+  loom_target_provider_t provider = {};
+  provider.profile_type = &kTargetProfileType;
+  const loom_target_provider_t* providers[] = {&provider};
+  const loom_target_provider_set_t provider_set =
+      loom_target_provider_set_make(providers, IREE_ARRAYSIZE(providers));
+  loom_target_environment_t environment = {};
+  IREE_ASSERT_OK(
+      loom_target_environment_initialize(&provider_set, &environment));
+
+  const loom_target_specification_t specification = {
+      /*.family=*/IREE_SVL("fake"),
+      /*.selector=*/IREE_SVL("target-123"),
+  };
+  const loom_target_profile_t* profile = nullptr;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_UNIMPLEMENTED,
+                        loom_target_environment_select_profile(
+                            &environment, &specification, &profile));
+  EXPECT_EQ(profile, nullptr);
+
+  loom_target_environment_deinitialize(&environment);
+}
+
+TEST(TargetSelectionTest, RejectsAmbiguousFamilyProviders) {
+  loom_target_provider_t first_provider = {};
+  first_provider.profile_type = &kTargetProfileType;
+  first_provider.select_profile = SelectFakeProfile;
+  loom_target_provider_t second_provider = {};
+  second_provider.profile_type = &kTargetProfileType;
+  second_provider.select_profile = SelectFakeProfile;
+  const loom_target_provider_t* providers[] = {
+      &first_provider,
+      &second_provider,
+  };
+  const loom_target_provider_set_t provider_set =
+      loom_target_provider_set_make(providers, IREE_ARRAYSIZE(providers));
+  loom_target_environment_t environment = {};
+  IREE_ASSERT_OK(
+      loom_target_environment_initialize(&provider_set, &environment));
+
+  const loom_target_specification_t specification = {
+      /*.family=*/IREE_SVL("fake"),
+      /*.selector=*/IREE_SVL("target-123"),
+  };
+  const loom_target_profile_t* profile = nullptr;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        loom_target_environment_select_profile(
+                            &environment, &specification, &profile));
+  EXPECT_EQ(profile, nullptr);
+
+  loom_target_environment_deinitialize(&environment);
+}
+
+TEST(TargetSelectionTest, RejectsProfileFromAnotherFamily) {
+  loom_target_provider_t provider = {};
+  provider.profile_type = &kTargetProfileType;
+  provider.select_profile = SelectOtherProfile;
+  const loom_target_provider_t* providers[] = {&provider};
+  const loom_target_provider_set_t provider_set =
+      loom_target_provider_set_make(providers, IREE_ARRAYSIZE(providers));
+  loom_target_environment_t environment = {};
+  IREE_ASSERT_OK(
+      loom_target_environment_initialize(&provider_set, &environment));
+
+  const loom_target_specification_t specification = {
+      /*.family=*/IREE_SVL("fake"),
+      /*.selector=*/IREE_SVL("target-123"),
+  };
+  const loom_target_profile_t* profile = nullptr;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INTERNAL,
+                        loom_target_environment_select_profile(
+                            &environment, &specification, &profile));
+  EXPECT_EQ(profile, nullptr);
+
+  loom_target_environment_deinitialize(&environment);
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/tooling/target/amdgpu/artifact_provider.c
+++ b/loom/src/loom/tooling/target/amdgpu/artifact_provider.c
@@ -9,6 +9,7 @@
 #include "loom/target/arch/amdgpu/artifact_key.h"
 #include "loom/target/arch/amdgpu/profile.h"
 #include "loom/target/arch/amdgpu/runtime_requirements.h"
+#include "loom/target/arch/amdgpu/target_info.h"
 #include "loom/target/emit/native/amdgpu/hal_kernel_library.h"
 #include "loom/target/emit/native/amdgpu/runtime_globals.h"
 
@@ -39,8 +40,10 @@ static iree_status_t loom_amdgpu_artifact_provider_select_target(
   IREE_RETURN_IF_ERROR(loom_amdgpu_artifact_key_parse(target_key, &identity));
   IREE_RETURN_IF_ERROR(
       loom_amdgpu_target_profile_initialize(&identity, &profile));
-  if (!loom_amdgpu_target_properties_support_hsaco(&profile.properties) ||
-      profile.identity.target == NULL) {
+  const loom_amdgpu_processor_info_t* processor =
+      loom_amdgpu_target_info_target_processor(profile.identity.target);
+  if (processor == NULL ||
+      !loom_amdgpu_processor_properties_support_hsaco(&processor->properties)) {
     return iree_make_status(IREE_STATUS_UNAVAILABLE,
                             "AMDGPU target '%.*s' cannot be emitted as HSACO "
                             "by Loom",

--- a/loom/src/loom/tooling/target/amdgpu/device_provider.c
+++ b/loom/src/loom/tooling/target/amdgpu/device_provider.c
@@ -71,8 +71,12 @@ static iree_status_t loom_amdgpu_device_provider_select_compatible_candidate(
           "AMDGPU device target '%.*s' kind does not match its target key",
           (int)candidate->target_key.size, candidate->target_key.data);
     }
-    if (!loom_amdgpu_target_properties_support_hsaco(
-            &candidate_profile.properties) ||
+    const loom_amdgpu_processor_info_t* processor =
+        loom_amdgpu_target_info_target_processor(
+            candidate_profile.identity.target);
+    if (processor == NULL ||
+        !loom_amdgpu_processor_properties_support_hsaco(
+            &processor->properties) ||
         (authored_requirement != NULL &&
          !loom_amdgpu_target_identity_satisfies_requirement(
              &candidate_profile.identity, authored_requirement))) {

--- a/loom/src/loom/tools/loom-link/BUILD.bazel
+++ b/loom/src/loom/tools/loom-link/BUILD.bazel
@@ -7,7 +7,6 @@
 load("//build_tools/testing:build_defs.bzl", "iree_execution_test_suite")
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
-    "iree_select",
     "loom_cc_binary",
 )
 
@@ -17,25 +16,9 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
-_AMDGPU_LINK_COPTS = iree_select({
-    "//loom/config/target/arch:amdgpu": [
-        "-DLOOM_LINK_HAVE_AMDGPU=1",
-    ],
-    "//conditions:default": [],
-})
-
-_AMDGPU_LINK_DEPS = iree_select({
-    "//loom/config/target/arch:amdgpu": [
-        "//loom/src/loom/target/arch/amdgpu:artifact_key",
-        "//loom/src/loom/target/arch/amdgpu:profile",
-    ],
-    "//conditions:default": [],
-})
-
 loom_cc_binary(
     name = "loom-link",
     srcs = ["loom-link.c"],
-    copts = _AMDGPU_LINK_COPTS,
     deps = [
         "//loom/src/loom/codegen/low:repr",
         "//loom/src/loom/codegen/low:text_asm",
@@ -52,6 +35,7 @@ loom_cc_binary(
         "//loom/src/loom/target:entry_selection",
         "//loom/src/loom/target:module_specialization",
         "//loom/src/loom/target:provider",
+        "//loom/src/loom/target:selection",
         "//loom/src/loom/target/configured:provider",
         "//loom/src/loom/tooling/cli:help",
         "//loom/src/loom/tooling/config",
@@ -65,7 +49,7 @@ loom_cc_binary(
         "//runtime/src/iree/base/tooling:flags",
         "//runtime/src/iree/io:file_handle",
         "//runtime/src/iree/io:stream",
-    ] + _AMDGPU_LINK_DEPS,
+    ],
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/loom-link/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-link/CMakeLists.txt
@@ -9,22 +9,11 @@
 
 iree_add_all_subdirs()
 
-set(_loom_link_platform_copts "")
-if(LOOM_TARGET_ARCH_AMDGPU)
-  list(APPEND _loom_link_platform_copts "-DLOOM_LINK_HAVE_AMDGPU=1")
-endif()
-set(_loom_link_platform_deps "")
-if(LOOM_TARGET_ARCH_AMDGPU)
-  list(APPEND _loom_link_platform_deps loom::target::arch::amdgpu::artifact_key)
-  list(APPEND _loom_link_platform_deps loom::target::arch::amdgpu::profile)
-endif()
 loom_cc_binary(
   NAME
     loom-link
   SRCS
     "loom-link.c"
-  COPTS
-    ${_loom_link_platform_copts}
   DEPS
     iree::base
     iree::base::internal::arena
@@ -47,6 +36,7 @@ loom_cc_binary(
     loom::target::entry_selection
     loom::target::module_specialization
     loom::target::provider
+    loom::target::selection
     loom::tooling::cli::help
     loom::tooling::config
     loom::tooling::context
@@ -54,7 +44,6 @@ loom_cc_binary(
     loom::tools::loom-format::convert
     loom::util::stream
     loom::verify
-    ${_loom_link_platform_deps}
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/loom-link/loom-link.c
+++ b/loom/src/loom/tools/loom-link/loom-link.c
@@ -32,6 +32,7 @@
 #include "loom/target/entry_selection.h"
 #include "loom/target/module_specialization.h"
 #include "loom/target/provider.h"
+#include "loom/target/selection.h"
 #include "loom/tooling/cli/help.h"
 #include "loom/tooling/config/config.h"
 #include "loom/tooling/context/context.h"
@@ -39,15 +40,6 @@
 #include "loom/tools/loom-format/convert.h"
 #include "loom/util/stream.h"
 #include "loom/verify/verify.h"
-
-#ifndef LOOM_LINK_HAVE_AMDGPU
-#define LOOM_LINK_HAVE_AMDGPU 0
-#endif  // LOOM_LINK_HAVE_AMDGPU
-
-#if LOOM_LINK_HAVE_AMDGPU
-#include "loom/target/arch/amdgpu/artifact_key.h"
-#include "loom/target/arch/amdgpu/profile.h"
-#endif  // LOOM_LINK_HAVE_AMDGPU
 
 IREE_FLAG(string, mode, "auto",
           "Planning mode: auto, merge, or link. Auto selects "
@@ -91,11 +83,10 @@ IREE_FLAG_LIST_NAMED(
     string, config_file, "config-file",
     "JSON/JSONC config object file. Repeat for multiple files. Nested object "
     "keys are flattened with '.' separators.");
-IREE_FLAG_NAMED(
-    string, target_profile, "target-profile", "",
-    "Optional homogeneous target profile in family:selector form, such as "
-    "amdgpu:gfx11-generic. The profile specializes each linked analysis "
-    "module before template selection.");
+IREE_FLAG(string, target, "",
+          "Optional homogeneous target in family:selector form, such as "
+          "amdgpu:gfx11-generic. The target specializes each linked analysis "
+          "module before template selection.");
 IREE_FLAG_NAMED(bool, include_input_exports, "include-input-exports", false,
                 "In link mode, add exported input symbols as roots.");
 IREE_FLAG_NAMED(
@@ -180,15 +171,6 @@ typedef struct loom_link_cli_prepare_state_t {
   // Homogeneous target profile applied to every kernel entry, if any.
   const loom_target_profile_t* target_profile;
 } loom_link_cli_prepare_state_t;
-
-typedef struct loom_link_cli_target_profile_storage_t {
-  // Selected target-neutral profile borrowing family-specific storage below.
-  const loom_target_profile_t* profile;
-#if LOOM_LINK_HAVE_AMDGPU
-  // AMDGPU profile storage valid for the lifetime of the link invocation.
-  loom_amdgpu_target_profile_t amdgpu;
-#endif  // LOOM_LINK_HAVE_AMDGPU
-} loom_link_cli_target_profile_storage_t;
 
 static const char* loom_link_cli_mode_name(loom_link_plan_mode_t mode) {
   switch (mode) {
@@ -330,49 +312,19 @@ static iree_status_t loom_link_cli_materialize_config(
                                                 NULL);
 }
 
-static iree_status_t loom_link_cli_select_target_profile(
-    loom_link_cli_target_profile_storage_t* out_storage) {
-  *out_storage = (loom_link_cli_target_profile_storage_t){0};
-
+static iree_status_t loom_link_cli_select_target(
+    const loom_target_environment_t* environment,
+    const loom_target_profile_t** out_profile) {
+  *out_profile = NULL;
   const iree_string_view_t specification =
-      iree_string_view_trim(iree_make_cstring_view(FLAG_target_profile));
+      iree_string_view_trim(iree_make_cstring_view(FLAG_target));
   if (iree_string_view_is_empty(specification)) {
     return iree_ok_status();
   }
-  iree_string_view_t family = iree_string_view_empty();
-  iree_string_view_t selector = iree_string_view_empty();
-  if (iree_string_view_split(specification, ':', &family, &selector) < 0) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "--target-profile='%.*s' must use family:selector syntax",
-        (int)specification.size, specification.data);
-  }
-  family = iree_string_view_trim(family);
-  selector = iree_string_view_trim(selector);
-  if (iree_string_view_is_empty(family) ||
-      iree_string_view_is_empty(selector)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "--target-profile='%.*s' must name a non-empty family and selector",
-        (int)specification.size, specification.data);
-  }
-
-#if LOOM_LINK_HAVE_AMDGPU
-  if (iree_string_view_equal(family, IREE_SV("amdgpu"))) {
-    loom_amdgpu_target_identity_t identity = {0};
-    IREE_RETURN_IF_ERROR(loom_amdgpu_artifact_key_parse(selector, &identity));
-    IREE_RETURN_IF_ERROR(
-        loom_amdgpu_target_profile_initialize(&identity, &out_storage->amdgpu));
-    out_storage->profile = &out_storage->amdgpu.base;
-    return iree_ok_status();
-  }
-#endif  // LOOM_LINK_HAVE_AMDGPU
-
-  return iree_make_status(
-      IREE_STATUS_INVALID_ARGUMENT,
-      "target profile family '%.*s' is not available in this loom-link "
-      "binary",
-      (int)family.size, family.data);
+  loom_target_specification_t target = {0};
+  IREE_RETURN_IF_ERROR(loom_target_specification_parse(specification, &target));
+  return loom_target_environment_select_profile(environment, &target,
+                                                out_profile);
 }
 
 static loom_diagnostic_sink_t loom_link_cli_materialization_diagnostic_sink(
@@ -1167,7 +1119,7 @@ static void loom_link_cli_print_agents_markdown(FILE* stream) {
       "--print-plan\n"
       "loom-link root.loom --library=providers.loom --root=@entry \\\n"
       "  --config=model.hidden_size=4096 \\\n"
-      "  --target-profile=amdgpu:gfx11-generic \\\n"
+      "  --target=amdgpu:gfx11-generic \\\n"
       "  --require-resolved-config\n"
       "loom-link root.loom --library=provider-a.loom --root=@entry \\\n"
       "  --allow-unresolved --to=bc --output=partial.loombc\n"
@@ -1176,7 +1128,7 @@ static void loom_link_cli_print_agents_markdown(FILE* stream) {
       "`--list-symbols` shows the indexed providers. `--print-plan` shows why\n"
       "each symbol is live before streaming modules into the linker. Config\n"
       "bindings are applied to the composed analysis module before each "
-      "dependency and template-selection step. `--target-profile` applies "
+      "dependency and template-selection step. `--target` applies "
       "structured target facts at the same boundary, so target and shape "
       "predicates can prune unreachable provider templates.\n"
       "`--allow-unresolved` preserves unresolved declarations whose libraries\n"
@@ -1190,7 +1142,7 @@ int main(int argc, char** argv) {
       "\n"
       "Usage:\n"
       "  loom-link [--mode=merge|link] [--from=auto|text|bc] "
-      "[--to=text|bc] [--target-profile=family:selector] "
+      "[--to=text|bc] [--target=family:selector] "
       "[--output=file] [file...]\n"
       "  loom-link model.loom --library=kernels.loombc --root=@entry "
       "--to=bc --output=model.loombc\n"
@@ -1231,7 +1183,7 @@ int main(int argc, char** argv) {
   bool context_initialized = false;
   loom_tooling_config_set_t config_set;
   loom_tooling_config_set_initialize(allocator, &config_set);
-  loom_link_cli_target_profile_storage_t target_profile = {0};
+  const loom_target_profile_t* target_profile = NULL;
   loom_link_cli_input_t* inputs = NULL;
   iree_host_size_t input_count = 0;
   loom_link_cli_index_t link_index = {0};
@@ -1293,7 +1245,8 @@ int main(int argc, char** argv) {
                          "--print-plan cannot be combined with --list-symbols");
   }
   if (iree_status_is_ok(status)) {
-    status = loom_link_cli_select_target_profile(&target_profile);
+    status = loom_link_cli_select_target(loom_configured_target_environment(),
+                                         &target_profile);
   }
   if (iree_status_is_ok(status)) {
     loom_context_initialize(allocator, &context);
@@ -1370,7 +1323,7 @@ int main(int argc, char** argv) {
     loom_link_cli_prepare_state_t prepare_state = {
         .config_set = &config_set,
         .target_environment = loom_configured_target_environment(),
-        .target_profile = target_profile.profile,
+        .target_profile = target_profile,
     };
     const loom_link_plan_materialization_environment_t environment = {
         .context = &context,


### PR DESCRIPTION
`loom-link` now accepts one universal `--target=family:selector` spelling for every configured target family with a named profile. This replaces the AMDGPU-only `--target-profile` path and lets linking specialize target-dependent templates without embedding any target implementation or storage model in the generic tool.

Target specifications are parsed as borrowed string views and resolved by scanning the immutable providers linked into the configured target environment. A family provider may return a borrowed process-lifetime profile for a selector; the generic boundary verifies unique family ownership, profile type, and bundle completeness. Selection performs no allocation, transfers no ownership, and introduces no teardown, cache, opaque storage pointer, or target-family union.

AMDGPU publishes generated immutable profiles for every configured target and target-ID feature combination, using the same canonical artifact-key selectors accepted elsewhere. SPIR-V publishes `spirv:vulkan1.3+bda` as its named offline baseline. HAL-derived SPIR-V profiles remain separate because cooperative matrix and vector properties come from the physical device rather than a static selector.

Configured-build optionality remains structural. Disabled target families contribute no provider dependency or implementation code to `loom-link`, and selecting an unavailable family fails explicitly. The generic selection package has no AMDGPU, SPIR-V, HAL, emitter, or artifact knowledge.

The user-facing forms are:

```text
loom-link model.loom --library=kernels.loom --root=@entry --target=amdgpu:gfx11-generic
loom-link model.loom --library=kernels.loom --root=@entry --target=spirv:vulkan1.3+bda
```

`--target` specializes the linked Loom module before provider-template selection. `--to=text|bc` remains solely the serialization choice for the resulting Loom IR; deployment products and artifact formats are deliberately outside this change.

## Reviewer notes

The highest-value review surfaces are the borrowed provider callback contract, the generated AMDGPU profile table, and the removal of all AMDGPU-specific code and dependencies from `loom-link`.
