### PR TITLE
[Loom] Replace offline compile backends with products and formats

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -337,18 +337,17 @@ IREE_ROCM_PATH=/opt/rocm python dev.py bazel configure \
 
 Loom target options describe product compiler capability: `LOOM_TARGET_AMDGPU=ON`
 means Loom can compile for AMDGPU, including the target architecture metadata and
-production artifact emission needed by that backend. Runtime execution remains a
-separate concern controlled by Loom execution support and the runtime
+canonical artifact formats registered for that target family. Runtime execution
+remains a separate concern controlled by Loom execution support and the runtime
 `IREE_HAL_DRIVER_*` options.
 
 The default dependency-satisfied Loom target set is
 `amdgpu,llvmir,spirv,x86`. AMDGPU and SPIR-V target compilation use pinned
 source dependencies by default and do not enable the matching runtime HAL
 drivers. WebAssembly remains opt-in until the WASI SDK repository is available
-in this checkout. The default execution substrate set is `iree_hal`;
-backend execution providers still require a matching runtime HAL driver such as
-`IREE_HAL_DRIVER_VULKAN` or
-`IREE_HAL_DRIVER_AMDGPU`.
+in this checkout. The default execution substrate set is `iree_hal`; HAL
+execution providers still require a matching runtime HAL driver such as
+`IREE_HAL_DRIVER_VULKAN` or `IREE_HAL_DRIVER_AMDGPU`.
 
 CMake exposes `LOOM_TARGET_DEFAULTS` and `LOOM_EXECUTE_DEFAULTS` to set the
 default value for dependency-satisfied target and execution options before the
@@ -470,9 +469,9 @@ python dev.py bazel configure \
 ```
 
 Execution options describe the runtime substrate available to Loom tools, not a
-target backend by themselves. For example, AMDGPU execution needs the AMDGPU
-Loom target, the IREE HAL execution substrate, and the AMDGPU runtime HAL
-driver:
+compilation target by themselves. For example, AMDGPU execution needs the
+AMDGPU Loom target, the IREE HAL execution substrate, and the AMDGPU runtime
+HAL driver:
 
 ```bash
 python dev.py bazel configure \

--- a/loom/build_tools/bazel/loom_binary.bzl
+++ b/loom/build_tools/bazel/loom_binary.bzl
@@ -99,7 +99,8 @@ def _declare_amdgpu_kernel_product(
     compile_report = ctx.actions.declare_file(output_stem + ".compile.json")
     args = ctx.actions.args()
     args.add(linked_module)
-    args.add("--backend=amdgpu-hal")
+    args.add("--product=kernel")
+    args.add("--format=amdgpu-hsaco")
     target_profile = ctx.attr.target[LoomTargetProfileInfo]
     args.add("--target=%s:%s" % (
         target_profile.family,
@@ -131,7 +132,8 @@ def _declare_command_product(ctx, linked_module):
     )
     args = ctx.actions.args()
     args.add(linked_module)
-    args.add("--backend=command")
+    args.add("--product=command")
+    args.add("--format=loom-command")
     args.add("--output=%s" % manifest.path)
     args.add("--emit-command-artifacts=%s" % artifacts.path)
     args.add("--compile-report=details")

--- a/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
@@ -105,7 +105,8 @@ def _test_kernel_binary_roots_direct_library_exports_impl(env, target):
 
     compile_action = _find_action(env, actions, "LoomKernelBinary")
     for expected_arg in [
-        "--backend=amdgpu-hal",
+        "--product=kernel",
+        "--format=amdgpu-hsaco",
         "--target=amdgpu:gfx11-generic",
         "--compile-report=details",
     ]:
@@ -293,7 +294,8 @@ def _test_command_binary_emits_composite_product_impl(env, target):
 
     command_action = _find_action(env, actions, "LoomCommandBinary")
     for expected_arg in [
-        "--backend=command",
+        "--product=command",
+        "--format=loom-command",
         "--compile-report=details",
     ]:
         if expected_arg not in command_action.argv:
@@ -316,7 +318,8 @@ def _test_command_binary_emits_composite_product_impl(env, target):
 
     kernel_action = _find_action(env, actions, "LoomCommandKernelBinary")
     for expected_arg in [
-        "--backend=amdgpu-hal",
+        "--product=kernel",
+        "--format=amdgpu-hsaco",
         "--target=amdgpu:gfx11-generic",
         "--compile-report=details",
     ]:

--- a/loom/build_tools/bazel/test/loom_library_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_library_rules_test.bzl
@@ -270,7 +270,8 @@ def _test_generated_kernel_binary_is_testonly_impl(env, target):
 
     action = _find_action(env, target[TestingAspectInfo].actions, "LoomKernelBinary")
     for expected_arg in [
-        "--backend=amdgpu-hal",
+        "--product=kernel",
+        "--format=amdgpu-hsaco",
         "--target=amdgpu:gfx11-generic",
     ]:
         if expected_arg not in action.argv:

--- a/loom/docs/examples/elementwise-transform/run.sh
+++ b/loom/docs/examples/elementwise-transform/run.sh
@@ -57,7 +57,7 @@ loom_example_run_tool loom-link "${loom_link}" \
 loom_example_section "Specialize and compile the selected kernel for ${target}"
 loom_example_run_tool loom-compile "${loom_compile}" \
   "${output_dir}/elementwise-transform.loom" \
-  --backend="${LOOM_EXAMPLE_BACKEND}" \
+  --format="${LOOM_EXAMPLE_FORMAT}" \
   --target="amdgpu:${LOOM_EXAMPLE_TARGET}" \
   --root=@elementwise_transform_f32 \
   --output="${output_dir}/elementwise-transform.hsaco" \
@@ -67,7 +67,7 @@ loom_example_run_tool loom-compile "${loom_compile}" \
 loom_example_section "Materialize the portable command program"
 loom_example_run_tool loom-compile "${loom_compile}" \
   "${output_dir}/elementwise-transform.loom" \
-  --backend=command \
+  --format=loom-command \
   --root=@elementwise_transform \
   --output="${output_dir}/elementwise-transform.commands.json" \
   --emit-command-artifacts="${output_dir}/elementwise-transform.commands"

--- a/loom/docs/examples/example.shlib
+++ b/loom/docs/examples/example.shlib
@@ -10,7 +10,7 @@ loom_example_configure_target() {
   LOOM_EXAMPLE_TARGET="$1"
   case "${LOOM_EXAMPLE_TARGET}" in
     gfx11-generic)
-      LOOM_EXAMPLE_BACKEND="amdgpu-hal"
+      LOOM_EXAMPLE_FORMAT="amdgpu-hsaco"
       ;;
     *)
       printf 'unsupported example target: %s\n' "${LOOM_EXAMPLE_TARGET}" >&2

--- a/loom/docs/examples/getting-started/first-kernel/run.sh
+++ b/loom/docs/examples/getting-started/first-kernel/run.sh
@@ -61,7 +61,7 @@ loom_example_run_tool iree-benchmark-loom "${iree_benchmark_loom}" \
 loom_example_section "Compile the deployment kernel for ${target}"
 loom_example_run_tool loom-compile "${loom_compile}" \
   saxpy.loom \
-  --backend="${LOOM_EXAMPLE_BACKEND}" \
+  --format="${LOOM_EXAMPLE_FORMAT}" \
   --target="amdgpu:${LOOM_EXAMPLE_TARGET}" \
   --root=@saxpy_f32 \
   --output="${output_dir}/saxpy.hsaco"

--- a/loom/docs/examples/product-frontiers/run.sh
+++ b/loom/docs/examples/product-frontiers/run.sh
@@ -58,7 +58,7 @@ loom_example_run_tool loom-link "${loom_link}" \
 loom_example_section "Emit the parent command product and child requests"
 loom_example_run_tool loom-compile "${loom_compile}" \
   "${output_dir}/heterogeneous.loombc" \
-  --backend=command \
+  --format=loom-command \
   --root=@heterogeneous \
   --output="${output_dir}/commands.json" \
   --emit-command-artifacts="${output_dir}/commands" \

--- a/loom/docs/src/getting-started/source-to-artifacts.md
+++ b/loom/docs/src/getting-started/source-to-artifacts.md
@@ -258,10 +258,10 @@ can be launched with other counts by other roots:
 
 !!! info "Command deployment products"
 
-    `loom-compile --backend=command` materializes each selected command root as
-    a portable `.loomcmd` and writes the shared executable-entry manifest. The
-    target-specific kernel executable remains a separate artifact so an
-    embedding can cache, replace, or prebuild it independently.
+    `loom-compile --format=loom-command` materializes each selected command
+    root as a portable `.loomcmd` and writes the shared executable-entry
+    manifest. The target-specific kernel executable remains a separate
+    artifact so an embedding can cache, replace, or prebuild it independently.
 
 The generated [`command` dialect
 reference](../reference/dialects/command/index.md) documents the source

--- a/loom/docs/src/guide/command-programs.md
+++ b/loom/docs/src/guide/command-programs.md
@@ -316,7 +316,7 @@ them to one device runtime:
 ```shell
 loom-compile model.loombc \
   --root=@two_layer \
-  --backend=command \
+  --format=loom-command \
   --output=commands.json \
   --emit-command-artifacts=commands/ \
   --emit-kernel-requests=kernel-requests/

--- a/loom/docs/src/workflows/agent-driven-kernel-development.md
+++ b/loom/docs/src/workflows/agent-driven-kernel-development.md
@@ -256,7 +256,7 @@ configuration, backend, and target identity:
 ```shell
 loom-compile kernel.loom \
   --root=@production_cut \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx1151 \
   --output=candidate.hsaco \
   --compile-report=summary \

--- a/loom/docs/src/workflows/compile-artifacts.md
+++ b/loom/docs/src/workflows/compile-artifacts.md
@@ -1,21 +1,25 @@
 # Compile artifacts
 
 `loom-compile` specializes one verified `.loom` or `.loombc` module and emits an
-artifact for a selected backend. It is the offline form of the same parse,
-link, configure, specialize, lower, and emit operations available through the
-`loomc` API.
+artifact for selected roots. It is the offline form of the same parse, link,
+configure, specialize, lower, and emit operations available through the `loomc`
+API.
 
-The shortest useful invocation names the input, backend, target profile, and
-artifact path. Reports, manifests, and IR traces are optional evidence products,
-not boilerplate required by every compile.
+Selected roots infer exactly one product: `kernel`, `command`, or `module`.
+With explicit `--root` values, `--product` is an optional assertion on that
+result and never reinterprets the roots. With no roots, an explicit product
+selects its canonical root set. `--target=family:selector` supplies a target
+when the roots do not already name one. `--format` requests an exact output
+encoding; when it is omitted, the tool requires one canonical compatible
+format. Reports, manifests, and IR traces are optional evidence products, not
+boilerplate required by every compile.
 
-## Compile for a HAL loader
+## Compile a loadable kernel
 
 Compile one targetless kernel for the generic GFX11 profile:
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
   --target=amdgpu:gfx11-generic \
   --output=kernel.hsaco
 ```
@@ -25,18 +29,20 @@ linked into the tool, and the remainder is interpreted only by that provider.
 A build without the requested family fails instead of enabling or loading it
 implicitly.
 
-The primary output is the executable byte sequence consumed by the selected
-HAL loader. For AMDGPU that representation is currently an HSACO. The source
-module can contain checks, reference functions, template providers, and other
-authoring support; the HAL backend materializes kernel entries and their
-dependency closures into the executable library.
+The kernel roots and AMDGPU target select the canonical `amdgpu-hsaco` format.
+Pass `--format=amdgpu-hsaco` when the exact encoding is part of the invocation's
+contract. The primary output is the executable byte sequence consumed by the
+selected HAL loader. The source module can contain checks, reference functions,
+template providers, and other authoring support; the selected format
+materializes kernel entries and their dependency closures into the executable
+library.
 
-Backend availability is a property of the installed Loom tool. Target pages
-own supported profile names; the compile workflow remains the same across
-backends. Offline emission is independent of runtime drivers: a Loom build with
-SPIR-V targeting and emission can produce SPIR-V artifacts without the Vulkan
-HAL, while creating a device and executing those artifacts still requires the
-Vulkan driver.
+Format and target availability are properties of the installed Loom tool.
+Target pages own supported profile names; the compile workflow remains the same
+across target families and formats. Offline emission is independent of runtime
+drivers: a Loom build with SPIR-V targeting and emission can produce SPIR-V
+artifacts without the Vulkan HAL, while creating a device and executing those
+artifacts still requires the Vulkan driver.
 
 ## Choose generic or exact specialization
 
@@ -44,7 +50,6 @@ A generic profile retains portability within one target family:
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
   --target=amdgpu:gfx11-generic \
   --output=kernel-gfx11.hsaco
 ```
@@ -53,7 +58,6 @@ An exact profile exposes the features and limits of one physical target:
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
   --target=amdgpu:gfx1151 \
   --output=kernel-gfx1151.hsaco
 ```
@@ -61,7 +65,7 @@ loom-compile kernel.loom \
 `--target` specializes every materialized kernel entry before the compile
 pipeline. An authored target remains a compatibility requirement: a generic
 GFX11 entry can specialize to `gfx1151`, while an entry constrained to an
-incompatible family fails. A HAL compile only needs `--target` when a
+incompatible family fails. A kernel compile only needs `--target` when a
 materialized root does not already carry an authored target.
 
 Reusable libraries generally omit authored targets. Their source can then
@@ -70,22 +74,24 @@ build rather than fragmenting into target-specific copies.
 
 ## Select roots from a catalog
 
-When `--root` is omitted, a HAL backend compiles every kernel entry and its
-dependency closure. Select one or more entries from a catalog by repeating the
-flag:
+When `--root` is omitted, public or retained command programs take precedence;
+otherwise the tool selects every kernel entry, or the whole module when neither
+kind exists. Select one or more entries from a catalog by repeating the flag.
+Every selected root must infer the same product:
 
 ```shell
 loom-compile catalog.loombc \
   --root=@prefill \
   --root=@decode \
-  --backend=amdgpu-hal \
   --target=amdgpu:gfx11-generic \
   --output=qwen-kernels.hsaco
 ```
 
 Root selection is reachability, not name filtering after compilation. Unused
 functions, providers, configurations, checks, and kernels are absent from the
-materialized compile module.
+materialized compile module. In a mixed command-and-kernel catalog, name the
+kernel roots explicitly or pass `--product=kernel` without roots to select all
+kernel entries. A product never changes the meaning of explicit roots.
 
 Use [`loom-link`](link-and-package.md#link-transitive-dependencies-incrementally)
 first when several independently shipped modules must be composed. Use
@@ -99,7 +105,6 @@ Bind the `config.decl` values that describe this artifact:
 ```shell
 loom-compile kernel.loombc \
   --root=@decode \
-  --backend=amdgpu-hal \
   --target=amdgpu:gfx1151 \
   --config=model.hidden_size=4096 \
   --config=model.head_count=32 \
@@ -110,7 +115,6 @@ JSON and JSONC files carry larger configuration objects:
 
 ```shell
 loom-compile kernel.loombc \
-  --backend=amdgpu-hal \
   --target=amdgpu:gfx1151 \
   --config-file=model-config.jsonc \
   --output=model-kernels.hsaco
@@ -123,13 +127,14 @@ separators; explicit bindings not referenced by the module are ignored.
 
 ## Emit portable command programs
 
-The command backend prepares selected command-program roots and emits one
-portable artifact per root:
+The command product prepares selected command-program roots and emits one
+portable artifact per root. Command roots select the canonical `loom-command`
+format, which may also be stated explicitly:
 
 ```shell
 loom-compile model.loombc \
   --root=@elementwise_transform \
-  --backend=command \
+  --format=loom-command \
   --output=commands.json \
   --emit-command-artifacts=commands/ \
   --emit-kernel-requests=kernel-requests/
@@ -144,12 +149,11 @@ partitioned only by decisions that change their generated kernels, so repeated
 sites and separate command roots share a request when their semantic class is
 the same. External bodyless entries remain plain binding requirements.
 
-Compile each manifest-listed source request independently through the target
-backend. For example, the first request can be compiled with:
+Compile each manifest-listed source request independently for its target. For
+example, the first request can be compiled with:
 
 ```shell
 loom-compile kernel-requests/kernel-0.loombc \
-  --backend=amdgpu-hal \
   --target=amdgpu:gfx11-generic \
   --output=kernel-0.hsaco
 ```
@@ -171,26 +175,26 @@ For example, an installation with the LLVM IR emitter can write textual or
 bitcode artifacts:
 
 ```shell
-loom-compile kernel.loom --backend=llvmir-text --output=kernel.ll
-loom-compile kernel.loom --backend=llvmir-bitcode --output=kernel.bc
+loom-compile kernel.loom --format=llvmir-text --output=kernel.ll
+loom-compile kernel.loom --format=llvmir-bitcode --output=kernel.bc
 ```
 
 ## Emit a target-native sidecar
 
-A HAL backend may have both a loader-ready representation and a target-native
-artifact. Request both when an integration needs the primary loader product and
-tooling needs the native object:
+A loadable kernel format may have both a loader-ready representation and a
+target-native artifact. Request both when an integration needs the primary
+loader product and tooling needs the native object:
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=kernel.executable \
   --emit-target-artifact=kernel.hsaco
 ```
 
 The two byte sequences may be identical. AMDGPU currently uses HSACO for both;
-the separate output contract still matters for backends whose loader container
+the separate output contract still matters for formats whose loader container
 and native artifact differ.
 
 ## Emit an artifact manifest
@@ -200,7 +204,7 @@ reverse-engineer it:
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=kernel.hsaco \
   --artifact-manifest=summary
@@ -212,7 +216,7 @@ layout:
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=kernel.hsaco \
   --artifact-manifest=details \

--- a/loom/docs/src/workflows/compile-report-queries.md
+++ b/loom/docs/src/workflows/compile-report-queries.md
@@ -118,7 +118,7 @@ allocation boundary rather than a contradiction.
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx1151 \
   --output=kernel.hsaco \
   --compile-report=details \
@@ -532,7 +532,7 @@ was anchored on one function.
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=kernel.hsaco \
   --dump-ir-after-all \

--- a/loom/docs/src/workflows/compile-reports.md
+++ b/loom/docs/src/workflows/compile-reports.md
@@ -21,7 +21,7 @@ Request a structured summary beside the emitted artifact:
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=kernel.hsaco \
   --compile-report=summary \
@@ -246,7 +246,7 @@ specific question whose answer needs row-level provenance:
 
 ```shell
 loom-compile kernel.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx1151 \
   --output=kernel.hsaco \
   --compile-report=details \

--- a/loom/docs/src/workflows/oracles/llvm-mc.md
+++ b/loom/docs/src/workflows/oracles/llvm-mc.md
@@ -41,7 +41,7 @@ Compile the exact kernel entry and retain both compiler and object metadata:
 ```shell
 loom-compile kernel.loom \
   --root=@kernel \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx1170 \
   --output=kernel.hsaco \
   --artifact-manifest=details \

--- a/loom/docs/src/workflows/oracles/native-schedule.md
+++ b/loom/docs/src/workflows/oracles/native-schedule.md
@@ -53,7 +53,7 @@ artifact construction rather than execution:
 
 ```shell
 loom-compile oracle.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --pipeline=none \
   --output=oracle.hsaco
 ```

--- a/loom/docs/src/workflows/product-frontiers.md
+++ b/loom/docs/src/workflows/product-frontiers.md
@@ -167,6 +167,6 @@ The boundaries distinguish unsupported source from deliberately external work:
 
 Use [`loom-link --print-plan`](link-and-package.md#inspect-before-linking) to
 inspect requester roots and provider selection before materialization. Use
-[`loom-compile --backend=command`](compile-artifacts.md#emit-portable-command-programs)
+[`loom-compile --format=loom-command`](compile-artifacts.md#emit-portable-command-programs)
 to emit the parent artifacts and optional child requests from an already linked
 catalog.

--- a/loom/py/loom/importers/check/main.py
+++ b/loom/py/loom/importers/check/main.py
@@ -216,7 +216,7 @@ TileLang/TVM generated artifacts. `--oracle=source` asks TileLang for generated
 device source, `--oracle=code-object` additionally compiles, unbundles, and
 externally disassembles a code object when the ROCm tools are available, and
 `--oracle=differential` also compiles the imported Loom IR through
-`loom-compile --backend=amdgpu-hal` for side-by-side disassembly-family
+`loom-compile --format=amdgpu-hsaco` for side-by-side disassembly-family
 comparison. This metadata is sidecar validation evidence: the checked stdout
 remains imported Loom IR. Use `--oracle-output-dir` or `--dump-temp-dir` to
 retain the generated source, bundled HSACO, unbundled code object, Loom HSACO,

--- a/loom/py/loom/importers/tilelang/README.md
+++ b/loom/py/loom/importers/tilelang/README.md
@@ -169,7 +169,7 @@ code-object profiling and source reverse-mapping.
 
 TileLang AMDGPU differential reporting compares two real code objects: the
 TileLang/TVM code-object oracle and the Loom artifact produced through
-`loom-compile --backend=amdgpu-hal`. The comparison is intentionally at the
+`loom-compile --format=amdgpu-hsaco`. The comparison is intentionally at the
 external disassembly summary level. Raw source, code objects, manifests,
 compile reports, and disassembly stay available for inspection, while the
 durable signal groups instruction-family mismatches into categories such as

--- a/loom/py/loom/importers/tilelang/differential.py
+++ b/loom/py/loom/importers/tilelang/differential.py
@@ -245,7 +245,8 @@ def capture_loom_amdgpu_artifact(
         (
             str(loom_compile),
             str(source_path),
-            "--backend=amdgpu-hal",
+            "--product=kernel",
+            "--format=amdgpu-hsaco",
             f"--target=amdgpu:{target_text}",
             f"--output={hal_artifact_path}",
             f"--emit-target-artifact={code_object_path}",

--- a/loom/py/loom/importers/tilelang/differential_test.py
+++ b/loom/py/loom/importers/tilelang/differential_test.py
@@ -168,10 +168,11 @@ def test_capture_loom_amdgpu_artifact_runs_production_compiler(
     )
 
     compile_command = commands[0]
-    assert compile_command[:3] == (
+    assert compile_command[:4] == (
         str(loom_compile),
         str(tmp_path / "out" / "copy.gfx1100.loom"),
-        "--backend=amdgpu-hal",
+        "--product=kernel",
+        "--format=amdgpu-hsaco",
     )
     assert "--target=amdgpu:gfx1100" in compile_command
     assert "--compile-report=summary" in compile_command

--- a/loom/src/loom/target/emit/llvmir/amdgpu/test/loom-compile.test.json
+++ b/loom/src/loom/target/emit/llvmir/amdgpu/test/loom-compile.test.json
@@ -7,7 +7,7 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/amdgcn_kernel.loom",
-          "--backend=llvmir-text",
+          "--format=llvmir-text",
           "--pipeline=none",
           "--output=-"
         ]

--- a/loom/src/loom/test/corpus/authoring/README.md
+++ b/loom/src/loom/test/corpus/authoring/README.md
@@ -98,7 +98,7 @@ sidecar when validating target lowering and packaging:
 ```bash
 loom-compile \
   loom/src/loom/test/corpus/authoring/ffn_gate_up_swiglu_q6q8.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=/tmp/loom-q6q8.hal \
   --emit-target-artifact=/tmp/loom-q6q8.hsaco \
@@ -209,7 +209,7 @@ snapshots around those boundaries:
 ```bash
 loom-compile \
   loom/src/loom/test/corpus/authoring/ffn_gate_up_swiglu_q6q8.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=/tmp/loom-q6q8.hal \
   --emit-target-artifact=/tmp/loom-q6q8.hsaco \
@@ -480,7 +480,7 @@ padding, swizzling, vectorization, or imported kernel staging choices:
 
 ```bash
 loom-compile loom/src/loom/test/corpus/authoring/hip/shared_memory_vector_tile.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=/tmp/shared-memory-vector-tile.hal \
   --compile-report=json-details \
@@ -520,7 +520,7 @@ greppable report is more convenient:
 
 ```bash
 loom-compile loom/src/loom/test/corpus/authoring/hip/shared_memory_vector_tile.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=/tmp/shared-memory-vector-tile.hal \
   --compile-report=text-details \

--- a/loom/src/loom/test/corpus/authoring/hip/README.md
+++ b/loom/src/loom/test/corpus/authoring/hip/README.md
@@ -302,7 +302,7 @@ Target compile evidence:
 
 ```bash
 loom-compile shared_memory_tile.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=/tmp/shared-memory-tile.hal \
   --emit-target-artifact=/tmp/shared-memory-tile.hsaco \
@@ -377,7 +377,7 @@ Target compile evidence:
 
 ```bash
 loom-compile shared_memory_transpose.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=/tmp/shared-memory-transpose.hal \
   --emit-target-artifact=/tmp/shared-memory-transpose.hsaco \
@@ -447,7 +447,7 @@ Target compile evidence:
 
 ```bash
 loom-compile shared_memory_vector_tile.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=/tmp/shared-memory-vector-tile.hal \
   --emit-target-artifact=/tmp/shared-memory-vector-tile.hsaco \
@@ -703,7 +703,7 @@ Compile the same source for generic wave32 and wave64 target profiles:
 
 ```bash
 loom-compile target_provider_selection.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx11-generic \
   --output=/tmp/target-provider-gfx11-generic.hal \
   --emit-target-artifact=/tmp/target-provider-gfx11-generic.hsaco \
@@ -712,7 +712,7 @@ loom-compile target_provider_selection.loom \
   --dump-ir-output=/tmp/target-provider-gfx11-generic-trace.jsonl
 
 loom-compile target_provider_selection.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx9-4-generic \
   --output=/tmp/target-provider-gfx9-4-generic.hal \
   --emit-target-artifact=/tmp/target-provider-gfx9-4-generic.hsaco \
@@ -791,7 +791,7 @@ Proof command:
 
 ```bash
 loom-compile cluster_b128_multicast.loom \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx1250 \
   --output=/tmp/cluster-b128-multicast.hal \
   --emit-target-artifact=/tmp/cluster-b128-multicast.hsaco \

--- a/loom/src/loom/test/corpus/authoring/hip/hip_authoring.test.json
+++ b/loom/src/loom/test/corpus/authoring/hip/hip_authoring.test.json
@@ -7,7 +7,8 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/wave64_reductions.loom",
-          "--backend=amdgpu-hal",
+          "--product=kernel",
+          "--format=amdgpu-hsaco",
           "--target=amdgpu:gfx1151",
           "--output={tmp}/wave64_reductions.hal",
           "--emit-target-artifact={tmp}/wave64_reductions.hsaco",
@@ -56,7 +57,8 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/shared_memory_vector_tile.loom",
-          "--backend=amdgpu-hal",
+          "--product=kernel",
+          "--format=amdgpu-hsaco",
           "--target=amdgpu:gfx11-generic",
           "--output={tmp}/shared_memory_vector_tile.hal",
           "--emit-target-artifact={tmp}/shared_memory_vector_tile.hsaco",
@@ -97,7 +99,8 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/cluster_b128_multicast.loom",
-          "--backend=amdgpu-hal",
+          "--product=kernel",
+          "--format=amdgpu-hsaco",
           "--target=amdgpu:gfx1250",
           "--output={tmp}/cluster_b128_multicast.hal",
           "--emit-target-artifact={tmp}/cluster_b128_multicast.hsaco",

--- a/loom/src/loom/test/corpus/authoring/linking/README.md
+++ b/loom/src/loom/test/corpus/authoring/linking/README.md
@@ -147,7 +147,7 @@ Compile the merged bytecode with a function specialization target:
 
 ```bash
 loom-compile portable.loombc \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx1100 \
   --output=scale_i32.hal \
   --emit-target-artifact=scale_i32.hsaco \
@@ -186,7 +186,7 @@ specialized function:
 
 ```bash
 loom-compile portable.loombc \
-  --backend=amdgpu-hal \
+  --format=amdgpu-hsaco \
   --target=amdgpu:gfx1100 \
   --output=scale_i32.hal \
   --emit-target-artifact=scale_i32.hsaco \

--- a/loom/src/loom/test/corpus/authoring/linking/linking.test.json
+++ b/loom/src/loom/test/corpus/authoring/linking/linking.test.json
@@ -115,7 +115,8 @@
             "tool": "loom-compile",
             "args": [
               "{tmp}/linked.loombc",
-              "--backend=amdgpu-hal",
+              "--product=kernel",
+              "--format=amdgpu-hsaco",
               "--target=amdgpu:gfx1100",
               "--output={tmp}/scale_i32.hal",
               "--emit-target-artifact={tmp}/scale_i32.hsaco",

--- a/loom/src/loom/tooling/compile/artifact.c
+++ b/loom/src/loom/tooling/compile/artifact.c
@@ -48,19 +48,6 @@ iree_status_t loom_artifact_target_select(
   return iree_ok_status();
 }
 
-const loom_artifact_provider_t* loom_artifact_provider_registry_lookup(
-    const loom_artifact_provider_registry_t* registry,
-    iree_string_view_t name) {
-  IREE_ASSERT_ARGUMENT(registry);
-  for (iree_host_size_t i = 0; i < registry->provider_count; ++i) {
-    const loom_artifact_provider_t* provider = registry->providers[i];
-    if (iree_string_view_equal(provider->name, name)) {
-      return provider;
-    }
-  }
-  return NULL;
-}
-
 static iree_status_t loom_artifact_candidate_publish_report(
     const loom_compile_options_t* options,
     const loom_artifact_candidate_t* candidate) {

--- a/loom/src/loom/tooling/compile/artifact.h
+++ b/loom/src/loom/tooling/compile/artifact.h
@@ -31,6 +31,12 @@ extern "C" {
 
 typedef struct loom_artifact_provider_t loom_artifact_provider_t;
 
+typedef uint32_t loom_artifact_provider_flags_t;
+enum loom_artifact_provider_flag_bits_e {
+  // Provider is the default format for its target family.
+  LOOM_ARTIFACT_PROVIDER_FLAG_CANONICAL = 1u << 0,
+};
+
 // Borrowed concrete compiler target selected independently of a runtime device.
 typedef struct loom_artifact_target_t {
   // Immutable structured target profile. NULL requests the module's authored
@@ -87,8 +93,12 @@ typedef void (*loom_artifact_provider_deinitialize_artifact_fn_t)(
 
 // Linked offline compiler for one target artifact family.
 struct loom_artifact_provider_t {
-  // User-facing provider name accepted by compilation and execution tools.
+  // Stable provider name used in diagnostics and execution tooling.
   iree_string_view_t name;
+  // Public artifact format produced by this provider.
+  iree_string_view_t public_artifact_format;
+  // Format selection flags.
+  loom_artifact_provider_flags_t flags;
   // Required target-family profile representation.
   const loom_target_profile_type_t* target_profile_type;
   // Artifact kind recorded in structured compile reports.
@@ -121,10 +131,6 @@ typedef struct loom_artifact_provider_registry_t {
   // Number of entries in |providers|.
   iree_host_size_t provider_count;
 } loom_artifact_provider_registry_t;
-
-// Looks up an artifact provider by user-facing provider name.
-const loom_artifact_provider_t* loom_artifact_provider_registry_lookup(
-    const loom_artifact_provider_registry_t* registry, iree_string_view_t name);
 
 // Artifact candidate produced by an offline compiler provider.
 typedef struct loom_artifact_candidate_t {

--- a/loom/src/loom/tooling/execution/hal/candidate_test.cc
+++ b/loom/src/loom/tooling/execution/hal/candidate_test.cc
@@ -196,6 +196,8 @@ void FakeHalDeinitializeArtifact(const loom_artifact_provider_t* provider,
 
 const loom_artifact_provider_t kFakeArtifactProvider = {
     /*.name=*/IREE_SVL("fake-hal"),
+    /*.public_artifact_format=*/IREE_SVL("FakeExecutableFormat123"),
+    /*.flags=*/LOOM_ARTIFACT_PROVIDER_FLAG_CANONICAL,
     /*.target_profile_type=*/&kFakeTargetProfileType,
     /*.artifact_kind=*/LOOM_TARGET_COMPILE_ARTIFACT_KIND_HAL_EXECUTABLE,
     /*.default_pipeline_options=*/{},

--- a/loom/src/loom/tooling/execution/hal/testbench_actual_test.cc
+++ b/loom/src/loom/tooling/execution/hal/testbench_actual_test.cc
@@ -167,6 +167,8 @@ static iree_status_t FakeHalSelectCompatibleDeviceTarget(
 
 static const loom_artifact_provider_t kFakeArtifactProvider = {
     /*.name=*/IREE_SVL("fake-hal"),
+    /*.public_artifact_format=*/IREE_SVL("FakeExecutableFormat123"),
+    /*.flags=*/LOOM_ARTIFACT_PROVIDER_FLAG_CANONICAL,
     /*.target_profile_type=*/&kFakeTargetProfileType,
     /*.artifact_kind=*/LOOM_TARGET_COMPILE_ARTIFACT_KIND_HAL_EXECUTABLE,
     /*.default_pipeline_options=*/{},

--- a/loom/src/loom/tooling/target/amdgpu/artifact_provider.c
+++ b/loom/src/loom/tooling/target/amdgpu/artifact_provider.c
@@ -122,6 +122,8 @@ static void loom_amdgpu_artifact_provider_deinitialize_artifact(
 
 const loom_artifact_provider_t loom_amdgpu_artifact_provider = {
     .name = IREE_SVL("amdgpu-hal"),
+    .public_artifact_format = IREE_SVL("amdgpu-hsaco"),
+    .flags = LOOM_ARTIFACT_PROVIDER_FLAG_CANONICAL,
     .target_profile_type = &loom_amdgpu_target_profile_type,
     .artifact_kind = LOOM_TARGET_COMPILE_ARTIFACT_KIND_HAL_EXECUTABLE,
     .emit_artifact = loom_amdgpu_artifact_provider_emit_artifact,

--- a/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
+++ b/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
@@ -7,7 +7,6 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/complete_authoring_module.loom",
-          "--backend=amdgpu-hal",
           "--target=amdgpu:gfx1100",
           "--output={tmp}/complete_authoring_module.hal",
           "--emit-target-artifact={tmp}/complete_authoring_module.hsaco"
@@ -30,7 +29,8 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/gfx1250_configured_fragment_bank.loom",
-          "--backend=amdgpu-hal",
+          "--product=kernel",
+          "--format=amdgpu-hsaco",
           "--target=amdgpu:gfx1250",
           "--config=test.fragment_bank.m_fragments=8",
           "--config=test.fragment_bank.n_fragments=4",
@@ -61,7 +61,8 @@
             "tool": "loom-compile",
             "args": [
               "{srcdir}/selected_root_amdgpu.loom",
-              "--backend=amdgpu-hal",
+              "--product=kernel",
+              "--format=amdgpu-hsaco",
               "--root=@selected_store_i32",
               "--target=amdgpu:gfx1151",
               "--output={tmp}/specialized_report.hal",

--- a/loom/src/loom/tooling/target/spirv/artifact_provider.c
+++ b/loom/src/loom/tooling/target/spirv/artifact_provider.c
@@ -253,6 +253,8 @@ static void loom_spirv_artifact_provider_deinitialize_artifact(
 
 const loom_artifact_provider_t loom_spirv_vulkan_artifact_provider = {
     .name = IREE_SVL("spirv-vulkan-hal"),
+    .public_artifact_format = IREE_SVL("spirv-binary"),
+    .flags = LOOM_ARTIFACT_PROVIDER_FLAG_CANONICAL,
     .target_profile_type = &loom_spirv_target_profile_type,
     .artifact_kind = LOOM_TARGET_COMPILE_ARTIFACT_KIND_HAL_EXECUTABLE,
     .default_pipeline_options =

--- a/loom/src/loom/tools/loom-compile/BUILD.bazel
+++ b/loom/src/loom/tools/loom-compile/BUILD.bazel
@@ -220,6 +220,7 @@ loom_cc_test(
     deps = [
         ":request",
         "//loom/src/loom/format/text:parser",
+        "//loom/src/loom/ir",
         "//loom/src/loom/ops/target",
         "//loom/src/loom/testing:context",
         "//loom/src/loom/testing:module_ptr",

--- a/loom/src/loom/tools/loom-compile/BUILD.bazel
+++ b/loom/src/loom/tools/loom-compile/BUILD.bazel
@@ -138,6 +138,23 @@ loom_cc_library(
     ],
 )
 
+loom_cc_library(
+    name = "request",
+    srcs = ["request.c"],
+    hdrs = ["request.h"],
+    visibility = ["//loom/src/loom/tools/loom-compile:__pkg__"],
+    deps = [
+        "//loom/src/loom/ir",
+        "//loom/src/loom/ops:op_defs",
+        "//loom/src/loom/target:entry_selection",
+        "//loom/src/loom/target:projection",
+        "//loom/src/loom/target:provider",
+        "//loom/src/loom/target:selection",
+        "//loom/src/loom/tooling/compile:artifact",
+        "//runtime/src/iree/base",
+    ],
+)
+
 loom_cc_binary(
     name = "loom-compile",
     srcs = ["loom-compile.c"],
@@ -145,6 +162,7 @@ loom_cc_binary(
     deps = [
         ":command_backend",
         ":command_manifest",
+        ":request",
         "//loom/src/loom/codegen/low:text_asm",
         "//loom/src/loom/error:diagnostic",
         "//loom/src/loom/format/text:printer",
@@ -191,6 +209,21 @@ loom_cc_test(
         "//loom/src/loom/target/arch/cmd:artifact_set",
         "//loom/src/loom/util:stream",
         "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_test(
+    name = "request_test",
+    srcs = ["request_test.cc"],
+    deps = [
+        ":request",
+        "//loom/src/loom/format/text:parser",
+        "//loom/src/loom/ops/target",
+        "//loom/src/loom/testing:context",
+        "//loom/src/loom/testing:module_ptr",
+        "//runtime/src/iree/base/internal:arena",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],

--- a/loom/src/loom/tools/loom-compile/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-compile/CMakeLists.txt
@@ -176,6 +176,7 @@ loom_cc_test(
     iree::testing::gtest
     iree::testing::gtest_main
     loom::format::text::parser
+    loom::ir
     loom::ops::target
     loom::testing::context
     loom::testing::module_ptr

--- a/loom/src/loom/tools/loom-compile/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-compile/CMakeLists.txt
@@ -54,6 +54,25 @@ loom_cc_library(
   PUBLIC
 )
 
+loom_cc_library(
+  NAME
+    request
+  HDRS
+    "request.h"
+  SRCS
+    "request.c"
+  DEPS
+    iree::base
+    loom::ir
+    loom::ops::op_defs
+    loom::target::entry_selection
+    loom::target::projection
+    loom::target::provider
+    loom::target::selection
+    loom::tooling::compile::artifact
+  PUBLIC
+)
+
 set(_loom_compile_platform_copts "")
 if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU)
   list(APPEND _loom_compile_platform_copts "-DLOOM_COMPILE_HAVE_AMDGPU=1")
@@ -99,6 +118,7 @@ loom_cc_binary(
   DEPS
     ::command_backend
     ::command_manifest
+    ::request
     iree::base
     iree::base::tooling::flags
     iree::io::file_handle
@@ -143,6 +163,22 @@ loom_cc_test(
     iree::testing::gtest_main
     loom::target::arch::cmd::artifact_set
     loom::util::stream
+)
+
+loom_cc_test(
+  NAME
+    request_test
+  SRCS
+    "request_test.cc"
+  DEPS
+    ::request
+    iree::base::internal::arena
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::format::text::parser
+    loom::ops::target
+    loom::testing::context
+    loom::testing::module_ptr
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/loom-compile/loom-compile-llvmir.test.json
+++ b/loom/src/loom/tools/loom-compile/loom-compile-llvmir.test.json
@@ -17,7 +17,7 @@
             "tool": "loom-compile",
             "args": [
               "{tmp}/mul.loom",
-              "--backend=llvmir-bitcode",
+              "--format=llvmir-bitcode",
               "--output={tmp}/mul.bc"
             ]
           },
@@ -31,7 +31,7 @@
       ]
     },
     {
-      "name": "rejects HAL sidecar path for LLVMIR emitters",
+      "name": "rejects loadable-kernel sidecar path for LLVMIR emitters",
       "steps": [
         {
           "name": "write-source",
@@ -46,7 +46,7 @@
             "tool": "loom-compile",
             "args": [
               "{tmp}/sidecar.loom",
-              "--backend=llvmir-text",
+              "--format=llvmir-text",
               "--emit-target-artifact={tmp}/unused.ll",
               "--output={tmp}/sidecar.ll"
             ]
@@ -56,19 +56,19 @@
           },
           "stderr": {
             "contains": [
-              "--emit-target-artifact is only valid for HAL artifact providers"
+              "--emit-target-artifact is only valid for loadable kernel formats"
             ]
           }
         }
       ]
     },
     {
-      "name": "rejects command artifacts for another backend",
+      "name": "rejects command artifacts for a non-command product",
       "run": {
         "tool": "loom-compile",
         "args": [
           "{srcdir}/testdata/llvmir_program.loom",
-          "--backend=llvmir-text",
+          "--format=llvmir-text",
           "--emit-command-artifacts={tmp}/commands",
           "--output={tmp}/program.ll"
         ]
@@ -78,7 +78,7 @@
       },
       "stderr": {
         "contains": [
-          "--emit-command-artifacts requires --backend=command"
+          "--emit-command-artifacts requires product 'command'"
         ]
       }
     },
@@ -88,7 +88,7 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/testdata/llvmir_program.loom",
-          "--backend=llvmir-text",
+          "--format=llvmir-text",
           "--output={tmp}/program.ll",
           "--dump-ir-after-all",
           "--dump-ir-format=jsonl",
@@ -114,7 +114,7 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/testdata/llvmir_program.loom",
-          "--backend=llvmir-text",
+          "--format=llvmir-text",
           "--output={tmp}/program.ll",
           "--sanitizer=access",
           "--dump-ir-before=sanitizer-insert-assertions",
@@ -142,7 +142,7 @@
         "args": [
           "{srcdir}/testdata/configured_llvmir.loom",
           "--config-file={srcdir}/testdata/configured_values.json",
-          "--backend=llvmir-text",
+          "--format=llvmir-text",
           "--output={tmp}/configured.ll"
         ]
       },

--- a/loom/src/loom/tools/loom-compile/loom-compile.c
+++ b/loom/src/loom/tools/loom-compile/loom-compile.c
@@ -37,6 +37,7 @@
 #include "loom/tooling/pass/trace_cli.h"
 #include "loom/tools/loom-compile/command_backend.h"
 #include "loom/tools/loom-compile/command_manifest.h"
+#include "loom/tools/loom-compile/request.h"
 
 #ifndef LOOM_COMPILE_HAVE_AMDGPU
 #define LOOM_COMPILE_HAVE_AMDGPU 0
@@ -125,24 +126,30 @@ static iree_status_t loom_compile_diagnostic_sink(
 #endif  // LOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV
 #endif  // LOOM_COMPILE_HAVE_LLVMIR
 
-IREE_FLAG(string, backend, "command",
-          "Compilation backend to emit, such as 'command' or a "
-          "linked native backend.");
+IREE_FLAG(string, product, "",
+          "Optional product: 'kernel', 'command', or 'module'. With explicit "
+          "--root values this validates their inferred product. With no "
+          "roots this selects the product's canonical roots.");
+IREE_FLAG(string, format, "",
+          "Optional exact artifact format, such as 'amdgpu-hsaco', "
+          "'spirv-binary', 'loom-command', or 'llvmir-text'. Omit this to "
+          "select the canonical format for the inferred product and target.");
 IREE_FLAG(string, target, "",
-          "Optional artifact target in family:selector form, such as "
+          "Optional compilation target in family:selector form, such as "
           "'amdgpu:gfx11-generic' or 'spirv:vulkan1.3+bda'. When present, "
           "every materialized kernel entry is specialized to that exact "
           "configured profile before the pass pipeline. Authored targets "
           "remain compatibility requirements.");
 IREE_FLAG_LIST(string, root,
                "Root symbol to materialize before compilation. Repeat for "
-               "multiple roots. When omitted, artifact providers compile every "
-               "kernel entry and its dependency closure, the command backend "
-               "emits every public or retained command program, and other "
-               "backends compile the full input module.");
+               "multiple roots. Roots must infer one homogeneous product. "
+               "When omitted, --product selects its canonical roots; without "
+               "either, public or retained command programs take precedence, "
+               "then kernel entries, then the whole module.");
 IREE_FLAG(string, pipeline, "default",
           "Pass pipeline to run before artifact emission. Use 'default' or "
-          "empty for the backend's default compile pipeline. 'none' disables "
+          "empty for the selected format's default compile pipeline. 'none' "
+          "disables "
           "all compiler transformations and passes the input directly to the "
           "selected emitter. Use '@symbol' to run a module-local pass.pipeline "
           "or a comma-separated pass list such as "
@@ -162,22 +169,21 @@ IREE_FLAG_LIST_NAMED(
     "JSON/JSONC config object file. Repeat for multiple files. Nested object "
     "keys are flattened with '.' separators.");
 IREE_FLAG(string, output, "-",
-          "Output path for the primary runtime artifact. For command this is "
-          "the command artifact-set manifest; for HAL this is the executable "
-          "artifact passed to the selected HAL loader; target-native emitters "
-          "write their native artifact directly.");
+          "Output path for the selected format. For 'loom-command' this is "
+          "the command artifact-set manifest; single-file kernel and module "
+          "formats write their artifact directly.");
 IREE_FLAG_NAMED(
     string, emit_target_artifact, "emit-target-artifact", "",
     "Optional output path for a target-native artifact produced beside the "
     "primary runtime artifact, such as AMDGPU HSACO.");
 IREE_FLAG_NAMED(
     string, emit_command_artifacts, "emit-command-artifacts", "",
-    "Directory receiving portable root artifacts for --backend=command. The "
+    "Directory receiving portable roots for the 'loom-command' format. The "
     "primary --output is the artifact-set manifest.");
 IREE_FLAG_NAMED(
     string, emit_kernel_requests, "emit-kernel-requests", "",
     "Optional directory receiving independently compilable Loom bytecode "
-    "kernel requests for --backend=command.");
+    "kernel requests for the 'loom-command' format.");
 IREE_FLAG_NAMED(
     string, compile_report, "compile-report", "",
     "Optional compile report output. Use 'summary'/'details' for structured "
@@ -274,15 +280,6 @@ static const loom_artifact_provider_registry_t
         .provider_count = 0,
 #endif  // LOOM_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER
 };
-
-typedef struct loom_compile_backend_t {
-  // Selected compiler artifact provider, if |--backend| names one.
-  const loom_artifact_provider_t* artifact_provider;
-  // Selected target-owned emitter, if |--backend| names an emitter format.
-  const loom_target_emitter_t* target_emitter;
-  // True when |--backend| names portable command artifact emission.
-  bool is_command_backend;
-} loom_compile_backend_t;
 
 static iree_status_t loom_compile_register_context(void* user_data,
                                                    loom_context_t* context) {
@@ -381,41 +378,40 @@ static iree_status_t loom_compile_materialize_config_set(
       run_module->module, &options, loom_run_session_block_pool(session), NULL);
 }
 
+static bool loom_compile_is_concrete_kernel_root(const loom_symbol_t* symbol) {
+  return symbol->defining_op != NULL &&
+         loom_symbol_implements(symbol, LOOM_SYMBOL_INTERFACE_KERNEL_ENTRY) &&
+         !loom_symbol_definition_is_declaration(symbol->definition);
+}
+
 static iree_status_t loom_compile_select_roots(
     loom_run_session_t* session, loom_run_module_t* run_module,
-    const loom_artifact_provider_t* artifact_provider,
-    iree_allocator_t allocator) {
-  iree_string_view_list_t roots = FLAG_root_list();
+    const loom_compile_request_t* request, iree_allocator_t allocator) {
+  iree_string_view_list_t roots = request->roots;
   iree_string_view_t* implicit_root_values = NULL;
-  if (roots.count == 0 && artifact_provider != NULL) {
-    loom_op_t* op = NULL;
-    loom_block_for_each_op(loom_module_block(run_module->module), op) {
-      if (loom_func_like_is_kernel_entry(
-              loom_func_like_cast(run_module->module, op))) {
+  if (roots.count == 0 && request->product == LOOM_COMPILE_PRODUCT_KERNEL) {
+    for (iree_host_size_t i = 0; i < run_module->module->symbols.count; ++i) {
+      const loom_symbol_t* symbol = &run_module->module->symbols.entries[i];
+      if (loom_compile_is_concrete_kernel_root(symbol)) {
         ++roots.count;
       }
     }
     if (roots.count == 0) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,
-          "artifact backend '%.*s' requires at least one kernel entry",
-          (int)artifact_provider->name.size, artifact_provider->name.data);
+          "kernel product requires at least one kernel entry");
     }
     IREE_RETURN_IF_ERROR(iree_allocator_malloc_array(
         allocator, roots.count, sizeof(*implicit_root_values),
         (void**)&implicit_root_values));
     iree_host_size_t root_ordinal = 0;
-    loom_block_for_each_op(loom_module_block(run_module->module), op) {
-      const loom_func_like_t function =
-          loom_func_like_cast(run_module->module, op);
-      if (!loom_func_like_is_kernel_entry(function)) {
+    for (iree_host_size_t i = 0; i < run_module->module->symbols.count; ++i) {
+      const loom_symbol_t* symbol = &run_module->module->symbols.entries[i];
+      if (!loom_compile_is_concrete_kernel_root(symbol)) {
         continue;
       }
-      const loom_symbol_ref_t function_ref = loom_func_like_callee(function);
-      const loom_symbol_t* function_symbol =
-          &run_module->module->symbols.entries[function_ref.symbol_id];
       implicit_root_values[root_ordinal++] =
-          run_module->module->strings.entries[function_symbol->name_id];
+          run_module->module->strings.entries[symbol->name_id];
     }
     roots.values = implicit_root_values;
   }
@@ -495,9 +491,9 @@ static iree_status_t loom_compile_make_artifact_manifest_path(
 }
 
 static iree_status_t loom_compile_artifact_manifest_options_initialize(
-    loom_compile_artifact_manifest_options_t* out_options, bool is_hal_backend,
-    iree_allocator_t allocator, iree_string_view_t* out_output_path,
-    char** out_output_path_storage) {
+    loom_compile_artifact_manifest_options_t* out_options,
+    bool has_artifact_provider, iree_allocator_t allocator,
+    iree_string_view_t* out_output_path, char** out_output_path_storage) {
   *out_options = (loom_compile_artifact_manifest_options_t){0};
   *out_output_path = iree_string_view_empty();
   *out_output_path_storage = NULL;
@@ -514,10 +510,10 @@ static iree_status_t loom_compile_artifact_manifest_options_initialize(
     }
     return iree_ok_status();
   }
-  if (!is_hal_backend) {
+  if (!has_artifact_provider) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "--artifact-manifest is only valid for HAL artifact providers");
+        "--artifact-manifest is only valid for loadable kernel formats");
   }
 
   const iree_string_view_t target_artifact_path =
@@ -848,13 +844,13 @@ static iree_status_t loom_compile_emit_target(
           iree_make_cstring_view(FLAG_emit_target_artifact))) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "--emit-target-artifact is only valid for HAL artifact providers");
+        "--emit-target-artifact is only valid for loadable kernel formats");
   }
   if (compile_options->artifact_manifest.mode !=
       LOOM_TARGET_ARTIFACT_MANIFEST_MODE_NONE) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "--artifact-manifest is only valid for HAL artifact providers");
+        "--artifact-manifest is only valid for loadable kernel formats");
   }
 
   loom_target_entry_options_t target_options = {
@@ -945,143 +941,37 @@ static iree_status_t loom_compile_emit_target(
   return status;
 }
 
-static iree_status_t loom_compile_append_backend_name(
-    iree_string_builder_t* builder, iree_string_view_t name,
-    bool* inout_needs_separator) {
-  if (*inout_needs_separator) {
-    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, ", "));
-  }
-  *inout_needs_separator = true;
-  return iree_string_builder_append_string(builder, name);
-}
-
-static iree_status_t loom_compile_append_artifact_backend_names(
-    const loom_artifact_provider_registry_t* artifact_provider_registry,
-    iree_string_builder_t* builder, bool* inout_needs_separator) {
-  for (iree_host_size_t i = 0; i < artifact_provider_registry->provider_count;
-       ++i) {
-    IREE_RETURN_IF_ERROR(loom_compile_append_backend_name(
-        builder, artifact_provider_registry->providers[i]->name,
-        inout_needs_separator));
-  }
-  return iree_ok_status();
-}
-
-static iree_status_t loom_compile_append_target_emitter_names(
-    const loom_target_environment_t* target_environment,
-    iree_string_builder_t* builder, bool* inout_needs_separator) {
-  const loom_target_emitter_list_t emitters =
-      loom_target_environment_emitter_list(target_environment);
-  for (iree_host_size_t i = 0; i < emitters.count; ++i) {
-    IREE_RETURN_IF_ERROR(loom_compile_append_backend_name(
-        builder, emitters.values[i]->public_artifact_format,
-        inout_needs_separator));
-  }
-  return iree_ok_status();
-}
-
-static iree_status_t loom_compile_make_unknown_backend_status(
-    iree_string_view_t backend_name,
-    const loom_artifact_provider_registry_t* artifact_provider_registry,
-    const loom_target_environment_t* target_environment,
-    iree_allocator_t allocator) {
-  iree_string_builder_t backend_names;
-  iree_string_builder_initialize(allocator, &backend_names);
-  bool needs_separator = false;
-  iree_status_t status = loom_compile_append_backend_name(
-      &backend_names, IREE_SV("command"), &needs_separator);
-  if (iree_status_is_ok(status)) {
-    status = loom_compile_append_artifact_backend_names(
-        artifact_provider_registry, &backend_names, &needs_separator);
-  }
-  if (iree_status_is_ok(status)) {
-    status = loom_compile_append_target_emitter_names(
-        target_environment, &backend_names, &needs_separator);
-  }
-  if (!iree_status_is_ok(status)) {
-    iree_string_builder_deinitialize(&backend_names);
-    return status;
-  }
-  status = iree_make_status(
-      IREE_STATUS_INVALID_ARGUMENT,
-      "unknown --backend='%.*s'; expected registered backend in [%.*s]",
-      (int)backend_name.size, backend_name.data,
-      (int)iree_string_builder_size(&backend_names),
-      iree_string_builder_buffer(&backend_names));
-  iree_string_builder_deinitialize(&backend_names);
-  return status;
-}
-
-static iree_status_t loom_compile_select_backend(
-    iree_string_view_t backend_name,
-    const loom_artifact_provider_registry_t* artifact_provider_registry,
-    const loom_target_environment_t* target_environment,
-    iree_allocator_t allocator, loom_compile_backend_t* out_backend) {
-  *out_backend = (loom_compile_backend_t){0};
-  const loom_artifact_provider_t* artifact_provider =
-      loom_artifact_provider_registry_lookup(artifact_provider_registry,
-                                             backend_name);
-  if (artifact_provider != NULL) {
-    out_backend->artifact_provider = artifact_provider;
-    return iree_ok_status();
-  }
-  if (iree_string_view_equal(backend_name, IREE_SV("command"))) {
-    out_backend->is_command_backend = true;
-    return iree_ok_status();
-  }
-  const loom_target_emitter_list_t emitters =
-      loom_target_environment_emitter_list(target_environment);
-  for (iree_host_size_t i = 0; i < emitters.count; ++i) {
-    const loom_target_emitter_t* emitter = emitters.values[i];
-    if (!iree_string_view_equal(emitter->public_artifact_format,
-                                backend_name)) {
-      continue;
-    }
-    if (out_backend->target_emitter != NULL) {
-      return iree_make_status(
-          IREE_STATUS_INTERNAL,
-          "target environment contains duplicate emitter artifact formats");
-    }
-    out_backend->target_emitter = emitter;
-  }
-  if (out_backend->target_emitter != NULL) {
-    return iree_ok_status();
-  }
-  return loom_compile_make_unknown_backend_status(
-      backend_name, artifact_provider_registry, target_environment, allocator);
-}
-
-static iree_status_t loom_compile_validate_backend_flags(
-    const loom_compile_backend_t* backend) {
+static iree_status_t loom_compile_validate_request_flags(
+    const loom_compile_request_t* request) {
   const iree_string_view_t command_artifact_directory =
       iree_make_cstring_view(FLAG_emit_command_artifacts);
   const iree_string_view_t kernel_request_directory =
       iree_make_cstring_view(FLAG_emit_kernel_requests);
-  if (!backend->is_command_backend) {
+  if (!loom_compile_request_is_command(request)) {
     if (!iree_string_view_is_empty(command_artifact_directory)) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,
-          "--emit-command-artifacts requires --backend=command");
+          "--emit-command-artifacts requires product 'command'");
     }
     if (!iree_string_view_is_empty(kernel_request_directory)) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "--emit-kernel-requests requires "
-                              "--backend=command");
+                              "product 'command'");
     }
     return iree_ok_status();
   }
 
   if (iree_string_view_is_empty(command_artifact_directory) ||
       loom_tooling_file_path_is_stdio(command_artifact_directory)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "--backend=command requires --emit-command-artifacts=<directory>");
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "format 'loom-command' requires "
+                            "--emit-command-artifacts=<directory>");
   }
   if (!iree_string_view_is_empty(
           iree_make_cstring_view(FLAG_emit_target_artifact))) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "--emit-target-artifact is only valid for HAL artifact providers");
+        "--emit-target-artifact is only valid for loadable kernel formats");
   }
   if (!iree_string_view_is_empty(kernel_request_directory) &&
       loom_tooling_file_path_is_stdio(kernel_request_directory)) {
@@ -1092,29 +982,7 @@ static iree_status_t loom_compile_validate_backend_flags(
   return iree_ok_status();
 }
 
-static iree_status_t loom_compile_select_explicit_artifact_target(
-    const loom_artifact_provider_t* artifact_provider,
-    const loom_target_environment_t* target_environment,
-    bool* out_target_selected, loom_artifact_target_t* out_target) {
-  *out_target_selected = false;
-  *out_target = (loom_artifact_target_t){0};
-
-  const iree_string_view_t target_specification =
-      iree_string_view_trim(iree_make_cstring_view(FLAG_target));
-  if (iree_string_view_is_empty(target_specification)) {
-    return iree_ok_status();
-  }
-  if (artifact_provider == NULL) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "--target is only valid for artifact providers");
-  }
-  IREE_RETURN_IF_ERROR(loom_artifact_target_select(
-      artifact_provider, target_environment, target_specification, out_target));
-  *out_target_selected = true;
-  return iree_ok_status();
-}
-
-static iree_status_t loom_compile_specialize_explicit_artifact_target(
+static iree_status_t loom_compile_specialize_explicit_target(
     const loom_run_execution_environment_t* environment,
     loom_run_session_t* session, loom_run_module_t* run_module,
     const loom_artifact_target_t* target,
@@ -1155,68 +1023,40 @@ static iree_status_t loom_compile_specialize_explicit_artifact_target(
   return iree_ok_status();
 }
 
-static iree_status_t loom_compile_require_artifact_kernel_targets(
-    const loom_artifact_provider_t* artifact_provider,
-    const loom_artifact_target_t* explicit_target, loom_module_t* module) {
-  if (artifact_provider == NULL || explicit_target != NULL) {
-    return iree_ok_status();
-  }
-  uint32_t unselected_root_count = 0;
-  if (module == NULL || module->body == NULL ||
-      module->body->block_count == 0) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "artifact target validation requires a module with a body block");
-  }
-  loom_op_t* op = NULL;
-  loom_block_for_each_op(loom_module_block(module), op) {
-    const loom_func_like_t function = loom_func_like_cast(module, op);
-    if (loom_func_like_is_kernel_entry(function) &&
-        !loom_symbol_ref_is_valid(loom_func_like_target(function))) {
-      ++unselected_root_count;
-    }
-  }
-  if (unselected_root_count == 0) {
-    return iree_ok_status();
-  }
-  return iree_make_status(
-      IREE_STATUS_INVALID_ARGUMENT,
-      "artifact backend '%.*s' requires --target= when %u kernel.def root%s "
-      "omit "
-      "target(...) attrs",
-      (int)artifact_provider->name.size, artifact_provider->name.data,
-      (unsigned)unselected_root_count, unselected_root_count == 1 ? "" : "s");
-}
-
 static void loom_compile_print_agents_markdown(FILE* stream) {
   fprintf(
       stream,
       "## loom-compile\n"
       "\n"
       "`loom-compile` specializes Loom text or bytecode and emits an offline\n"
-      "artifact. Choose the backend from the consumer that will load the "
-      "result,\n"
-      "then use a target only when that product needs specialization.\n"
+      "artifact. Selected roots infer the product, the target selects the "
+      "machine or API contract, and the format names the output encoding.\n"
       "\n"
       "### Select the product\n"
       "\n"
       "```shell\n"
-      "loom-compile program.loom --backend=command --output=manifest.json \\\n"
+      "loom-compile program.loom --output=manifest.json \\\n"
       "  --emit-command-artifacts=commands/ \\\n"
       "  --emit-kernel-requests=kernel-requests/\n"
-      "loom-compile kernel.loom --backend=amdgpu-hal \\\n"
+      "loom-compile kernel.loom \\\n"
       "  --target=amdgpu:gfx11-generic --output=kernel.hsaco\n"
-      "loom-compile catalog.loombc --root=@entry --backend=amdgpu-hal \\\n"
+      "loom-compile catalog.loombc --root=@entry \\\n"
       "  --target=amdgpu:gfx1151 --output=entry.hsaco\n"
+      "loom-compile kernel.loom --format=llvmir-text --output=kernel.ll\n"
       "```\n"
       "\n"
-      "`--backend=command` emits portable command programs and their shared\n"
+      "Command roots select `--format=loom-command` by default and emit "
+      "portable command programs and their shared\n"
       "entry-requirement manifest. `--emit-kernel-requests` additionally "
       "emits\n"
       "one ordinary Loom bytecode request per reachable semantic kernel "
       "class.\n"
-      "HAL backends emit loader-ready native executables. `--root=@symbol`\n"
-      "selects entries from a catalog; without it, the backend compiles every\n"
+      "Kernel roots select the canonical format for their target. "
+      "`--format` can request an exact alternate or diagnostic format. "
+      "With no explicit roots, `--product` selects that product's canonical "
+      "roots. "
+      "`--root=@symbol`\n"
+      "selects entries from a catalog; without it, the tool compiles every\n"
       "relevant exported entry and its dependency closure.\n"
       "\n"
       "A generic target such as `gfx11-generic` preserves family portability.\n"
@@ -1234,7 +1074,7 @@ static void loom_compile_print_agents_markdown(FILE* stream) {
       "normal source, correctness acceptance, and production artifacts.\n"
       "\n"
       "```shell\n"
-      "loom-compile prepared-low.loom --backend=amdgpu-hal \\\n"
+      "loom-compile prepared-low.loom --format=amdgpu-hsaco \\\n"
       "  --pipeline=none --output=oracle.hsaco\n"
       "```\n"
       "\n"
@@ -1252,7 +1092,7 @@ static void loom_compile_print_agents_markdown(FILE* stream) {
       "### Describe the artifact and compilation\n"
       "\n"
       "```shell\n"
-      "loom-compile kernel.loom --backend=amdgpu-hal \\\n"
+      "loom-compile kernel.loom --format=amdgpu-hsaco \\\n"
       "  --target=amdgpu:gfx11-generic --output=kernel.hsaco \\\n"
       "  --artifact-manifest=summary --emit-artifact-manifest=manifest.json "
       "\\\n"
@@ -1294,10 +1134,11 @@ int main(int argc, char** argv) {
       "Compiles a Loom module to a runtime artifact.\n"
       "\n"
       "Usage:\n"
-      "  loom-compile [file.loom] --backend=command "
+      "  loom-compile [file.loom] --product=command "
       "--output=commands.json --emit-command-artifacts=commands/ "
       "[--emit-kernel-requests=kernels/]\n"
-      "  loom-compile [file.loom] --backend=amdgpu-hal "
+      "  loom-compile [file.loom] --product=kernel "
+      "--format=amdgpu-hsaco "
       "--target=amdgpu:gfx11-generic --output=kernel.hsaco\n"
       "  loom-compile --agents_md\n"
       "\n"
@@ -1337,18 +1178,13 @@ int main(int argc, char** argv) {
   loom_compile_report_capture_options_t compile_report_options = {0};
   loom_compile_report_capture_t compile_report_capture = {0};
   loom_tooling_pass_trace_t pass_trace = {0};
-  const loom_artifact_provider_t* artifact_provider = NULL;
-  const loom_target_emitter_t* target_emitter = NULL;
+  loom_compile_request_t request = {0};
   loom_compile_artifact_manifest_options_t artifact_manifest_options = {0};
   iree_string_view_t artifact_manifest_output_path = iree_string_view_empty();
   char* artifact_manifest_output_path_storage = NULL;
-  bool is_command_backend = false;
-  loom_artifact_target_t explicit_artifact_target = {0};
-  bool explicit_artifact_target_selected = false;
   bool emitted = false;
   bool report_written = false;
   int exit_code = 0;
-  const iree_string_view_t backend_name = iree_make_cstring_view(FLAG_backend);
 
   if (iree_status_is_ok(status)) {
     status = loom_compile_initialize_session(&environment, allocator, &session);
@@ -1380,49 +1216,44 @@ int main(int argc, char** argv) {
         &compile_report_capture, run_module.module, &config_set);
   }
   if (iree_status_is_ok(status)) {
-    loom_compile_backend_t backend = {0};
-    status = loom_compile_select_backend(
-        backend_name, &kLoomCompileArtifactProviderRegistry,
+    const loom_compile_request_options_t request_options = {
+        .roots = FLAG_root_list(),
+        .product = iree_make_cstring_view(FLAG_product),
+        .format = iree_make_cstring_view(FLAG_format),
+        .target = iree_make_cstring_view(FLAG_target),
+    };
+    status = loom_compile_request_resolve(
+        run_module.module, &request_options,
+        &kLoomCompileArtifactProviderRegistry,
         loom_run_execution_environment_target_environment(&environment),
-        allocator, &backend);
-    artifact_provider = backend.artifact_provider;
-    target_emitter = backend.target_emitter;
-    is_command_backend = backend.is_command_backend;
+        &request);
     if (iree_status_is_ok(status)) {
-      status = loom_compile_validate_backend_flags(&backend);
+      status = loom_compile_validate_request_flags(&request);
     }
   }
-  if (iree_status_is_ok(status)) {
-    status = loom_compile_select_explicit_artifact_target(
-        artifact_provider,
-        loom_run_execution_environment_target_environment(&environment),
-        &explicit_artifact_target_selected, &explicit_artifact_target);
-  }
-  if (iree_status_is_ok(status) && explicit_artifact_target_selected) {
-    status = loom_compile_specialize_explicit_artifact_target(
-        &environment, &session, &run_module, &explicit_artifact_target,
+  if (iree_status_is_ok(status) &&
+      request.explicit_target.target_profile != NULL) {
+    status = loom_compile_specialize_explicit_target(
+        &environment, &session, &run_module, &request.explicit_target,
         &compile_report_capture, allocator);
   }
   if (iree_status_is_ok(status)) {
-    status = loom_compile_select_roots(&session, &run_module, artifact_provider,
-                                       allocator);
+    status =
+        loom_compile_select_roots(&session, &run_module, &request, allocator);
   }
   if (iree_status_is_ok(status)) {
     status = loom_compile_artifact_manifest_options_initialize(
-        &artifact_manifest_options, artifact_provider != NULL, allocator,
+        &artifact_manifest_options,
+        loom_compile_request_artifact_provider(&request) != NULL, allocator,
         &artifact_manifest_output_path, &artifact_manifest_output_path_storage);
-  }
-  if (iree_status_is_ok(status)) {
-    status = loom_compile_require_artifact_kernel_targets(
-        artifact_provider,
-        explicit_artifact_target_selected ? &explicit_artifact_target : NULL,
-        run_module.module);
   }
 
   loom_compile_options_t compile_options = {0};
   loom_compile_options_initialize(&compile_options);
   loom_compile_pipeline_result_t pipeline_result = {0};
   compile_options.artifact_manifest = artifact_manifest_options;
+  const loom_artifact_provider_t* artifact_provider =
+      loom_compile_request_artifact_provider(&request);
   if (artifact_provider != NULL) {
     compile_options.target_pipeline_options =
         artifact_provider->default_pipeline_options;
@@ -1482,9 +1313,9 @@ int main(int argc, char** argv) {
     // Eagerly expanding the whole input here would erase unresolved kernel
     // decisions before command planning can classify launch sites and emit
     // independent kernel requests. Explicit user pipelines remain honored.
-    const bool run_pipeline =
-        !is_command_backend || !loom_compile_pipeline_is_default(
-                                   iree_make_cstring_view(FLAG_pipeline));
+    const bool run_pipeline = !loom_compile_request_is_command(&request) ||
+                              !loom_compile_pipeline_is_default(
+                                  iree_make_cstring_view(FLAG_pipeline));
     if (run_pipeline) {
       status = loom_compile_run_pass_pipeline(
           &environment, &session, &run_module,
@@ -1503,26 +1334,38 @@ int main(int argc, char** argv) {
     }
     compile_options.function_versions = &pipeline_result.function_versions.list;
   }
-  if (iree_status_is_ok(status) && exit_code == 0 && !is_command_backend) {
+  if (iree_status_is_ok(status) && exit_code == 0 &&
+      !loom_compile_request_is_command(&request)) {
     status =
         loom_tooling_config_require_resolved_module(run_module.module, NULL);
   }
 
   if (iree_status_is_ok(status) && exit_code == 0) {
-    if (artifact_provider != NULL) {
-      status = loom_compile_emit_artifact(
-          artifact_provider,
-          explicit_artifact_target_selected ? &explicit_artifact_target : NULL,
-          &run_module, &compile_options, &compile_report_capture,
-          artifact_manifest_output_path, allocator, &emitted, &report_written);
-    } else if (target_emitter != NULL) {
-      status = loom_compile_emit_target(&environment, &session, target_emitter,
-                                        &run_module, &compile_options,
-                                        allocator, &emitted);
-    } else if (is_command_backend) {
-      status = loom_compile_emit_command(
-          &session, &run_module, &compile_options, &compile_report_capture,
-          allocator, &emitted);
+    switch (request.producer.kind) {
+      case LOOM_COMPILE_PRODUCER_ARTIFACT:
+        status = loom_compile_emit_artifact(
+            request.producer.value.artifact_provider,
+            request.explicit_target.target_profile != NULL
+                ? &request.explicit_target
+                : NULL,
+            &run_module, &compile_options, &compile_report_capture,
+            artifact_manifest_output_path, allocator, &emitted,
+            &report_written);
+        break;
+      case LOOM_COMPILE_PRODUCER_TARGET_EMITTER:
+        status = loom_compile_emit_target(
+            &environment, &session, request.producer.value.target_emitter,
+            &run_module, &compile_options, allocator, &emitted);
+        break;
+      case LOOM_COMPILE_PRODUCER_COMMAND:
+        status = loom_compile_emit_command(
+            &session, &run_module, &compile_options, &compile_report_capture,
+            allocator, &emitted);
+        break;
+      case LOOM_COMPILE_PRODUCER_INVALID:
+        status = iree_make_status(IREE_STATUS_INTERNAL,
+                                  "compile request has no producer");
+        break;
     }
   }
   if (iree_status_is_ok(status) && exit_code == 0 && !emitted) {

--- a/loom/src/loom/tools/loom-compile/loom-compile.test.json
+++ b/loom/src/loom/tools/loom-compile/loom-compile.test.json
@@ -17,7 +17,8 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/testdata/command_artifacts.loom",
-          "--backend=command",
+          "--product=command",
+          "--format=loom-command",
           "--output={tmp}/manifest.json",
           "--emit-command-artifacts={tmp}/commands"
         ]
@@ -43,7 +44,8 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/testdata/command_kernel_requests.loom",
-          "--backend=command",
+          "--product=command",
+          "--format=loom-command",
           "--output={tmp}/manifest.json",
           "--emit-command-artifacts={tmp}/commands",
           "--emit-kernel-requests={tmp}/requests"
@@ -66,7 +68,8 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/testdata/command_artifacts.loom",
-          "--backend=command",
+          "--product=command",
+          "--format=loom-command",
           "--root=@increment_then_double",
           "--output={tmp}/manifest.json",
           "--emit-command-artifacts={tmp}/commands"
@@ -89,7 +92,8 @@
         "tool": "loom-compile",
         "args": [
           "{srcdir}/testdata/command_artifacts.loom",
-          "--backend=command",
+          "--product=command",
+          "--format=loom-command",
           "--output={tmp}/manifest.json"
         ]
       },
@@ -98,8 +102,25 @@
       },
       "stderr": {
         "contains": [
-          "--backend=command requires --emit-command-artifacts=<directory>"
+          "format 'loom-command' requires --emit-command-artifacts=<directory>"
         ]
+      }
+    },
+    {
+      "name": "rejects the removed backend flag",
+      "run": {
+        "tool": "loom-compile",
+        "args": [
+          "{srcdir}/testdata/command_artifacts.loom",
+          "--backend=command",
+          "--output={tmp}/manifest.json"
+        ]
+      },
+      "exit": {
+        "nonzero": true
+      },
+      "stderr": {
+        "contains": ["flag 'backend' not recognized"]
       }
     }
   ]

--- a/loom/src/loom/tools/loom-compile/request.c
+++ b/loom/src/loom/tools/loom-compile/request.c
@@ -1,0 +1,609 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tools/loom-compile/request.h"
+
+#include "loom/ops/op_defs.h"
+#include "loom/target/entry_selection.h"
+#include "loom/target/projection.h"
+#include "loom/target/selection.h"
+
+iree_string_view_t loom_compile_product_name(loom_compile_product_t product) {
+  switch (product) {
+    case LOOM_COMPILE_PRODUCT_INVALID:
+      break;
+    case LOOM_COMPILE_PRODUCT_KERNEL:
+      return IREE_SV("kernel");
+    case LOOM_COMPILE_PRODUCT_COMMAND:
+      return IREE_SV("command");
+    case LOOM_COMPILE_PRODUCT_MODULE:
+      return IREE_SV("module");
+  }
+  return IREE_SV("unknown");
+}
+
+static iree_status_t loom_compile_request_lookup_root(
+    const loom_module_t* module, iree_string_view_t root_name,
+    const loom_symbol_t** out_symbol) {
+  *out_symbol = NULL;
+  root_name = loom_target_entry_normalize_symbol_name(root_name);
+  if (iree_string_view_is_empty(root_name)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "root symbol name must not be empty");
+  }
+  const loom_string_id_t name_id = loom_module_lookup_string(module, root_name);
+  const loom_symbol_id_t symbol_id =
+      name_id != LOOM_STRING_ID_INVALID
+          ? loom_module_find_symbol(module, name_id)
+          : LOOM_SYMBOL_ID_INVALID;
+  if (symbol_id == LOOM_SYMBOL_ID_INVALID) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "root symbol '@%.*s' was not found",
+                            (int)root_name.size, root_name.data);
+  }
+  const loom_symbol_t* symbol = &module->symbols.entries[symbol_id];
+  if (symbol->defining_op == NULL) {
+    return iree_make_status(
+        IREE_STATUS_NOT_FOUND,
+        "root symbol '@%.*s' has no materialized definition or declaration",
+        (int)root_name.size, root_name.data);
+  }
+  *out_symbol = symbol;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_compile_request_classify_symbol(
+    const loom_module_t* module, const loom_symbol_t* symbol,
+    loom_compile_product_t* out_product) {
+  if (loom_symbol_implements(symbol, LOOM_SYMBOL_INTERFACE_COMMAND_PROGRAM)) {
+    *out_product = LOOM_COMPILE_PRODUCT_COMMAND;
+    return iree_ok_status();
+  }
+  if (loom_symbol_implements(symbol, LOOM_SYMBOL_INTERFACE_KERNEL)) {
+    *out_product = LOOM_COMPILE_PRODUCT_KERNEL;
+    return iree_ok_status();
+  }
+  if (loom_symbol_implements(symbol, LOOM_SYMBOL_INTERFACE_FUNC_LIKE)) {
+    *out_product = LOOM_COMPILE_PRODUCT_MODULE;
+    return iree_ok_status();
+  }
+  const iree_string_view_t symbol_name =
+      module->strings.entries[symbol->name_id];
+  return iree_make_status(
+      IREE_STATUS_INVALID_ARGUMENT,
+      "root symbol '@%.*s' does not define a compilable product",
+      (int)symbol_name.size, symbol_name.data);
+}
+
+static iree_status_t loom_compile_request_kernel_target_fact_type(
+    const loom_module_t* module, const loom_symbol_t* symbol,
+    const loom_target_fact_type_t** out_fact_type) {
+  *out_fact_type = NULL;
+  const loom_func_like_t function =
+      loom_func_like_const_cast(module, symbol->defining_op);
+  if (!loom_func_like_isa(function)) {
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "kernel root does not implement FuncLike");
+  }
+  const loom_symbol_ref_t target_ref = loom_func_like_target(function);
+  if (!loom_symbol_ref_is_valid(target_ref)) {
+    return iree_ok_status();
+  }
+  if (target_ref.module_id != 0 ||
+      target_ref.symbol_id >= module->symbols.count) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "kernel root has an invalid target reference");
+  }
+  const loom_symbol_t* target_symbol =
+      &module->symbols.entries[target_ref.symbol_id];
+  const loom_target_like_t target =
+      loom_target_like_cast(module, target_symbol->defining_op);
+  const loom_target_like_descriptor_t* descriptor =
+      loom_target_like_descriptor(target);
+  if (descriptor == NULL || descriptor->fact_type == NULL) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "kernel root target is not a target definition");
+  }
+  *out_fact_type = descriptor->fact_type;
+  return iree_ok_status();
+}
+
+typedef struct loom_compile_root_summary_t {
+  // Product shared by every selected root.
+  loom_compile_product_t product;
+  // Number of selected product roots.
+  iree_host_size_t root_count;
+  // Common authored kernel target type.
+  const loom_target_fact_type_t* target_fact_type;
+  // Number of selected kernel roots without an authored target.
+  iree_host_size_t untargeted_kernel_count;
+} loom_compile_root_summary_t;
+
+static iree_status_t loom_compile_request_merge_kernel_target(
+    const loom_module_t* module, const loom_symbol_t* symbol,
+    loom_compile_root_summary_t* summary) {
+  const loom_target_fact_type_t* fact_type = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_compile_request_kernel_target_fact_type(module, symbol, &fact_type));
+  if (fact_type == NULL) {
+    ++summary->untargeted_kernel_count;
+    return iree_ok_status();
+  }
+  if (summary->target_fact_type != NULL &&
+      summary->target_fact_type != fact_type) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "selected kernel roots use multiple target families ('%.*s' and "
+        "'%.*s')",
+        (int)summary->target_fact_type->name.size,
+        summary->target_fact_type->name.data, (int)fact_type->name.size,
+        fact_type->name.data);
+  }
+  summary->target_fact_type = fact_type;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_compile_request_merge_root(
+    const loom_module_t* module, const loom_symbol_t* symbol,
+    loom_compile_root_summary_t* summary) {
+  loom_compile_product_t product = LOOM_COMPILE_PRODUCT_INVALID;
+  IREE_RETURN_IF_ERROR(
+      loom_compile_request_classify_symbol(module, symbol, &product));
+  if (summary->root_count != 0 && summary->product != product) {
+    const iree_string_view_t symbol_name =
+        module->strings.entries[symbol->name_id];
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "selected roots mix '%.*s' and '%.*s' products at '@%.*s'",
+        (int)loom_compile_product_name(summary->product).size,
+        loom_compile_product_name(summary->product).data,
+        (int)loom_compile_product_name(product).size,
+        loom_compile_product_name(product).data, (int)symbol_name.size,
+        symbol_name.data);
+  }
+  summary->product = product;
+  ++summary->root_count;
+  if (product == LOOM_COMPILE_PRODUCT_KERNEL) {
+    IREE_RETURN_IF_ERROR(
+        loom_compile_request_merge_kernel_target(module, symbol, summary));
+  }
+  return iree_ok_status();
+}
+
+static bool loom_compile_request_is_concrete_public_command(
+    const loom_symbol_t* symbol) {
+  return symbol->defining_op != NULL &&
+         loom_symbol_implements(symbol,
+                                LOOM_SYMBOL_INTERFACE_COMMAND_PROGRAM) &&
+         !loom_symbol_definition_is_declaration(symbol->definition) &&
+         iree_any_bit_set(symbol->flags,
+                          LOOM_SYMBOL_FLAG_PUBLIC | LOOM_SYMBOL_FLAG_RETAIN);
+}
+
+static bool loom_compile_request_is_concrete_kernel_entry(
+    const loom_symbol_t* symbol) {
+  return symbol->defining_op != NULL &&
+         loom_symbol_implements(symbol, LOOM_SYMBOL_INTERFACE_KERNEL_ENTRY) &&
+         !loom_symbol_definition_is_declaration(symbol->definition);
+}
+
+static void loom_compile_request_collect_implicit_commands(
+    const loom_module_t* module, loom_compile_root_summary_t* summary) {
+  summary->product = LOOM_COMPILE_PRODUCT_COMMAND;
+  for (iree_host_size_t i = 0; i < module->symbols.count; ++i) {
+    const loom_symbol_t* symbol = &module->symbols.entries[i];
+    if (loom_compile_request_is_concrete_public_command(symbol)) {
+      ++summary->root_count;
+    }
+  }
+}
+
+static iree_status_t loom_compile_request_collect_implicit_kernels(
+    const loom_module_t* module, loom_compile_root_summary_t* summary) {
+  summary->product = LOOM_COMPILE_PRODUCT_KERNEL;
+  for (iree_host_size_t i = 0; i < module->symbols.count; ++i) {
+    const loom_symbol_t* symbol = &module->symbols.entries[i];
+    if (!loom_compile_request_is_concrete_kernel_entry(symbol)) {
+      continue;
+    }
+    ++summary->root_count;
+    IREE_RETURN_IF_ERROR(
+        loom_compile_request_merge_kernel_target(module, symbol, summary));
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_compile_request_validate_product(
+    loom_compile_product_t inferred_product,
+    loom_compile_product_t explicit_product) {
+  if (explicit_product == LOOM_COMPILE_PRODUCT_INVALID ||
+      explicit_product == inferred_product) {
+    return iree_ok_status();
+  }
+  const iree_string_view_t inferred_name =
+      loom_compile_product_name(inferred_product);
+  const iree_string_view_t explicit_name =
+      loom_compile_product_name(explicit_product);
+  return iree_make_status(
+      IREE_STATUS_INVALID_ARGUMENT,
+      "selected roots infer product '%.*s'; --product='%.*s' cannot "
+      "reinterpret them",
+      (int)inferred_name.size, inferred_name.data, (int)explicit_name.size,
+      explicit_name.data);
+}
+
+static iree_status_t loom_compile_request_select_roots(
+    const loom_module_t* module, iree_string_view_list_t roots,
+    loom_compile_product_t explicit_product,
+    loom_compile_root_summary_t* out_summary) {
+  *out_summary = (loom_compile_root_summary_t){0};
+  if (roots.count != 0 && roots.values == NULL) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "root count is nonzero but roots are NULL");
+  }
+  for (iree_host_size_t i = 0; i < roots.count; ++i) {
+    const loom_symbol_t* symbol = NULL;
+    IREE_RETURN_IF_ERROR(
+        loom_compile_request_lookup_root(module, roots.values[i], &symbol));
+    IREE_RETURN_IF_ERROR(
+        loom_compile_request_merge_root(module, symbol, out_summary));
+  }
+  if (out_summary->root_count != 0) {
+    return loom_compile_request_validate_product(out_summary->product,
+                                                 explicit_product);
+  }
+
+  if (explicit_product == LOOM_COMPILE_PRODUCT_COMMAND) {
+    loom_compile_request_collect_implicit_commands(module, out_summary);
+    if (out_summary->root_count == 0) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "product 'command' requires at least one public or retained command "
+          "root");
+    }
+    return iree_ok_status();
+  }
+  if (explicit_product == LOOM_COMPILE_PRODUCT_KERNEL) {
+    IREE_RETURN_IF_ERROR(
+        loom_compile_request_collect_implicit_kernels(module, out_summary));
+    if (out_summary->root_count == 0) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "product 'kernel' requires at least one kernel entry root");
+    }
+    return iree_ok_status();
+  }
+  if (explicit_product == LOOM_COMPILE_PRODUCT_MODULE) {
+    out_summary->product = LOOM_COMPILE_PRODUCT_MODULE;
+    return iree_ok_status();
+  }
+
+  loom_compile_request_collect_implicit_commands(module, out_summary);
+  if (out_summary->root_count != 0) {
+    return iree_ok_status();
+  }
+
+  *out_summary = (loom_compile_root_summary_t){0};
+  IREE_RETURN_IF_ERROR(
+      loom_compile_request_collect_implicit_kernels(module, out_summary));
+  if (out_summary->root_count != 0) {
+    return iree_ok_status();
+  }
+
+  out_summary->product = LOOM_COMPILE_PRODUCT_MODULE;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_compile_request_select_explicit_target(
+    iree_string_view_t target_value,
+    const loom_target_environment_t* target_environment,
+    loom_artifact_target_t* out_target) {
+  *out_target = (loom_artifact_target_t){0};
+  target_value = iree_string_view_trim(target_value);
+  if (iree_string_view_is_empty(target_value)) {
+    return iree_ok_status();
+  }
+  loom_target_specification_t specification = {0};
+  IREE_RETURN_IF_ERROR(
+      loom_target_specification_parse(target_value, &specification));
+  const loom_target_profile_t* profile = NULL;
+  IREE_RETURN_IF_ERROR(loom_target_environment_select_profile(
+      target_environment, &specification, &profile));
+  *out_target = (loom_artifact_target_t){
+      .target_profile = profile,
+      .target_key = specification.selector,
+  };
+  return iree_ok_status();
+}
+
+static iree_status_t loom_compile_request_parse_product(
+    iree_string_view_t value, loom_compile_product_t* out_product) {
+  *out_product = LOOM_COMPILE_PRODUCT_INVALID;
+  value = iree_string_view_trim(value);
+  if (iree_string_view_is_empty(value)) {
+    return iree_ok_status();
+  }
+  for (loom_compile_product_t product = LOOM_COMPILE_PRODUCT_KERNEL;
+       product <= LOOM_COMPILE_PRODUCT_MODULE; ++product) {
+    if (iree_string_view_equal(value, loom_compile_product_name(product))) {
+      *out_product = product;
+      return iree_ok_status();
+    }
+  }
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "unknown --product='%.*s'; expected 'kernel', "
+                          "'command', or 'module'",
+                          (int)value.size, value.data);
+}
+
+static iree_status_t loom_compile_request_validate_artifact_provider(
+    const loom_artifact_provider_t* provider,
+    const loom_target_fact_type_t* target_fact_type) {
+  if (provider->target_profile_type == NULL ||
+      provider->target_profile_type->fact_type == NULL) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "artifact provider '%.*s' has no target profile type",
+        (int)provider->name.size, provider->name.data);
+  }
+  if (provider->public_artifact_format.data == NULL ||
+      iree_string_view_is_empty(provider->public_artifact_format)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "artifact provider '%.*s' has no public artifact format",
+        (int)provider->name.size, provider->name.data);
+  }
+  if (target_fact_type != provider->target_profile_type->fact_type) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "format '%.*s' requires target family '%.*s'; selected roots use "
+        "'%.*s'",
+        (int)provider->public_artifact_format.size,
+        provider->public_artifact_format.data,
+        (int)provider->target_profile_type->name.size,
+        provider->target_profile_type->name.data,
+        (int)target_fact_type->name.size, target_fact_type->name.data);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_compile_request_select_named_format(
+    loom_compile_product_t product, iree_string_view_t format,
+    const loom_target_fact_type_t* target_fact_type,
+    const loom_artifact_provider_registry_t* artifact_provider_registry,
+    const loom_target_environment_t* target_environment,
+    loom_compile_producer_t* out_producer) {
+  *out_producer = (loom_compile_producer_t){0};
+  iree_host_size_t match_count = 0;
+  if (iree_string_view_equal(format, IREE_SV("loom-command"))) {
+    out_producer->kind = LOOM_COMPILE_PRODUCER_COMMAND;
+    ++match_count;
+  }
+  for (iree_host_size_t i = 0; i < artifact_provider_registry->provider_count;
+       ++i) {
+    const loom_artifact_provider_t* provider =
+        artifact_provider_registry->providers[i];
+    if (provider != NULL &&
+        iree_string_view_equal(provider->public_artifact_format, format)) {
+      out_producer->kind = LOOM_COMPILE_PRODUCER_ARTIFACT;
+      out_producer->value.artifact_provider = provider;
+      ++match_count;
+    }
+  }
+  const loom_target_emitter_list_t emitters =
+      loom_target_environment_emitter_list(target_environment);
+  for (iree_host_size_t i = 0; i < emitters.count; ++i) {
+    const loom_target_emitter_t* emitter = emitters.values[i];
+    if (emitter != NULL &&
+        iree_string_view_equal(emitter->public_artifact_format, format)) {
+      out_producer->kind = LOOM_COMPILE_PRODUCER_TARGET_EMITTER;
+      out_producer->value.target_emitter = emitter;
+      ++match_count;
+    }
+  }
+  if (match_count == 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "format '%.*s' is not available in this binary",
+                            (int)format.size, format.data);
+  }
+  if (match_count != 1) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "format '%.*s' has multiple configured producers",
+                            (int)format.size, format.data);
+  }
+
+  const iree_string_view_t product_name = loom_compile_product_name(product);
+  switch (out_producer->kind) {
+    case LOOM_COMPILE_PRODUCER_COMMAND:
+      if (product != LOOM_COMPILE_PRODUCT_COMMAND) {
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "format 'loom-command' cannot emit product '%.*s'",
+            (int)product_name.size, product_name.data);
+      }
+      return iree_ok_status();
+    case LOOM_COMPILE_PRODUCER_ARTIFACT:
+      if (product != LOOM_COMPILE_PRODUCT_KERNEL) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "format '%.*s' cannot emit product '%.*s'",
+                                (int)format.size, format.data,
+                                (int)product_name.size, product_name.data);
+      }
+      return loom_compile_request_validate_artifact_provider(
+          out_producer->value.artifact_provider, target_fact_type);
+    case LOOM_COMPILE_PRODUCER_TARGET_EMITTER:
+      if (product == LOOM_COMPILE_PRODUCT_COMMAND) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "format '%.*s' cannot emit product 'command'",
+                                (int)format.size, format.data);
+      }
+      return iree_ok_status();
+    case LOOM_COMPILE_PRODUCER_INVALID:
+      break;
+  }
+  return iree_make_status(IREE_STATUS_INTERNAL,
+                          "format producer selection is invalid");
+}
+
+static iree_status_t loom_compile_request_select_canonical_kernel_format(
+    const loom_target_fact_type_t* target_fact_type,
+    const loom_artifact_provider_registry_t* artifact_provider_registry,
+    iree_string_view_t* out_format, loom_compile_producer_t* out_producer) {
+  *out_format = iree_string_view_empty();
+  *out_producer = (loom_compile_producer_t){0};
+  iree_host_size_t match_count = 0;
+  for (iree_host_size_t i = 0; i < artifact_provider_registry->provider_count;
+       ++i) {
+    const loom_artifact_provider_t* provider =
+        artifact_provider_registry->providers[i];
+    if (provider == NULL ||
+        !iree_any_bit_set(provider->flags,
+                          LOOM_ARTIFACT_PROVIDER_FLAG_CANONICAL) ||
+        provider->target_profile_type == NULL ||
+        provider->target_profile_type->fact_type != target_fact_type) {
+      continue;
+    }
+    IREE_RETURN_IF_ERROR(loom_compile_request_validate_artifact_provider(
+        provider, target_fact_type));
+    *out_format = provider->public_artifact_format;
+    out_producer->kind = LOOM_COMPILE_PRODUCER_ARTIFACT;
+    out_producer->value.artifact_provider = provider;
+    ++match_count;
+  }
+  if (match_count == 0) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "no canonical kernel format is configured for target family '%.*s'",
+        (int)target_fact_type->name.size, target_fact_type->name.data);
+  }
+  if (match_count != 1) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "target family '%.*s' has multiple canonical kernel formats; pass "
+        "--format to select one",
+        (int)target_fact_type->name.size, target_fact_type->name.data);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_compile_request_select_format(
+    loom_compile_product_t product, iree_string_view_t explicit_format,
+    const loom_target_fact_type_t* target_fact_type,
+    const loom_artifact_provider_registry_t* artifact_provider_registry,
+    const loom_target_environment_t* target_environment,
+    iree_string_view_t* out_format, loom_compile_producer_t* out_producer) {
+  explicit_format = iree_string_view_trim(explicit_format);
+  if (!iree_string_view_is_empty(explicit_format)) {
+    IREE_RETURN_IF_ERROR(loom_compile_request_select_named_format(
+        product, explicit_format, target_fact_type, artifact_provider_registry,
+        target_environment, out_producer));
+    *out_format = explicit_format;
+    return iree_ok_status();
+  }
+  switch (product) {
+    case LOOM_COMPILE_PRODUCT_INVALID:
+      break;
+    case LOOM_COMPILE_PRODUCT_KERNEL:
+      return loom_compile_request_select_canonical_kernel_format(
+          target_fact_type, artifact_provider_registry, out_format,
+          out_producer);
+    case LOOM_COMPILE_PRODUCT_COMMAND:
+      *out_format = IREE_SV("loom-command");
+      out_producer->kind = LOOM_COMPILE_PRODUCER_COMMAND;
+      return iree_ok_status();
+    case LOOM_COMPILE_PRODUCT_MODULE:
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "module product has no canonical format; pass --format");
+  }
+  return iree_make_status(IREE_STATUS_INTERNAL,
+                          "compile product selection is invalid");
+}
+
+iree_status_t loom_compile_request_resolve(
+    const loom_module_t* module, const loom_compile_request_options_t* options,
+    const loom_artifact_provider_registry_t* artifact_provider_registry,
+    const loom_target_environment_t* target_environment,
+    loom_compile_request_t* out_request) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(options);
+  IREE_ASSERT_ARGUMENT(artifact_provider_registry);
+  IREE_ASSERT_ARGUMENT(target_environment);
+  IREE_ASSERT_ARGUMENT(out_request);
+  *out_request = (loom_compile_request_t){0};
+
+  loom_compile_product_t explicit_product = LOOM_COMPILE_PRODUCT_INVALID;
+  IREE_RETURN_IF_ERROR(
+      loom_compile_request_parse_product(options->product, &explicit_product));
+  loom_compile_root_summary_t root_summary = {0};
+  IREE_RETURN_IF_ERROR(loom_compile_request_select_roots(
+      module, options->roots, explicit_product, &root_summary));
+
+  loom_artifact_target_t explicit_target = {0};
+  IREE_RETURN_IF_ERROR(loom_compile_request_select_explicit_target(
+      options->target, target_environment, &explicit_target));
+  if (explicit_target.target_profile != NULL &&
+      root_summary.product != LOOM_COMPILE_PRODUCT_KERNEL) {
+    const iree_string_view_t product_name =
+        loom_compile_product_name(root_summary.product);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "--target is not valid for product '%.*s'",
+                            (int)product_name.size, product_name.data);
+  }
+  if (explicit_target.target_profile != NULL &&
+      root_summary.target_fact_type != NULL &&
+      explicit_target.target_profile->type->fact_type !=
+          root_summary.target_fact_type) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "--target family '%.*s' cannot specialize roots authored for target "
+        "family '%.*s'",
+        (int)explicit_target.target_profile->type->name.size,
+        explicit_target.target_profile->type->name.data,
+        (int)root_summary.target_fact_type->name.size,
+        root_summary.target_fact_type->name.data);
+  }
+  const loom_target_fact_type_t* target_fact_type =
+      explicit_target.target_profile != NULL
+          ? explicit_target.target_profile->type->fact_type
+          : root_summary.target_fact_type;
+  if (root_summary.product == LOOM_COMPILE_PRODUCT_KERNEL &&
+      explicit_target.target_profile == NULL &&
+      root_summary.untargeted_kernel_count != 0) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "kernel product requires --target when %u selected kernel root%s "
+        "omit target(...) attrs",
+        (unsigned)root_summary.untargeted_kernel_count,
+        root_summary.untargeted_kernel_count == 1 ? "" : "s");
+  }
+  if (root_summary.product == LOOM_COMPILE_PRODUCT_KERNEL &&
+      target_fact_type == NULL) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "kernel product requires a target");
+  }
+  if (target_fact_type != NULL &&
+      loom_target_environment_lookup_fact_provider(target_environment,
+                                                   target_fact_type) == NULL) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "target family '%.*s' is not available in this binary",
+        (int)target_fact_type->name.size, target_fact_type->name.data);
+  }
+
+  loom_compile_request_t request = {
+      .product = root_summary.product,
+      .roots = options->roots,
+      .explicit_target = explicit_target,
+      .target_fact_type = target_fact_type,
+  };
+  IREE_RETURN_IF_ERROR(loom_compile_request_select_format(
+      request.product, options->format, request.target_fact_type,
+      artifact_provider_registry, target_environment, &request.format,
+      &request.producer));
+  *out_request = request;
+  return iree_ok_status();
+}

--- a/loom/src/loom/tools/loom-compile/request.h
+++ b/loom/src/loom/tools/loom-compile/request.h
@@ -1,0 +1,114 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Allocation-free loom-compile product and format request resolution.
+
+#ifndef LOOM_TOOLS_LOOM_COMPILE_REQUEST_H_
+#define LOOM_TOOLS_LOOM_COMPILE_REQUEST_H_
+
+#include "iree/base/api.h"
+#include "loom/ir/module.h"
+#include "loom/tooling/compile/artifact.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Semantic product inferred from the selected module roots.
+typedef enum loom_compile_product_e {
+  LOOM_COMPILE_PRODUCT_INVALID = 0,
+  LOOM_COMPILE_PRODUCT_KERNEL = 1,
+  LOOM_COMPILE_PRODUCT_COMMAND = 2,
+  LOOM_COMPILE_PRODUCT_MODULE = 3,
+} loom_compile_product_t;
+
+// Returns the stable public name of |product|.
+iree_string_view_t loom_compile_product_name(loom_compile_product_t product);
+
+// Concrete producer selected for one compile request.
+typedef enum loom_compile_producer_kind_e {
+  LOOM_COMPILE_PRODUCER_INVALID = 0,
+  LOOM_COMPILE_PRODUCER_COMMAND = 1,
+  LOOM_COMPILE_PRODUCER_ARTIFACT = 2,
+  LOOM_COMPILE_PRODUCER_TARGET_EMITTER = 3,
+} loom_compile_producer_kind_t;
+
+typedef struct loom_compile_producer_t {
+  // Active member of |value|.
+  loom_compile_producer_kind_t kind;
+
+  // Producer selected by |kind|.
+  union {
+    // Offline kernel artifact provider.
+    const loom_artifact_provider_t* artifact_provider;
+    // Target-owned diagnostic or intermediate emitter.
+    const loom_target_emitter_t* target_emitter;
+  } value;
+} loom_compile_producer_t;
+
+// User constraints applied while resolving one compilation request.
+typedef struct loom_compile_request_options_t {
+  // Explicit root names, or an empty list to use product root policy.
+  iree_string_view_list_t roots;
+  // Optional product selection or explicit-root assertion.
+  iree_string_view_t product;
+  // Optional exact artifact format.
+  iree_string_view_t format;
+  // Optional family-qualified target profile.
+  iree_string_view_t target;
+} loom_compile_request_options_t;
+
+// Fully resolved compile request borrowing immutable configured state.
+typedef struct loom_compile_request_t {
+  // Product inferred from selected roots.
+  loom_compile_product_t product;
+  // Explicit root names, or an empty list when product root policy applies.
+  iree_string_view_list_t roots;
+  // Exact public artifact format.
+  iree_string_view_t format;
+  // Producer implementing |format| for |product|.
+  loom_compile_producer_t producer;
+  // Explicit target selected by --target, or empty for authored targets.
+  loom_artifact_target_t explicit_target;
+  // Effective target fact type, or NULL for target-independent products.
+  const loom_target_fact_type_t* target_fact_type;
+} loom_compile_request_t;
+
+// Returns the selected artifact provider, or NULL for other producers.
+static inline const loom_artifact_provider_t*
+loom_compile_request_artifact_provider(const loom_compile_request_t* request) {
+  return request != NULL &&
+                 request->producer.kind == LOOM_COMPILE_PRODUCER_ARTIFACT
+             ? request->producer.value.artifact_provider
+             : NULL;
+}
+
+// Returns true when portable command emission was selected.
+static inline bool loom_compile_request_is_command(
+    const loom_compile_request_t* request) {
+  return request != NULL &&
+         request->producer.kind == LOOM_COMPILE_PRODUCER_COMMAND;
+}
+
+// Resolves roots, product, target, format, and producer exactly once.
+//
+// All inputs and outputs are borrowed. Resolution performs no allocation and
+// never probes a producer by compiling. With explicit roots, an explicit
+// product only validates the inferred product and cannot reinterpret them. With
+// no roots, an explicit product selects that product's canonical root policy.
+// An omitted format selects the unique configured kernel artifact provider for
+// the selected target or the target-independent command format.
+iree_status_t loom_compile_request_resolve(
+    const loom_module_t* module, const loom_compile_request_options_t* options,
+    const loom_artifact_provider_registry_t* artifact_provider_registry,
+    const loom_target_environment_t* target_environment,
+    loom_compile_request_t* out_request);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TOOLS_LOOM_COMPILE_REQUEST_H_

--- a/loom/src/loom/tools/loom-compile/request_test.cc
+++ b/loom/src/loom/tools/loom-compile/request_test.cc
@@ -1,0 +1,484 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tools/loom-compile/request.h"
+
+#include "iree/base/internal/arena.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "loom/format/text/parser.h"
+#include "loom/ir/context.h"
+#include "loom/ops/target/ops.h"
+#include "loom/testing/context.h"
+#include "loom/testing/module_ptr.h"
+
+namespace loom {
+namespace {
+
+using ModulePtr = ::loom::testing::ModulePtr;
+
+static const loom_target_snapshot_t kTargetSnapshot = {
+    /*.name=*/IREE_SVL("Snapshot123"),
+};
+static const loom_target_export_plan_t kTargetExportPlan = {
+    /*.name=*/IREE_SVL("ExportPlan123"),
+};
+static const loom_target_config_t kTargetConfig = {
+    /*.name=*/IREE_SVL("TargetConfig123"),
+};
+static const loom_target_bundle_t kTargetBundle = {
+    /*.name=*/IREE_SVL("TargetBundle123"),
+    /*.snapshot=*/&kTargetSnapshot,
+    /*.export_plan=*/&kTargetExportPlan,
+    /*.config=*/&kTargetConfig,
+};
+
+static iree_status_t ProjectTargetFacts(const loom_target_profile_t* profile,
+                                        iree_arena_allocator_t* arena,
+                                        loom_target_facts_t* out_facts) {
+  (void)profile;
+  (void)arena;
+  (void)out_facts;
+  return iree_ok_status();
+}
+
+static const loom_target_profile_type_t kTargetProfileType = {
+    /*.name=*/IREE_SVL("TargetFamily123"),
+    /*.fact_type=*/&loom_target_generic_fact_type,
+    /*.project_facts=*/ProjectTargetFacts,
+};
+static const loom_target_profile_t kTargetProfile = {
+    /*.type=*/&kTargetProfileType,
+    /*.target_bundle=*/&kTargetBundle,
+};
+static const loom_target_fact_type_t kOtherTargetFactType = {
+    /*.name=*/IREE_SVL("OtherTargetFamily123"),
+    /*.storage_size=*/sizeof(loom_target_facts_t),
+};
+static const loom_target_profile_type_t kOtherTargetProfileType = {
+    /*.name=*/IREE_SVL("OtherTargetFamily123"),
+    /*.fact_type=*/&kOtherTargetFactType,
+    /*.project_facts=*/ProjectTargetFacts,
+};
+
+static iree_status_t SelectTargetProfile(
+    iree_string_view_t selector, const loom_target_profile_t** out_profile) {
+  *out_profile = nullptr;
+  if (!iree_string_view_equal(selector, IREE_SV("Target456"))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "unknown synthetic target selector");
+  }
+  *out_profile = &kTargetProfile;
+  return iree_ok_status();
+}
+
+static iree_status_t EmitDiagnosticFormat(
+    const loom_target_emit_request_t* request,
+    loom_target_emit_artifact_t* out_artifact) {
+  (void)request;
+  *out_artifact = {};
+  return iree_ok_status();
+}
+
+static const loom_target_emitter_t kDiagnosticEmitter = {
+    /*.name=*/IREE_SVL("DiagnosticEmitter123"),
+    /*.public_artifact_format=*/IREE_SVL("DiagnosticFormat123"),
+    /*.default_identifier=*/IREE_SVL("diagnostic.out"),
+    /*.target_artifact_format=*/LOOM_TARGET_ARTIFACT_FORMAT_UNKNOWN,
+    /*.emit=*/EmitDiagnosticFormat,
+};
+static const loom_target_emitter_t* const kTargetEmitters[] = {
+    &kDiagnosticEmitter,
+};
+
+static const loom_artifact_provider_t kExecutableProvider = {
+    /*.name=*/IREE_SVL("Compiler123"),
+    /*.public_artifact_format=*/IREE_SVL("ExecutableFormat123"),
+    /*.flags=*/LOOM_ARTIFACT_PROVIDER_FLAG_CANONICAL,
+    /*.target_profile_type=*/&kTargetProfileType,
+};
+static const loom_artifact_provider_t kAlternateExecutableProvider = {
+    /*.name=*/IREE_SVL("AlternateCompiler123"),
+    /*.public_artifact_format=*/IREE_SVL("AlternateExecutableFormat123"),
+    /*.flags=*/0,
+    /*.target_profile_type=*/&kTargetProfileType,
+};
+static const loom_artifact_provider_t kDuplicateCanonicalProvider = {
+    /*.name=*/IREE_SVL("DuplicateCompiler123"),
+    /*.public_artifact_format=*/IREE_SVL("DuplicateExecutableFormat123"),
+    /*.flags=*/LOOM_ARTIFACT_PROVIDER_FLAG_CANONICAL,
+    /*.target_profile_type=*/&kTargetProfileType,
+};
+static const loom_artifact_provider_t kOtherExecutableProvider = {
+    /*.name=*/IREE_SVL("OtherCompiler123"),
+    /*.public_artifact_format=*/IREE_SVL("OtherExecutableFormat123"),
+    /*.flags=*/LOOM_ARTIFACT_PROVIDER_FLAG_CANONICAL,
+    /*.target_profile_type=*/&kOtherTargetProfileType,
+};
+
+class CompileRequestTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_arena_block_pool_initialize(4096, iree_allocator_system(),
+                                     &block_pool_);
+    loom_context_initialize(iree_allocator_system(), &context_);
+    IREE_ASSERT_OK(loom_testing_context_register_all_dialects(&context_));
+    IREE_ASSERT_OK(loom_context_finalize(&context_));
+    target_provider_.profile_type = &kTargetProfileType;
+    target_provider_.emitter_list = loom_target_emitter_list_make(
+        kTargetEmitters, IREE_ARRAYSIZE(kTargetEmitters));
+    target_provider_.target_fact_type = &loom_target_generic_fact_type;
+    target_provider_.select_profile = SelectTargetProfile;
+    target_providers_[0] = &target_provider_;
+    target_provider_set_ = loom_target_provider_set_make(target_providers_, 1);
+    IREE_ASSERT_OK(loom_target_environment_initialize(&target_provider_set_,
+                                                      &environment_));
+  }
+
+  void TearDown() override {
+    loom_target_environment_deinitialize(&environment_);
+    loom_context_deinitialize(&context_);
+    iree_arena_block_pool_deinitialize(&block_pool_);
+  }
+
+  ModulePtr Parse(const char* source) {
+    loom_module_t* module = nullptr;
+    loom_text_parse_options_t options = {};
+    IREE_EXPECT_OK(loom_text_parse(iree_make_cstring_view(source),
+                                   IREE_SV("request_test.loom"), &context_,
+                                   &block_pool_, &options, &module));
+    EXPECT_NE(module, nullptr);
+    return ModulePtr(module);
+  }
+
+  loom_compile_request_t Resolve(
+      const loom_module_t* module, loom_compile_request_options_t options,
+      const loom_artifact_provider_t* const* providers,
+      iree_host_size_t provider_count) {
+    const loom_artifact_provider_registry_t registry = {
+        /*.providers=*/providers,
+        /*.provider_count=*/provider_count,
+    };
+    loom_compile_request_t request = {};
+    IREE_EXPECT_OK(loom_compile_request_resolve(module, &options, &registry,
+                                                &environment_, &request));
+    return request;
+  }
+
+  static ModulePtr ParseKernel(CompileRequestTest* test, bool with_target) {
+    return with_target ? test->Parse(R"(
+target.generic<reference> @Target789 {
+  subgroup_size = 32
+}
+kernel.def target(@Target789) @Kernel123() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)")
+                       : test->Parse(R"(
+kernel.def @Kernel123() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+  }
+
+  iree_arena_block_pool_t block_pool_;
+  loom_context_t context_;
+  loom_target_provider_t target_provider_ = {};
+  const loom_target_provider_t* target_providers_[1] = {};
+  loom_target_provider_set_t target_provider_set_ = {};
+  loom_target_environment_t environment_;
+};
+
+TEST_F(CompileRequestTest, InfersKernelAndCanonicalFormat) {
+  ModulePtr module = ParseKernel(this, true);
+  const loom_artifact_provider_t* providers[] = {&kExecutableProvider};
+  const loom_compile_request_t request =
+      Resolve(module.get(), {}, providers, IREE_ARRAYSIZE(providers));
+
+  EXPECT_EQ(request.product, LOOM_COMPILE_PRODUCT_KERNEL);
+  EXPECT_TRUE(
+      iree_string_view_equal(request.format, IREE_SV("ExecutableFormat123")));
+  EXPECT_EQ(request.producer.kind, LOOM_COMPILE_PRODUCER_ARTIFACT);
+  EXPECT_EQ(request.producer.value.artifact_provider, &kExecutableProvider);
+  EXPECT_EQ(request.target_fact_type, &loom_target_generic_fact_type);
+  EXPECT_EQ(request.explicit_target.target_profile, nullptr);
+}
+
+TEST_F(CompileRequestTest, InfersPublicCommandBeforeKernelDependencies) {
+  ModulePtr module = Parse(R"(
+kernel.def @Kernel123() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+command.program.def public @Command123() launch() {
+  kernel.launch @Kernel123() : ()
+  command.return
+}
+)");
+  const loom_compile_request_t request = Resolve(module.get(), {}, nullptr, 0);
+
+  EXPECT_EQ(request.product, LOOM_COMPILE_PRODUCT_COMMAND);
+  EXPECT_TRUE(iree_string_view_equal(request.format, IREE_SV("loom-command")));
+  EXPECT_EQ(request.producer.kind, LOOM_COMPILE_PRODUCER_COMMAND);
+  EXPECT_EQ(request.target_fact_type, nullptr);
+}
+
+TEST_F(CompileRequestTest, RejectsMixedExplicitRootProducts) {
+  ModulePtr module = Parse(R"(
+kernel.def @Kernel123() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+command.program.def public @Command123() launch() {
+  command.return
+}
+)");
+  const iree_string_view_t roots[] = {
+      IREE_SV("@Kernel123"),
+      IREE_SV("@Command123"),
+  };
+  const loom_compile_request_options_t options = {
+      /*.roots=*/
+      {
+          /*.count=*/IREE_ARRAYSIZE(roots),
+          /*.values=*/roots,
+      },
+  };
+  const loom_artifact_provider_registry_t registry = {};
+  loom_compile_request_t request = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_compile_request_resolve(module.get(), &options, &registry,
+                                   &environment_, &request));
+}
+
+TEST_F(CompileRequestTest, ProductConstraintCannotReinterpretRoots) {
+  ModulePtr module = ParseKernel(this, true);
+  const loom_artifact_provider_t* providers[] = {&kExecutableProvider};
+  const loom_artifact_provider_registry_t registry = {
+      /*.providers=*/providers,
+      /*.provider_count=*/IREE_ARRAYSIZE(providers),
+  };
+  const iree_string_view_t roots[] = {IREE_SV("@Kernel123")};
+  const loom_compile_request_options_t options = {
+      /*.roots=*/
+      {
+          /*.count=*/IREE_ARRAYSIZE(roots),
+          /*.values=*/roots,
+      },
+      /*.product=*/IREE_SV("command"),
+  };
+  loom_compile_request_t request = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_compile_request_resolve(module.get(), &options, &registry,
+                                   &environment_, &request));
+}
+
+TEST_F(CompileRequestTest, ExplicitProductSelectsCanonicalRoots) {
+  ModulePtr module = Parse(R"(
+kernel.def @Kernel123() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+command.program.def public @Command123() launch() {
+  kernel.launch @Kernel123() : ()
+  command.return
+}
+)");
+  const loom_artifact_provider_t* providers[] = {&kExecutableProvider};
+  const loom_compile_request_options_t options = {
+      /*.roots=*/{},
+      /*.product=*/IREE_SV("kernel"),
+      /*.format=*/{},
+      /*.target=*/IREE_SV("TargetFamily123:Target456"),
+  };
+  const loom_compile_request_t request =
+      Resolve(module.get(), options, providers, IREE_ARRAYSIZE(providers));
+
+  EXPECT_EQ(request.product, LOOM_COMPILE_PRODUCT_KERNEL);
+  EXPECT_EQ(request.producer.value.artifact_provider, &kExecutableProvider);
+  EXPECT_EQ(request.explicit_target.target_profile, &kTargetProfile);
+}
+
+TEST_F(CompileRequestTest, RejectsUnknownProduct) {
+  ModulePtr module = ParseKernel(this, true);
+  const loom_artifact_provider_registry_t registry = {};
+  const loom_compile_request_options_t options = {
+      /*.roots=*/{},
+      /*.product=*/IREE_SV("Product123"),
+  };
+  loom_compile_request_t request = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_compile_request_resolve(module.get(), &options, &registry,
+                                   &environment_, &request));
+}
+
+TEST_F(CompileRequestTest, ModuleRequiresExplicitFormat) {
+  ModulePtr module = Parse(R"(
+func.def public @Function123() {
+  func.return
+}
+)");
+  const loom_artifact_provider_registry_t registry = {};
+  loom_compile_request_t request = {};
+  loom_compile_request_options_t options = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_compile_request_resolve(module.get(), &options, &registry,
+                                   &environment_, &request));
+
+  options.format = IREE_SV("DiagnosticFormat123");
+  IREE_ASSERT_OK(loom_compile_request_resolve(module.get(), &options, &registry,
+                                              &environment_, &request));
+  EXPECT_EQ(request.product, LOOM_COMPILE_PRODUCT_MODULE);
+  EXPECT_EQ(request.producer.kind, LOOM_COMPILE_PRODUCER_TARGET_EMITTER);
+  EXPECT_EQ(request.producer.value.target_emitter, &kDiagnosticEmitter);
+}
+
+TEST_F(CompileRequestTest, ExplicitTargetSpecializesUntargetedKernel) {
+  ModulePtr module = ParseKernel(this, false);
+  const loom_artifact_provider_t* providers[] = {&kExecutableProvider};
+  const loom_compile_request_options_t options = {
+      /*.roots=*/{},
+      /*.product=*/IREE_SV("kernel"),
+      /*.format=*/{},
+      /*.target=*/IREE_SV("TargetFamily123:Target456"),
+  };
+  const loom_compile_request_t request =
+      Resolve(module.get(), options, providers, IREE_ARRAYSIZE(providers));
+
+  EXPECT_EQ(request.explicit_target.target_profile, &kTargetProfile);
+  EXPECT_TRUE(iree_string_view_equal(request.explicit_target.target_key,
+                                     IREE_SV("Target456")));
+  EXPECT_EQ(request.target_fact_type, &loom_target_generic_fact_type);
+  EXPECT_EQ(request.producer.value.artifact_provider, &kExecutableProvider);
+}
+
+TEST_F(CompileRequestTest, ExplicitFormatMustMatchKernelTarget) {
+  ModulePtr module = ParseKernel(this, true);
+  const loom_artifact_provider_t* providers[] = {&kOtherExecutableProvider};
+  const loom_artifact_provider_registry_t registry = {
+      /*.providers=*/providers,
+      /*.provider_count=*/IREE_ARRAYSIZE(providers),
+  };
+  const loom_compile_request_options_t options = {
+      /*.roots=*/{},
+      /*.product=*/{},
+      /*.format=*/IREE_SV("OtherExecutableFormat123"),
+  };
+  loom_compile_request_t request = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_compile_request_resolve(module.get(), &options, &registry,
+                                   &environment_, &request));
+}
+
+TEST_F(CompileRequestTest, MissingOptionalKernelProviderFailsClosed) {
+  ModulePtr module = ParseKernel(this, true);
+  const loom_artifact_provider_registry_t registry = {};
+  const loom_compile_request_options_t options = {};
+  loom_compile_request_t request = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_compile_request_resolve(module.get(), &options, &registry,
+                                   &environment_, &request));
+}
+
+TEST_F(CompileRequestTest, MissingOptionalTargetFamilyFailsClosed) {
+  ModulePtr module = ParseKernel(this, true);
+  const loom_artifact_provider_t* providers[] = {&kExecutableProvider};
+  const loom_artifact_provider_registry_t registry = {
+      /*.providers=*/providers,
+      /*.provider_count=*/IREE_ARRAYSIZE(providers),
+  };
+  const loom_target_provider_set_t empty_provider_set =
+      loom_target_provider_set_make(nullptr, 0);
+  loom_target_environment_t empty_environment;
+  IREE_ASSERT_OK(loom_target_environment_initialize(&empty_provider_set,
+                                                    &empty_environment));
+
+  const loom_compile_request_options_t options = {};
+  loom_compile_request_t request = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_compile_request_resolve(module.get(), &options, &registry,
+                                   &empty_environment, &request));
+
+  loom_target_environment_deinitialize(&empty_environment);
+}
+
+TEST_F(CompileRequestTest, ExplicitFormatSelectsNoncanonicalAlternative) {
+  ModulePtr module = ParseKernel(this, true);
+  const loom_artifact_provider_t* providers[] = {
+      &kExecutableProvider,
+      &kAlternateExecutableProvider,
+  };
+  const loom_artifact_provider_registry_t registry = {
+      /*.providers=*/providers,
+      /*.provider_count=*/IREE_ARRAYSIZE(providers),
+  };
+  loom_compile_request_options_t options = {};
+  loom_compile_request_t request = {};
+  IREE_ASSERT_OK(loom_compile_request_resolve(module.get(), &options, &registry,
+                                              &environment_, &request));
+  EXPECT_EQ(request.producer.value.artifact_provider, &kExecutableProvider);
+
+  options.format = IREE_SV("AlternateExecutableFormat123");
+  IREE_ASSERT_OK(loom_compile_request_resolve(module.get(), &options, &registry,
+                                              &environment_, &request));
+  EXPECT_EQ(request.producer.value.artifact_provider,
+            &kAlternateExecutableProvider);
+}
+
+TEST_F(CompileRequestTest, RejectsMultipleCanonicalFormats) {
+  ModulePtr module = ParseKernel(this, true);
+  const loom_artifact_provider_t* providers[] = {
+      &kExecutableProvider,
+      &kDuplicateCanonicalProvider,
+  };
+  const loom_artifact_provider_registry_t registry = {
+      /*.providers=*/providers,
+      /*.provider_count=*/IREE_ARRAYSIZE(providers),
+  };
+  const loom_compile_request_options_t options = {};
+  loom_compile_request_t request = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_FAILED_PRECONDITION,
+      loom_compile_request_resolve(module.get(), &options, &registry,
+                                   &environment_, &request));
+}
+
+TEST_F(CompileRequestTest, DiagnosticFormatCanInspectKernelProduct) {
+  ModulePtr module = ParseKernel(this, true);
+  const loom_artifact_provider_registry_t registry = {};
+  const loom_compile_request_options_t options = {
+      /*.roots=*/{},
+      /*.product=*/IREE_SV("kernel"),
+      /*.format=*/IREE_SV("DiagnosticFormat123"),
+  };
+  loom_compile_request_t request = {};
+  IREE_ASSERT_OK(loom_compile_request_resolve(module.get(), &options, &registry,
+                                              &environment_, &request));
+  EXPECT_EQ(request.product, LOOM_COMPILE_PRODUCT_KERNEL);
+  EXPECT_EQ(request.producer.kind, LOOM_COMPILE_PRODUCER_TARGET_EMITTER);
+}
+
+}  // namespace
+}  // namespace loom


### PR DESCRIPTION
`loom-compile` now describes an offline artifact with orthogonal `--product`, `--target`, and `--format` options instead of selecting an overloaded compiler backend. The input roots determine what is compiled, the target names the machine or API contract, and the format names the output encoding. The old `--backend` flag is removed without an alias.

Explicit `--root` values must resolve to one homogeneous `kernel`, `command`, or `module` product. In that form, `--product` is an optional assertion and cannot reinterpret the roots. With no explicit roots, `--product` selects that product's canonical roots; with neither option, public command programs take precedence, followed by kernel entries and then the whole module. This preserves composite command packaging without turning a requested product into a hidden filter over explicit roots.

Artifact providers declare a public format and whether it is canonical for their target family. An omitted `--format` must resolve to exactly one compatible canonical format; an explicit format selects an exact linked producer. Resolution borrows immutable configured profiles, compares target-family type identities, performs no compiler probes, and allocates no selection state. Missing optional targets or formats fail instead of enabling or loading dependencies implicitly.

Typical invocations become:

```text
loom-compile kernel.loom --target=amdgpu:gfx11-generic --output=kernel.hsaco
loom-compile kernel.loom --target=spirv:vulkan1.3+bda --format=spirv-binary --output=kernel.spv
loom-compile model.loombc --product=command --output=commands.json --emit-command-artifacts=commands/
loom-compile kernel.loom --format=llvmir-text --output=kernel.ll
```

Bazel kernel and command product actions use the same product and format vocabulary. Direct compiler integrations, execution manifests, generated CMake metadata, workflow documentation, and runnable examples move with the CLI. Offline SPIR-V remains independent of the Vulkan HAL driver, and a target-free build of `loom-compile` continues to emit portable command artifacts.

## Reviewer notes

The central decision boundary is `loom/src/loom/tools/loom-compile/request.{h,c}`. Its tests use synthetic target and format identities and cover explicit-root validation, implicit product selection, canonical and alternate formats, missing optional providers, and ambiguous defaults.
