### PR TITLE
[Loom] Centralize offline compiler provider composition

### DIFF
--- a/loom/src/loom/target/arch/cmd/BUILD.bazel
+++ b/loom/src/loom/target/arch/cmd/BUILD.bazel
@@ -105,6 +105,7 @@ loom_cc_library(
     visibility = [
         "//loom/src/loom/target/all:__pkg__",
         "//loom/src/loom/target/arch/cmd/check:__pkg__",
+        "//loom/src/loom/tooling/compile:__pkg__",
         "//loom/src/loom/tools/loom-compile:__pkg__",
         "//loom/src/loom/tools/loom-format:__pkg__",
     ],

--- a/loom/src/loom/target/configured/BUILD.bazel
+++ b/loom/src/loom/target/configured/BUILD.bazel
@@ -83,16 +83,31 @@ _CONFIGURED_TARGET_DEPS = (
 )
 
 loom_cc_library(
-    name = "provider",
-    srcs = ["provider.c"],
-    hdrs = ["provider.h"],
+    name = "provider_set",
+    srcs = ["provider_set.c"],
+    hdrs = ["provider_set.h"],
     copts = _CONFIGURED_TARGET_COPTS,
-    visibility = ["//loom/src/loom/tools:__subpackages__"],
+    visibility = [
+        "//loom/src/loom/tooling/compile:__pkg__",
+        "//loom/src/loom/tools:__subpackages__",
+    ],
     deps = [
         "//loom/src/loom/target:provider",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/threading",
     ] + _CONFIGURED_TARGET_DEPS,
+)
+
+loom_cc_library(
+    name = "provider",
+    srcs = ["provider.c"],
+    hdrs = ["provider.h"],
+    visibility = ["//loom/src/loom/tools:__subpackages__"],
+    deps = [
+        ":provider_set",
+        "//loom/src/loom/target:provider",
+        "//runtime/src/iree/base/threading",
+    ],
 )
 
 loom_cc_library(

--- a/loom/src/loom/target/configured/CMakeLists.txt
+++ b/loom/src/loom/target/configured/CMakeLists.txt
@@ -9,52 +9,66 @@
 
 iree_add_all_subdirs()
 
-set(_provider_platform_copts "")
+set(_provider_set_platform_copts "")
 if(LOOM_TARGET_ARCH_AMDGPU)
-  list(APPEND _provider_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_AMDGPU=1")
+  list(APPEND _provider_set_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_AMDGPU=1")
 endif()
 if(LOOM_TARGET_ARCH_LLVMIR)
-  list(APPEND _provider_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_LLVMIR=1")
+  list(APPEND _provider_set_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_LLVMIR=1")
 endif()
 if(LOOM_TARGET_ARCH_SPIRV)
-  list(APPEND _provider_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_SPIRV=1")
+  list(APPEND _provider_set_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_SPIRV=1")
 endif()
 if(LOOM_TARGET_ARCH_WASM)
-  list(APPEND _provider_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_WASM=1")
+  list(APPEND _provider_set_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_WASM=1")
 endif()
 if(LOOM_TARGET_ARCH_X86)
-  list(APPEND _provider_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_X86=1")
+  list(APPEND _provider_set_platform_copts "-DLOOM_CONFIG_TARGET_HAVE_X86=1")
 endif()
-set(_provider_platform_deps "")
+set(_provider_set_platform_deps "")
 if(LOOM_TARGET_ARCH_AMDGPU)
-  list(APPEND _provider_platform_deps loom::target::arch::amdgpu::provider)
+  list(APPEND _provider_set_platform_deps loom::target::arch::amdgpu::provider)
 endif()
 if(LOOM_TARGET_ARCH_LLVMIR)
-  list(APPEND _provider_platform_deps loom::target::arch::llvmir::provider)
+  list(APPEND _provider_set_platform_deps loom::target::arch::llvmir::provider)
 endif()
 if(LOOM_TARGET_ARCH_SPIRV)
-  list(APPEND _provider_platform_deps loom::target::arch::spirv::provider)
+  list(APPEND _provider_set_platform_deps loom::target::arch::spirv::provider)
 endif()
 if(LOOM_TARGET_ARCH_WASM)
-  list(APPEND _provider_platform_deps loom::target::arch::wasm::provider)
+  list(APPEND _provider_set_platform_deps loom::target::arch::wasm::provider)
 endif()
 if(LOOM_TARGET_ARCH_X86)
-  list(APPEND _provider_platform_deps loom::target::arch::x86::provider)
+  list(APPEND _provider_set_platform_deps loom::target::arch::x86::provider)
 endif()
 loom_cc_library(
   NAME
-    provider
+    provider_set
   COPTS
-    ${_provider_platform_copts}
+    ${_provider_set_platform_copts}
+  HDRS
+    "provider_set.h"
+  SRCS
+    "provider_set.c"
+  DEPS
+    iree::base
+    iree::base::threading
+    loom::target::provider
+    ${_provider_set_platform_deps}
+  PUBLIC
+)
+
+loom_cc_library(
+  NAME
+    provider
   HDRS
     "provider.h"
   SRCS
     "provider.c"
   DEPS
-    iree::base
+    ::provider_set
     iree::base::threading
     loom::target::provider
-    ${_provider_platform_deps}
   PUBLIC
 )
 

--- a/loom/src/loom/target/configured/provider.c
+++ b/loom/src/loom/target/configured/provider.c
@@ -8,83 +8,12 @@
 
 #include "iree/base/threading/call_once.h"
 
-#ifndef LOOM_CONFIG_TARGET_HAVE_AMDGPU
-#define LOOM_CONFIG_TARGET_HAVE_AMDGPU 0
-#endif  // LOOM_CONFIG_TARGET_HAVE_AMDGPU
-#ifndef LOOM_CONFIG_TARGET_HAVE_LLVMIR
-#define LOOM_CONFIG_TARGET_HAVE_LLVMIR 0
-#endif  // LOOM_CONFIG_TARGET_HAVE_LLVMIR
-#ifndef LOOM_CONFIG_TARGET_HAVE_SPIRV
-#define LOOM_CONFIG_TARGET_HAVE_SPIRV 0
-#endif  // LOOM_CONFIG_TARGET_HAVE_SPIRV
-#ifndef LOOM_CONFIG_TARGET_HAVE_WASM
-#define LOOM_CONFIG_TARGET_HAVE_WASM 0
-#endif  // LOOM_CONFIG_TARGET_HAVE_WASM
-#ifndef LOOM_CONFIG_TARGET_HAVE_X86
-#define LOOM_CONFIG_TARGET_HAVE_X86 0
-#endif  // LOOM_CONFIG_TARGET_HAVE_X86
-
-#define LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER                           \
-  (LOOM_CONFIG_TARGET_HAVE_AMDGPU || LOOM_CONFIG_TARGET_HAVE_LLVMIR || \
-   LOOM_CONFIG_TARGET_HAVE_SPIRV || LOOM_CONFIG_TARGET_HAVE_WASM ||    \
-   LOOM_CONFIG_TARGET_HAVE_X86)
-
-#if LOOM_CONFIG_TARGET_HAVE_AMDGPU
-#include "loom/target/arch/amdgpu/provider.h"
-#endif  // LOOM_CONFIG_TARGET_HAVE_AMDGPU
-#if LOOM_CONFIG_TARGET_HAVE_LLVMIR
-#include "loom/target/arch/llvmir/provider.h"
-#endif  // LOOM_CONFIG_TARGET_HAVE_LLVMIR
-#if LOOM_CONFIG_TARGET_HAVE_SPIRV
-#include "loom/target/arch/spirv/provider.h"
-#endif  // LOOM_CONFIG_TARGET_HAVE_SPIRV
-#if LOOM_CONFIG_TARGET_HAVE_WASM
-#include "loom/target/arch/wasm/provider.h"
-#endif  // LOOM_CONFIG_TARGET_HAVE_WASM
-#if LOOM_CONFIG_TARGET_HAVE_X86
-#include "loom/target/arch/x86/provider.h"
-#endif  // LOOM_CONFIG_TARGET_HAVE_X86
-
-#if LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER
-static const loom_target_provider_t* const kConfiguredTargetProviders[] = {
-#if LOOM_CONFIG_TARGET_HAVE_AMDGPU
-    &loom_amdgpu_target_provider,
-#endif  // LOOM_CONFIG_TARGET_HAVE_AMDGPU
-#if LOOM_CONFIG_TARGET_HAVE_LLVMIR
-    &loom_llvmir_target_provider,
-#endif  // LOOM_CONFIG_TARGET_HAVE_LLVMIR
-#if LOOM_CONFIG_TARGET_HAVE_SPIRV
-    &loom_spirv_target_provider,
-#endif  // LOOM_CONFIG_TARGET_HAVE_SPIRV
-#if LOOM_CONFIG_TARGET_HAVE_WASM
-    &loom_wasm_target_provider,
-#endif  // LOOM_CONFIG_TARGET_HAVE_WASM
-#if LOOM_CONFIG_TARGET_HAVE_X86
-    &loom_x86_target_provider,
-#endif  // LOOM_CONFIG_TARGET_HAVE_X86
-};
-#endif  // LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER
-
-static const loom_target_provider_set_t kConfiguredTargetProviderSet = {
-#if LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER
-    .providers = kConfiguredTargetProviders,
-    .provider_count = IREE_ARRAYSIZE(kConfiguredTargetProviders),
-#else
-    .providers = NULL,
-    .provider_count = 0,
-#endif  // LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER
-};
-
 static loom_target_environment_t configured_target_environment;
 static iree_once_flag configured_target_environment_once = IREE_ONCE_FLAG_INIT;
 
 static void loom_configured_target_environment_initialize_once(void) {
   IREE_CHECK_OK(loom_target_environment_initialize(
-      &kConfiguredTargetProviderSet, &configured_target_environment));
-}
-
-const loom_target_provider_set_t* loom_configured_target_provider_set(void) {
-  return &kConfiguredTargetProviderSet;
+      loom_configured_target_provider_set(), &configured_target_environment));
 }
 
 const loom_target_environment_t* loom_configured_target_environment(void) {

--- a/loom/src/loom/target/configured/provider.h
+++ b/loom/src/loom/target/configured/provider.h
@@ -4,19 +4,16 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Configured target provider set selected by //loom/config/target.
+// Composed target environment selected by //loom/config/target.
 
 #ifndef LOOM_TARGET_CONFIGURED_PROVIDER_H_
 #define LOOM_TARGET_CONFIGURED_PROVIDER_H_
 
-#include "loom/target/provider.h"
+#include "loom/target/configured/provider_set.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// Returns the static configured target provider set.
-const loom_target_provider_set_t* loom_configured_target_provider_set(void);
 
 // Returns the lazily-composed configured target environment.
 const loom_target_environment_t* loom_configured_target_environment(void);

--- a/loom/src/loom/target/configured/provider_set.c
+++ b/loom/src/loom/target/configured/provider_set.c
@@ -1,0 +1,78 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/configured/provider_set.h"
+
+#ifndef LOOM_CONFIG_TARGET_HAVE_AMDGPU
+#define LOOM_CONFIG_TARGET_HAVE_AMDGPU 0
+#endif  // LOOM_CONFIG_TARGET_HAVE_AMDGPU
+#ifndef LOOM_CONFIG_TARGET_HAVE_LLVMIR
+#define LOOM_CONFIG_TARGET_HAVE_LLVMIR 0
+#endif  // LOOM_CONFIG_TARGET_HAVE_LLVMIR
+#ifndef LOOM_CONFIG_TARGET_HAVE_SPIRV
+#define LOOM_CONFIG_TARGET_HAVE_SPIRV 0
+#endif  // LOOM_CONFIG_TARGET_HAVE_SPIRV
+#ifndef LOOM_CONFIG_TARGET_HAVE_WASM
+#define LOOM_CONFIG_TARGET_HAVE_WASM 0
+#endif  // LOOM_CONFIG_TARGET_HAVE_WASM
+#ifndef LOOM_CONFIG_TARGET_HAVE_X86
+#define LOOM_CONFIG_TARGET_HAVE_X86 0
+#endif  // LOOM_CONFIG_TARGET_HAVE_X86
+
+#define LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER                           \
+  (LOOM_CONFIG_TARGET_HAVE_AMDGPU || LOOM_CONFIG_TARGET_HAVE_LLVMIR || \
+   LOOM_CONFIG_TARGET_HAVE_SPIRV || LOOM_CONFIG_TARGET_HAVE_WASM ||    \
+   LOOM_CONFIG_TARGET_HAVE_X86)
+
+#if LOOM_CONFIG_TARGET_HAVE_AMDGPU
+#include "loom/target/arch/amdgpu/provider.h"
+#endif  // LOOM_CONFIG_TARGET_HAVE_AMDGPU
+#if LOOM_CONFIG_TARGET_HAVE_LLVMIR
+#include "loom/target/arch/llvmir/provider.h"
+#endif  // LOOM_CONFIG_TARGET_HAVE_LLVMIR
+#if LOOM_CONFIG_TARGET_HAVE_SPIRV
+#include "loom/target/arch/spirv/provider.h"
+#endif  // LOOM_CONFIG_TARGET_HAVE_SPIRV
+#if LOOM_CONFIG_TARGET_HAVE_WASM
+#include "loom/target/arch/wasm/provider.h"
+#endif  // LOOM_CONFIG_TARGET_HAVE_WASM
+#if LOOM_CONFIG_TARGET_HAVE_X86
+#include "loom/target/arch/x86/provider.h"
+#endif  // LOOM_CONFIG_TARGET_HAVE_X86
+
+#if LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER
+static const loom_target_provider_t* const kConfiguredTargetProviders[] = {
+#if LOOM_CONFIG_TARGET_HAVE_AMDGPU
+    &loom_amdgpu_target_provider,
+#endif  // LOOM_CONFIG_TARGET_HAVE_AMDGPU
+#if LOOM_CONFIG_TARGET_HAVE_LLVMIR
+    &loom_llvmir_target_provider,
+#endif  // LOOM_CONFIG_TARGET_HAVE_LLVMIR
+#if LOOM_CONFIG_TARGET_HAVE_SPIRV
+    &loom_spirv_target_provider,
+#endif  // LOOM_CONFIG_TARGET_HAVE_SPIRV
+#if LOOM_CONFIG_TARGET_HAVE_WASM
+    &loom_wasm_target_provider,
+#endif  // LOOM_CONFIG_TARGET_HAVE_WASM
+#if LOOM_CONFIG_TARGET_HAVE_X86
+    &loom_x86_target_provider,
+#endif  // LOOM_CONFIG_TARGET_HAVE_X86
+};
+#endif  // LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER
+
+static const loom_target_provider_set_t kConfiguredTargetProviderSet = {
+#if LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER
+    .providers = kConfiguredTargetProviders,
+    .provider_count = IREE_ARRAYSIZE(kConfiguredTargetProviders),
+#else
+    .providers = NULL,
+    .provider_count = 0,
+#endif  // LOOM_CONFIG_TARGET_HAVE_ANY_PROVIDER
+};
+
+const loom_target_provider_set_t* loom_configured_target_provider_set(void) {
+  return &kConfiguredTargetProviderSet;
+}

--- a/loom/src/loom/target/configured/provider_set.h
+++ b/loom/src/loom/target/configured/provider_set.h
@@ -1,0 +1,25 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Target provider set selected by //loom/config/target.
+
+#ifndef LOOM_TARGET_CONFIGURED_PROVIDER_SET_H_
+#define LOOM_TARGET_CONFIGURED_PROVIDER_SET_H_
+
+#include "loom/target/provider.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Returns the immutable configured target provider set.
+const loom_target_provider_set_t* loom_configured_target_provider_set(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TARGET_CONFIGURED_PROVIDER_SET_H_

--- a/loom/src/loom/target/emit/llvmir/BUILD.bazel
+++ b/loom/src/loom/target/emit/llvmir/BUILD.bazel
@@ -6,6 +6,7 @@
 
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
+    "iree_select",
     "loom_cc_library",
     "loom_cc_test",
     "loom_config_compatible_with",
@@ -41,6 +42,36 @@ _LLVMIR_TARGET_SCENARIOS_COMPATIBLE_WITH = loom_config_compatible_with([
 _LLVMIR_X86_TARGET_ENV_COMPATIBLE_WITH = loom_config_compatible_with([
     "//loom/config/target/arch:x86",
 ])
+
+_CONFIGURED_TARGET_PROFILE_COPTS = (
+    iree_select({
+        "//loom/config/target:llvmir_amdgpu_target_env": [
+            "-DLOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES=1",
+        ],
+        "//conditions:default": [],
+    }) +
+    iree_select({
+        "//loom/config/target:llvmir_x86_target_env": [
+            "-DLOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES=1",
+        ],
+        "//conditions:default": [],
+    })
+)
+
+_CONFIGURED_TARGET_PROFILE_DEPS = (
+    iree_select({
+        "//loom/config/target:llvmir_amdgpu_target_env": [
+            "//loom/src/loom/target/emit/llvmir/amdgpu:target_env",
+        ],
+        "//conditions:default": [],
+    }) +
+    iree_select({
+        "//loom/config/target:llvmir_x86_target_env": [
+            "//loom/src/loom/target/emit/llvmir/x86:target_env",
+        ],
+        "//conditions:default": [],
+    })
+)
 
 #===------------------------------------------------------------------------===#
 # Target-neutral LLVMIR core
@@ -107,6 +138,28 @@ loom_cc_library(
 )
 
 loom_cc_library(
+    name = "configured_target_profiles",
+    srcs = ["configured_target_profiles.c"],
+    hdrs = ["configured_target_profiles.h"],
+    copts = _CONFIGURED_TARGET_PROFILE_COPTS,
+    deps = [
+        ":target_presets",
+        "//runtime/src/iree/base",
+    ] + _CONFIGURED_TARGET_PROFILE_DEPS,
+)
+
+loom_cc_test(
+    name = "configured_target_profiles_test",
+    srcs = ["configured_target_profiles_test.cc"],
+    copts = _CONFIGURED_TARGET_PROFILE_COPTS,
+    deps = [
+        ":configured_target_profiles",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_library(
     name = "module_emitter",
     srcs = ["module_emitter.c"],
     hdrs = ["module_emitter.h"],
@@ -142,6 +195,7 @@ loom_cc_library(
     hdrs = ["artifact_emitter.h"],
     visibility = _LLVMIR_ARTIFACT_EMITTER_VISIBILITY,
     deps = [
+        ":configured_target_profiles",
         ":core",
         ":module_emitter",
         ":target_presets",
@@ -189,6 +243,7 @@ loom_cc_library(
     hdrs = ["check/loom_check.h"],
     visibility = _LLVMIR_LOOM_CHECK_VISIBILITY,
     deps = [
+        ":configured_target_profiles",
         ":core",
         ":module_emitter",
         ":target_env",

--- a/loom/src/loom/target/emit/llvmir/BUILD.bazel
+++ b/loom/src/loom/target/emit/llvmir/BUILD.bazel
@@ -24,6 +24,7 @@ package(
 
 _LLVMIR_ARTIFACT_EMITTER_VISIBILITY = [
     "//loom/binding/c/target/llvmir:__pkg__",
+    "//loom/src/loom/tooling/compile:__pkg__",
     "//loom/src/loom/tools/loom-compile:__pkg__",
 ]
 

--- a/loom/src/loom/target/emit/llvmir/CMakeLists.txt
+++ b/loom/src/loom/target/emit/llvmir/CMakeLists.txt
@@ -78,6 +78,63 @@ loom_cc_library(
 endif()
 
 if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR)
+set(_configured_target_profiles_platform_copts "")
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_AMDGPU)
+  list(APPEND _configured_target_profiles_platform_copts "-DLOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES=1")
+endif()
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_X86)
+  list(APPEND _configured_target_profiles_platform_copts "-DLOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES=1")
+endif()
+set(_configured_target_profiles_platform_deps "")
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_AMDGPU)
+  list(APPEND _configured_target_profiles_platform_deps loom::target::emit::llvmir::amdgpu::target_env)
+endif()
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_X86)
+  list(APPEND _configured_target_profiles_platform_deps loom::target::emit::llvmir::x86::target_env)
+endif()
+loom_cc_library(
+  NAME
+    configured_target_profiles
+  COPTS
+    ${_configured_target_profiles_platform_copts}
+  HDRS
+    "configured_target_profiles.h"
+  SRCS
+    "configured_target_profiles.c"
+  DEPS
+    ::target_presets
+    iree::base
+    ${_configured_target_profiles_platform_deps}
+  PUBLIC
+)
+endif()
+
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR)
+set(_configured_target_profiles_test_platform_copts "")
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_AMDGPU)
+  list(APPEND _configured_target_profiles_test_platform_copts "-DLOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES=1")
+endif()
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_X86)
+  list(APPEND _configured_target_profiles_test_platform_copts "-DLOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES=1")
+endif()
+loom_cc_test(
+  NAME
+    configured_target_profiles_test
+  SRCS
+    "configured_target_profiles_test.cc"
+  COPTS
+    ${_configured_target_profiles_test_platform_copts}
+  DEPS
+    ::configured_target_profiles
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "iree-build-requirement=loom.target.arch.llvmir"
+    "iree-build-requirement=loom.emit.llvmir"
+)
+endif()
+
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR)
 loom_cc_library(
   NAME
     module_emitter
@@ -121,6 +178,7 @@ loom_cc_library(
   SRCS
     "artifact_emitter.c"
   DEPS
+    ::configured_target_profiles
     ::core
     ::module_emitter
     ::target_presets
@@ -182,6 +240,7 @@ loom_cc_library(
   SRCS
     "check/loom_check.c"
   DEPS
+    ::configured_target_profiles
     ::core
     ::module_emitter
     ::target_env

--- a/loom/src/loom/target/emit/llvmir/amdgpu/target_env.c
+++ b/loom/src/loom/target/emit/llvmir/amdgpu/target_env.c
@@ -171,8 +171,8 @@ static bool loom_llvmir_amdgpu_project_bundle(
   return true;
 }
 
-static const loom_llvmir_target_profile_provider_t
-    kAmdgpuTargetProfileProvider = {
+const loom_llvmir_target_profile_provider_t
+    loom_llvmir_amdgpu_target_profile_provider = {
         .name = IREE_SVL("amdgpu"),
         .profiles = kAmdgpuTargetProfiles,
         .profile_count = IREE_ARRAYSIZE(kAmdgpuTargetProfiles),
@@ -191,11 +191,6 @@ const loom_llvmir_target_env_t* loom_llvmir_target_env_amdgcn_amd_amdhsa(void) {
 const loom_llvmir_target_profile_t* loom_llvmir_target_profile_amdgpu_hal(
     void) {
   return &kAmdgpuHalProfile;
-}
-
-const loom_llvmir_target_profile_provider_t*
-loom_llvmir_amdgpu_target_profile_provider(void) {
-  return &kAmdgpuTargetProfileProvider;
 }
 
 iree_status_t loom_llvmir_target_profile_initialize_amdgpu_hal(

--- a/loom/src/loom/target/emit/llvmir/amdgpu/target_env.h
+++ b/loom/src/loom/target/emit/llvmir/amdgpu/target_env.h
@@ -29,9 +29,9 @@ const loom_target_bundle_t* loom_llvmir_target_bundle_amdgpu_hal(void);
 iree_status_t loom_llvmir_target_profile_initialize_amdgpu_hal(
     loom_llvmir_target_profile_t* out_profile);
 
-// Returns the static profile provider for AMDGPU LLVMIR target presets.
-const loom_llvmir_target_profile_provider_t*
-loom_llvmir_amdgpu_target_profile_provider(void);
+// Static profile provider for AMDGPU LLVMIR target presets.
+extern const loom_llvmir_target_profile_provider_t
+    loom_llvmir_amdgpu_target_profile_provider;
 
 #ifdef __cplusplus
 }

--- a/loom/src/loom/target/emit/llvmir/amdgpu/target_env_test.cc
+++ b/loom/src/loom/target/emit/llvmir/amdgpu/target_env_test.cc
@@ -227,7 +227,7 @@ TEST(LlvmIrAmdgpuTargetEnvTest,
   };
 
   const loom_llvmir_target_profile_provider_t* provider =
-      loom_llvmir_amdgpu_target_profile_provider();
+      &loom_llvmir_amdgpu_target_profile_provider;
   const loom_llvmir_target_profile_t* profile = nullptr;
   loom_llvmir_target_profile_projection_request_t request = {
       /*.bundle=*/&kBundle,

--- a/loom/src/loom/target/emit/llvmir/artifact_emitter.c
+++ b/loom/src/loom/target/emit/llvmir/artifact_emitter.c
@@ -8,6 +8,7 @@
 
 #include "iree/io/vec_stream.h"
 #include "loom/target/emit/llvmir/bitcode_writer.h"
+#include "loom/target/emit/llvmir/configured_target_profiles.h"
 #include "loom/target/emit/llvmir/module_emitter.h"
 #include "loom/target/emit/llvmir/text_writer.h"
 #include "loom/target/emit/llvmir/verify.h"
@@ -17,50 +18,6 @@ typedef enum loom_llvmir_artifact_emitter_format_e {
   LOOM_LLVMIR_ARTIFACT_EMITTER_FORMAT_TEXT = 0,
   LOOM_LLVMIR_ARTIFACT_EMITTER_FORMAT_BITCODE = 1,
 } loom_llvmir_artifact_emitter_format_t;
-
-typedef struct loom_llvmir_artifact_emitter_option_prefix_t {
-  // Option descriptor type.
-  uint32_t type;
-  // Size of this structure in bytes.
-  iree_host_size_t structure_size;
-  // Next emitter option descriptor.
-  const void* next;
-} loom_llvmir_artifact_emitter_option_prefix_t;
-
-void loom_llvmir_artifact_emitter_options_initialize(
-    loom_llvmir_artifact_emitter_options_t* out_options) {
-  *out_options = (loom_llvmir_artifact_emitter_options_t){
-      .type = LOOM_LLVMIR_ARTIFACT_EMITTER_OPTION_TYPE_OPTIONS,
-      .structure_size = sizeof(*out_options),
-  };
-}
-
-static iree_status_t loom_llvmir_artifact_emitter_options_resolve(
-    const void* option_chain,
-    loom_llvmir_emit_low_module_options_t* out_options) {
-  loom_llvmir_emit_low_module_options_initialize(out_options);
-  const void* node = option_chain;
-  while (node != NULL) {
-    const loom_llvmir_artifact_emitter_option_prefix_t* prefix =
-        (const loom_llvmir_artifact_emitter_option_prefix_t*)node;
-    if (prefix->type == LOOM_LLVMIR_ARTIFACT_EMITTER_OPTION_TYPE_OPTIONS) {
-      if (prefix->structure_size != 0 &&
-          prefix->structure_size <
-              sizeof(loom_llvmir_artifact_emitter_options_t)) {
-        return iree_make_status(
-            IREE_STATUS_INVALID_ARGUMENT,
-            "LLVMIR artifact emitter options structure_size is too small");
-      }
-      const loom_llvmir_artifact_emitter_options_t* options =
-          (const loom_llvmir_artifact_emitter_options_t*)node;
-      out_options->target_profile_registry = options->target_profile_registry;
-      node = options->next;
-      continue;
-    }
-    node = prefix->next;
-  }
-  return iree_ok_status();
-}
 
 static iree_status_t loom_llvmir_artifact_write_text(
     const loom_llvmir_module_t* module, iree_allocator_t allocator,
@@ -128,8 +85,9 @@ static iree_status_t loom_llvmir_artifact_emit(
 
   loom_llvmir_module_t* module = NULL;
   loom_llvmir_emit_low_module_options_t emit_options = {0};
-  IREE_RETURN_IF_ERROR(loom_llvmir_artifact_emitter_options_resolve(
-      request->option_chain, &emit_options));
+  loom_llvmir_emit_low_module_options_initialize(&emit_options);
+  emit_options.target_profile_registry =
+      &loom_llvmir_configured_target_profile_registry;
   emit_options.function_versions = request->function_versions;
   iree_status_t status = loom_llvmir_emit_low_module(
       request->module, request->low_descriptor_registry,

--- a/loom/src/loom/target/emit/llvmir/artifact_emitter.h
+++ b/loom/src/loom/target/emit/llvmir/artifact_emitter.h
@@ -14,30 +14,11 @@
 #ifndef LOOM_TARGET_EMIT_LLVMIR_ARTIFACT_EMITTER_H_
 #define LOOM_TARGET_EMIT_LLVMIR_ARTIFACT_EMITTER_H_
 
-#include "loom/target/emit/llvmir/target_presets.h"
 #include "loom/target/provider.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef enum loom_llvmir_artifact_emitter_option_type_e {
-  LOOM_LLVMIR_ARTIFACT_EMITTER_OPTION_TYPE_OPTIONS = 0x4C4C564D,
-} loom_llvmir_artifact_emitter_option_type_t;
-
-typedef struct loom_llvmir_artifact_emitter_options_t {
-  // Option descriptor type.
-  loom_llvmir_artifact_emitter_option_type_t type;
-  // Size of this structure in bytes.
-  iree_host_size_t structure_size;
-  // Next emitter option descriptor.
-  const void* next;
-  // Optional registry of linked target profiles for kernel projection.
-  const loom_llvmir_target_profile_registry_t* target_profile_registry;
-} loom_llvmir_artifact_emitter_options_t;
-
-void loom_llvmir_artifact_emitter_options_initialize(
-    loom_llvmir_artifact_emitter_options_t* out_options);
 
 // Provider contribution containing LLVMIR text and bitcode artifact emitters.
 extern const loom_target_provider_t loom_llvmir_artifact_emitter_provider;

--- a/loom/src/loom/target/emit/llvmir/check/loom_check.c
+++ b/loom/src/loom/target/emit/llvmir/check/loom_check.c
@@ -13,6 +13,7 @@
 #include "loom/ops/target/facts.h"
 #include "loom/target/arch/llvmir/facts.h"
 #include "loom/target/emit/llvmir/bitcode_writer.h"
+#include "loom/target/emit/llvmir/configured_target_profiles.h"
 #include "loom/target/emit/llvmir/module_emitter.h"
 #include "loom/target/emit/llvmir/target_env.h"
 #include "loom/target/emit/llvmir/text_writer.h"
@@ -75,7 +76,7 @@ static iree_status_t loom_llvmir_loom_check_require_declared_requirement(
                                                          requirement, result);
 }
 
-iree_status_t loom_llvmir_loom_check_emit_provider_check_requirements(
+static iree_status_t loom_llvmir_loom_check_emit_provider_check_requirements(
     const loom_check_emit_provider_t* provider,
     const loom_test_case_t* test_case, loom_check_result_t* result,
     bool* out_continue_execution) {
@@ -98,7 +99,7 @@ iree_status_t loom_llvmir_loom_check_emit_provider_check_requirements(
   return iree_ok_status();
 }
 
-bool loom_llvmir_loom_check_emit_provider_matches(
+static bool loom_llvmir_loom_check_emit_provider_matches(
     const loom_check_emit_provider_t* provider,
     iree_string_view_t target_name) {
   return iree_string_view_equal(target_name, IREE_SV("llvmir")) ||
@@ -467,11 +468,10 @@ static iree_status_t loom_llvmir_loom_check_prepare_low_module(
       request->diagnostic_collector, request->block_pool);
 }
 
-iree_status_t loom_llvmir_loom_check_emit_provider_execute(
+static iree_status_t loom_llvmir_loom_check_emit_provider_execute(
     const loom_check_emit_provider_t* provider,
     const loom_check_emit_provider_request_t* request) {
-  const loom_llvmir_loom_check_emit_provider_t* llvmir_provider =
-      (const loom_llvmir_loom_check_emit_provider_t*)provider;
+  (void)provider;
   loom_llvmir_loom_check_emit_format_t format;
   IREE_RETURN_IF_ERROR(
       loom_llvmir_loom_check_parse_emit_format(request->target_name, &format));
@@ -495,50 +495,17 @@ iree_status_t loom_llvmir_loom_check_emit_provider_execute(
       .emitter = LOOM_EMITTER_PASS,
   };
   loom_llvmir_module_t* lowered_module = NULL;
-  const loom_llvmir_target_profile_provider_t** target_profile_providers = NULL;
-  loom_llvmir_target_profile_registry_t target_profile_registry = {0};
-  iree_status_t status = iree_ok_status();
-  if (llvmir_provider->target_profile_provider_function_count != 0) {
-    const iree_host_size_t byte_length =
-        llvmir_provider->target_profile_provider_function_count *
-        sizeof(*target_profile_providers);
-    status = iree_allocator_malloc(request->host_allocator, byte_length,
-                                   (void**)&target_profile_providers);
-  }
-  if (iree_status_is_ok(status) && target_profile_providers != NULL) {
-    for (iree_host_size_t i = 0;
-         i < llvmir_provider->target_profile_provider_function_count; ++i) {
-      target_profile_providers[i] =
-          llvmir_provider->target_profile_provider_functions[i]();
-      if (target_profile_providers[i] == NULL) {
-        status = iree_make_status(
-            IREE_STATUS_FAILED_PRECONDITION,
-            "LLVMIR loom-check target profile provider returned null");
-        break;
-      }
-    }
-  }
-  if (iree_status_is_ok(status) && target_profile_providers != NULL) {
-    target_profile_registry = (loom_llvmir_target_profile_registry_t){
-        .providers = target_profile_providers,
-        .provider_count =
-            llvmir_provider->target_profile_provider_function_count,
-    };
-  }
   loom_llvmir_emit_low_module_options_t options = {0};
   loom_llvmir_emit_low_module_options_initialize(&options);
   options.target_profile_registry =
-      target_profile_providers != NULL ? &target_profile_registry : NULL;
-  if (iree_status_is_ok(status)) {
-    status = loom_llvmir_emit_low_module(
-        request->module, &request->low_registry->registry,
-        (iree_diagnostic_emitter_t){
-            .fn = loom_check_diagnostic_emitter_capture_emit,
-            .user_data = &diagnostic_capture,
-        },
-        request->case_arena, &options, &lowered_module,
-        request->host_allocator);
-  }
+      &loom_llvmir_configured_target_profile_registry;
+  iree_status_t status = loom_llvmir_emit_low_module(
+      request->module, &request->low_registry->registry,
+      (iree_diagnostic_emitter_t){
+          .fn = loom_check_diagnostic_emitter_capture_emit,
+          .user_data = &diagnostic_capture,
+      },
+      request->case_arena, &options, &lowered_module, request->host_allocator);
   const bool has_lowered_module =
       request->diagnostic_collector->count == 0 && lowered_module != NULL;
   if (iree_status_is_ok(status) && has_lowered_module) {
@@ -565,11 +532,10 @@ iree_status_t loom_llvmir_loom_check_emit_provider_execute(
     }
   }
   loom_llvmir_module_free(lowered_module);
-  iree_allocator_free(request->host_allocator, target_profile_providers);
   return status;
 }
 
-iree_status_t loom_llvmir_loom_check_emit_provider_append_names(
+static iree_status_t loom_llvmir_loom_check_emit_provider_append_names(
     const loom_check_emit_provider_t* provider,
     iree_string_builder_t* builder) {
   return iree_string_builder_append_cstring(
@@ -577,6 +543,15 @@ iree_status_t loom_llvmir_loom_check_emit_provider_append_names(
       "llvmir, llvmir-text, llvmir-body, llvmir-text-body, llvmir-bitcode, "
       "llvmir-object");
 }
+
+const loom_check_emit_provider_t loom_llvmir_loom_check_emit_provider = {
+    .name = IREE_SVL("llvmir"),
+    .match = loom_llvmir_loom_check_emit_provider_matches,
+    .check_requirements =
+        loom_llvmir_loom_check_emit_provider_check_requirements,
+    .execute = loom_llvmir_loom_check_emit_provider_execute,
+    .append_names = loom_llvmir_loom_check_emit_provider_append_names,
+};
 
 static bool loom_llvmir_loom_check_requirement_provider_matches(
     const loom_check_requirement_provider_t* provider,

--- a/loom/src/loom/target/emit/llvmir/check/loom_check.h
+++ b/loom/src/loom/target/emit/llvmir/check/loom_check.h
@@ -16,53 +16,8 @@
 extern "C" {
 #endif
 
-typedef const loom_llvmir_target_profile_provider_t*(
-    IREE_API_PTR* loom_llvmir_loom_check_target_profile_provider_fn_t)(void);
-
-typedef struct loom_llvmir_loom_check_emit_provider_t {
-  // Base loom-check emit provider embedded as the first field for dispatch.
-  loom_check_emit_provider_t provider;
-  // Target profile provider functions linked into this runner.
-  const loom_llvmir_loom_check_target_profile_provider_fn_t*
-      target_profile_provider_functions;
-  // Number of entries in |target_profile_provider_functions|.
-  iree_host_size_t target_profile_provider_function_count;
-} loom_llvmir_loom_check_emit_provider_t;
-
-bool loom_llvmir_loom_check_emit_provider_matches(
-    const loom_check_emit_provider_t* provider, iree_string_view_t target_name);
-
-iree_status_t loom_llvmir_loom_check_emit_provider_check_requirements(
-    const loom_check_emit_provider_t* provider,
-    const loom_test_case_t* test_case, loom_check_result_t* result,
-    bool* out_continue_execution);
-
-iree_status_t loom_llvmir_loom_check_emit_provider_execute(
-    const loom_check_emit_provider_t* provider,
-    const loom_check_emit_provider_request_t* request);
-
-iree_status_t loom_llvmir_loom_check_emit_provider_append_names(
-    const loom_check_emit_provider_t* provider, iree_string_builder_t* builder);
-
-#define LOOM_LLVMIR_LOOM_CHECK_EMIT_PROVIDER_INITIALIZER(                  \
-    target_profile_provider_functions_value,                               \
-    target_profile_provider_function_count_value)                          \
-  {                                                                        \
-      .provider =                                                          \
-          {                                                                \
-              .name = IREE_SVL("llvmir"),                                  \
-              .match = loom_llvmir_loom_check_emit_provider_matches,       \
-              .check_requirements =                                        \
-                  loom_llvmir_loom_check_emit_provider_check_requirements, \
-              .execute = loom_llvmir_loom_check_emit_provider_execute,     \
-              .append_names =                                              \
-                  loom_llvmir_loom_check_emit_provider_append_names,       \
-          },                                                               \
-      .target_profile_provider_functions =                                 \
-          target_profile_provider_functions_value,                         \
-      .target_profile_provider_function_count =                            \
-          target_profile_provider_function_count_value,                    \
-  }
+// Emit namespace provider for LLVMIR oracle output.
+extern const loom_check_emit_provider_t loom_llvmir_loom_check_emit_provider;
 
 // Requirement provider for LLVM tools and llc target-profile checks.
 extern const loom_check_requirement_provider_t

--- a/loom/src/loom/target/emit/llvmir/configured_target_profiles.c
+++ b/loom/src/loom/target/emit/llvmir/configured_target_profiles.c
@@ -1,0 +1,48 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/emit/llvmir/configured_target_profiles.h"
+
+#ifndef LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES
+#define LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES 0
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES
+#ifndef LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES
+#define LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES 0
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES
+
+#define LOOM_CONFIG_LLVMIR_HAVE_ANY_TARGET_PROFILES  \
+  (LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES || \
+   LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES)
+
+#if LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES
+#include "loom/target/emit/llvmir/amdgpu/target_env.h"
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES
+#if LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES
+#include "loom/target/emit/llvmir/x86/target_env.h"
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES
+
+#if LOOM_CONFIG_LLVMIR_HAVE_ANY_TARGET_PROFILES
+static const loom_llvmir_target_profile_provider_t* const
+    kConfiguredTargetProfileProviders[] = {
+#if LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES
+        &loom_llvmir_x86_target_profile_provider,
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES
+#if LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES
+        &loom_llvmir_amdgpu_target_profile_provider,
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES
+};
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_ANY_TARGET_PROFILES
+
+const loom_llvmir_target_profile_registry_t
+    loom_llvmir_configured_target_profile_registry = {
+#if LOOM_CONFIG_LLVMIR_HAVE_ANY_TARGET_PROFILES
+        .providers = kConfiguredTargetProfileProviders,
+        .provider_count = IREE_ARRAYSIZE(kConfiguredTargetProfileProviders),
+#else
+        .providers = NULL,
+        .provider_count = 0,
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_ANY_TARGET_PROFILES
+};

--- a/loom/src/loom/target/emit/llvmir/configured_target_profiles.h
+++ b/loom/src/loom/target/emit/llvmir/configured_target_profiles.h
@@ -1,0 +1,26 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// LLVMIR target profiles selected by the Loom build configuration.
+
+#ifndef LOOM_TARGET_EMIT_LLVMIR_CONFIGURED_TARGET_PROFILES_H_
+#define LOOM_TARGET_EMIT_LLVMIR_CONFIGURED_TARGET_PROFILES_H_
+
+#include "loom/target/emit/llvmir/target_presets.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Immutable process-lifetime registry of configured LLVMIR target profiles.
+extern const loom_llvmir_target_profile_registry_t
+    loom_llvmir_configured_target_profile_registry;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TARGET_EMIT_LLVMIR_CONFIGURED_TARGET_PROFILES_H_

--- a/loom/src/loom/target/emit/llvmir/configured_target_profiles_test.cc
+++ b/loom/src/loom/target/emit/llvmir/configured_target_profiles_test.cc
@@ -1,0 +1,43 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/emit/llvmir/configured_target_profiles.h"
+
+#include "iree/testing/gtest.h"
+
+#ifndef LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES
+#define LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES 0
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES
+#ifndef LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES
+#define LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES 0
+#endif  // LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES
+
+namespace loom {
+namespace {
+
+TEST(ConfiguredTargetProfilesTest, ContainsConfiguredProvidersExactlyOnce) {
+  const loom_llvmir_target_profile_registry_t* registry =
+      &loom_llvmir_configured_target_profile_registry;
+  const iree_host_size_t expected_provider_count =
+      LOOM_CONFIG_LLVMIR_HAVE_AMDGPU_TARGET_PROFILES +
+      LOOM_CONFIG_LLVMIR_HAVE_X86_TARGET_PROFILES;
+  ASSERT_EQ(registry->provider_count, expected_provider_count);
+  EXPECT_EQ(registry->providers == nullptr, expected_provider_count == 0);
+
+  for (iree_host_size_t i = 0; i < registry->provider_count; ++i) {
+    const loom_llvmir_target_profile_provider_t* provider =
+        registry->providers[i];
+    ASSERT_NE(provider, nullptr);
+    EXPECT_FALSE(iree_string_view_is_empty(provider->name));
+    for (iree_host_size_t j = 0; j < i; ++j) {
+      EXPECT_FALSE(
+          iree_string_view_equal(provider->name, registry->providers[j]->name));
+    }
+  }
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/target/emit/llvmir/target_env_test.cc
+++ b/loom/src/loom/target/emit/llvmir/target_env_test.cc
@@ -23,7 +23,7 @@ std::string ToString(iree_string_view_t value) {
 bool LookupRegisteredProfile(iree_string_view_t profile_name,
                              const loom_llvmir_target_profile_t** out_profile) {
   const loom_llvmir_target_profile_provider_t* providers[] = {
-      loom_llvmir_x86_target_profile_provider(),
+      &loom_llvmir_x86_target_profile_provider,
   };
   loom_llvmir_target_profile_registry_t registry = {};
   registry.default_profile = loom_llvmir_target_profile_x86_64_object();
@@ -254,7 +254,7 @@ TEST(LlvmIrTargetEnvTest, ProjectsX86ProfileByDescriptorSetKey) {
   };
 
   const loom_llvmir_target_profile_provider_t* provider =
-      loom_llvmir_x86_target_profile_provider();
+      &loom_llvmir_x86_target_profile_provider;
   const loom_llvmir_target_profile_t* profile = nullptr;
   const loom_llvmir_target_profile_projection_request_t request = {
       /*.bundle=*/&kBundle,
@@ -274,7 +274,7 @@ TEST(LlvmIrTargetEnvTest, RejectsUnknownRegisteredProfileName) {
 
 TEST(LlvmIrTargetEnvTest, RegistryOnlySeesExplicitProviders) {
   const loom_llvmir_target_profile_provider_t* providers[] = {
-      loom_llvmir_x86_target_profile_provider(),
+      &loom_llvmir_x86_target_profile_provider,
   };
   loom_llvmir_target_profile_registry_t registry = {};
   registry.default_profile = loom_llvmir_target_profile_x86_64_object();

--- a/loom/src/loom/target/emit/llvmir/target_presets.h
+++ b/loom/src/loom/target/emit/llvmir/target_presets.h
@@ -6,9 +6,9 @@
 
 // Explicit LLVM target profile preset registries.
 //
-// Target providers own their preset rows. Developer tools and embedders
-// assemble a registry from the providers they intentionally link, keeping the
-// generic LLVMIR infrastructure free of a process-wide target catalog.
+// Target providers own their preset rows. Configured binaries assemble one
+// immutable registry from the providers selected by the build, keeping the
+// target-neutral LLVMIR representation free of a process-wide target catalog.
 
 #ifndef LOOM_TARGET_LLVMIR_TARGET_PRESETS_H_
 #define LOOM_TARGET_LLVMIR_TARGET_PRESETS_H_

--- a/loom/src/loom/target/emit/llvmir/x86/target_env.c
+++ b/loom/src/loom/target/emit/llvmir/x86/target_env.c
@@ -181,12 +181,13 @@ static bool loom_llvmir_x86_project_bundle(
       bundle->config->contract_set_key, out_profile);
 }
 
-static const loom_llvmir_target_profile_provider_t kX86TargetProfileProvider = {
-    .name = IREE_SVL("x86"),
-    .profiles = kX86TargetProfiles,
-    .profile_count = IREE_ARRAYSIZE(kX86TargetProfiles),
-    .llc_target_name = IREE_SVL("x86"),
-    .project_bundle = loom_llvmir_x86_project_bundle,
+const loom_llvmir_target_profile_provider_t
+    loom_llvmir_x86_target_profile_provider = {
+        .name = IREE_SVL("x86"),
+        .profiles = kX86TargetProfiles,
+        .profile_count = IREE_ARRAYSIZE(kX86TargetProfiles),
+        .llc_target_name = IREE_SVL("x86"),
+        .project_bundle = loom_llvmir_x86_project_bundle,
 };
 
 const loom_target_bundle_t* loom_llvmir_target_bundle_x86_64_object(void) {
@@ -211,11 +212,6 @@ const loom_llvmir_target_profile_t* loom_llvmir_target_profile_x86_64_object(
 const loom_llvmir_target_profile_t*
 loom_llvmir_target_profile_x86_64_packed_dot_object(void) {
   return &kX86PackedDotObjectProfile;
-}
-
-const loom_llvmir_target_profile_provider_t*
-loom_llvmir_x86_target_profile_provider(void) {
-  return &kX86TargetProfileProvider;
 }
 
 iree_status_t loom_llvmir_target_profile_initialize_x86_64_object(

--- a/loom/src/loom/target/emit/llvmir/x86/target_env.h
+++ b/loom/src/loom/target/emit/llvmir/x86/target_env.h
@@ -39,9 +39,9 @@ const loom_target_bundle_t* loom_llvmir_target_bundle_x86_64_packed_dot_object(
 iree_status_t loom_llvmir_target_profile_initialize_x86_64_object(
     loom_llvmir_target_profile_t* out_profile);
 
-// Returns the static profile provider for x86 LLVMIR target presets.
-const loom_llvmir_target_profile_provider_t*
-loom_llvmir_x86_target_profile_provider(void);
+// Static profile provider for x86 LLVMIR target presets.
+extern const loom_llvmir_target_profile_provider_t
+    loom_llvmir_x86_target_profile_provider;
 
 #ifdef __cplusplus
 }

--- a/loom/src/loom/tooling/compile/BUILD.bazel
+++ b/loom/src/loom/tooling/compile/BUILD.bazel
@@ -7,8 +7,51 @@
 load("//build_tools/bazel:query.bzl", "iree_assert_dependency_boundary")
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
+    "iree_select",
     "loom_cc_library",
     "loom_cc_test",
+)
+
+_CONFIGURED_COMPILE_COPTS = (
+    iree_select({
+        "//loom/config/target:amdgpu_artifacts": [
+            "-DLOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS=1",
+        ],
+        "//conditions:default": [],
+    }) +
+    iree_select({
+        "//loom/config/target:spirv_artifacts": [
+            "-DLOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS=1",
+        ],
+        "//conditions:default": [],
+    }) +
+    iree_select({
+        "//loom/config/target:llvmir_artifacts": [
+            "-DLOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS=1",
+        ],
+        "//conditions:default": [],
+    })
+)
+
+_CONFIGURED_COMPILE_DEPS = (
+    iree_select({
+        "//loom/config/target:amdgpu_artifacts": [
+            "//loom/src/loom/tooling/target/amdgpu:artifact_provider",
+        ],
+        "//conditions:default": [],
+    }) +
+    iree_select({
+        "//loom/config/target:spirv_artifacts": [
+            "//loom/src/loom/tooling/target/spirv:artifact_provider",
+        ],
+        "//conditions:default": [],
+    }) +
+    iree_select({
+        "//loom/config/target:llvmir_artifacts": [
+            "//loom/src/loom/target/emit/llvmir:artifact_emitter",
+        ],
+        "//conditions:default": [],
+    })
 )
 
 package(
@@ -46,6 +89,32 @@ loom_cc_library(
         "//loom/src/loom/target:types",
         "//loom/src/loom/target/reporting:report",
         "//runtime/src/iree/base",
+    ],
+)
+
+loom_cc_library(
+    name = "configured",
+    srcs = ["configured.c"],
+    hdrs = ["configured.h"],
+    copts = _CONFIGURED_COMPILE_COPTS,
+    deps = [
+        ":artifact",
+        "//loom/src/loom/target:provider",
+        "//loom/src/loom/target/arch/cmd:provider",
+        "//loom/src/loom/target/configured:provider_set",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading",
+    ] + _CONFIGURED_COMPILE_DEPS,
+)
+
+loom_cc_test(
+    name = "configured_test",
+    srcs = ["configured_test.cc"],
+    copts = _CONFIGURED_COMPILE_COPTS,
+    deps = [
+        ":configured",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )
 

--- a/loom/src/loom/tooling/compile/CMakeLists.txt
+++ b/loom/src/loom/tooling/compile/CMakeLists.txt
@@ -47,6 +47,69 @@ loom_cc_library(
   PUBLIC
 )
 
+set(_configured_platform_copts "")
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU)
+  list(APPEND _configured_platform_copts "-DLOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS=1")
+endif()
+if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV)
+  list(APPEND _configured_platform_copts "-DLOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS=1")
+endif()
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR)
+  list(APPEND _configured_platform_copts "-DLOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS=1")
+endif()
+set(_configured_platform_deps "")
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU)
+  list(APPEND _configured_platform_deps loom::tooling::target::amdgpu::artifact_provider)
+endif()
+if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV)
+  list(APPEND _configured_platform_deps loom::tooling::target::spirv::artifact_provider)
+endif()
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR)
+  list(APPEND _configured_platform_deps loom::target::emit::llvmir::artifact_emitter)
+endif()
+loom_cc_library(
+  NAME
+    configured
+  COPTS
+    ${_configured_platform_copts}
+  HDRS
+    "configured.h"
+  SRCS
+    "configured.c"
+  DEPS
+    ::artifact
+    iree::base
+    iree::base::threading
+    loom::target::arch::cmd::provider
+    loom::target::configured::provider_set
+    loom::target::provider
+    ${_configured_platform_deps}
+  PUBLIC
+)
+
+set(_configured_test_platform_copts "")
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU)
+  list(APPEND _configured_test_platform_copts "-DLOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS=1")
+endif()
+if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV)
+  list(APPEND _configured_test_platform_copts "-DLOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS=1")
+endif()
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR)
+  list(APPEND _configured_test_platform_copts "-DLOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS=1")
+endif()
+loom_cc_test(
+  NAME
+    configured_test
+  SRCS
+    "configured_test.cc"
+  COPTS
+    ${_configured_test_platform_copts}
+  DEPS
+    ::configured
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 loom_cc_test(
   NAME
     artifact_test

--- a/loom/src/loom/tooling/compile/configured.c
+++ b/loom/src/loom/tooling/compile/configured.c
@@ -1,0 +1,129 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tooling/compile/configured.h"
+
+#include "iree/base/threading/call_once.h"
+#include "loom/target/arch/cmd/provider.h"
+#include "loom/target/configured/provider_set.h"
+
+#ifndef LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS
+#define LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS 0
+#endif  // LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS
+#ifndef LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS
+#define LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS 0
+#endif  // LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS
+#ifndef LOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS
+#define LOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS 0
+#endif  // LOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS
+
+#define LOOM_CONFIG_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER \
+  (LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS ||        \
+   LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS)
+
+#if LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS
+#include "loom/tooling/target/amdgpu/artifact_provider.h"
+#endif  // LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS
+#if LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS
+#include "loom/tooling/target/spirv/artifact_provider.h"
+#endif  // LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS
+#if LOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS
+#include "loom/target/emit/llvmir/artifact_emitter.h"
+#endif  // LOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS
+
+enum {
+  LOOM_TOOLING_CONFIGURED_COMPILE_ADDITIONAL_TARGET_PROVIDER_COUNT =
+      1 + LOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS,
+  LOOM_TOOLING_CONFIGURED_COMPILE_TARGET_PROVIDER_CAPACITY = 64,
+};
+
+typedef struct loom_tooling_configured_compile_storage_t {
+  // Configured target providers plus compile-only provider contributions.
+  const loom_target_provider_t* target_providers
+      [LOOM_TOOLING_CONFIGURED_COMPILE_TARGET_PROVIDER_CAPACITY];
+  // Number of entries in |target_providers|.
+  iree_host_size_t target_provider_count;
+  // Provider-set view over |target_providers|.
+  loom_target_provider_set_t target_provider_set;
+  // Composed compiler target environment.
+  loom_target_environment_t target_environment;
+  // Public borrowed view over the configured compiler providers.
+  loom_tooling_compile_environment_t environment;
+} loom_tooling_configured_compile_storage_t;
+
+#if LOOM_CONFIG_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER
+static const loom_artifact_provider_t* const kConfiguredArtifactProviders[] = {
+#if LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS
+    &loom_amdgpu_artifact_provider,
+#endif  // LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS
+#if LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS
+    &loom_spirv_vulkan_artifact_provider,
+#endif  // LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS
+};
+#endif  // LOOM_CONFIG_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER
+
+static const loom_artifact_provider_registry_t
+    kConfiguredArtifactProviderRegistry = {
+#if LOOM_CONFIG_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER
+        .providers = kConfiguredArtifactProviders,
+        .provider_count = IREE_ARRAYSIZE(kConfiguredArtifactProviders),
+#else
+        .providers = NULL,
+        .provider_count = 0,
+#endif  // LOOM_CONFIG_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER
+};
+
+static loom_tooling_configured_compile_storage_t configured_compile_storage;
+static iree_once_flag configured_compile_once = IREE_ONCE_FLAG_INIT;
+
+static iree_status_t loom_tooling_configured_compile_initialize_storage(void) {
+  const loom_target_provider_set_t* configured_target_providers =
+      loom_configured_target_provider_set();
+  if (configured_target_providers->provider_count >
+      IREE_ARRAYSIZE(configured_compile_storage.target_providers) -
+          LOOM_TOOLING_CONFIGURED_COMPILE_ADDITIONAL_TARGET_PROVIDER_COUNT) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "configured compile target provider capacity "
+                            "exceeded");
+  }
+  for (iree_host_size_t i = 0; i < configured_target_providers->provider_count;
+       ++i) {
+    configured_compile_storage
+        .target_providers[configured_compile_storage.target_provider_count++] =
+        configured_target_providers->providers[i];
+  }
+  configured_compile_storage
+      .target_providers[configured_compile_storage.target_provider_count++] =
+      &loom_cmd_target_provider;
+#if LOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS
+  configured_compile_storage
+      .target_providers[configured_compile_storage.target_provider_count++] =
+      &loom_llvmir_artifact_emitter_provider;
+#endif  // LOOM_CONFIG_COMPILE_HAVE_LLVMIR_ARTIFACTS
+  configured_compile_storage.target_provider_set =
+      loom_target_provider_set_make(
+          configured_compile_storage.target_providers,
+          configured_compile_storage.target_provider_count);
+  IREE_RETURN_IF_ERROR(loom_target_environment_initialize(
+      &configured_compile_storage.target_provider_set,
+      &configured_compile_storage.target_environment));
+  configured_compile_storage.environment = (loom_tooling_compile_environment_t){
+      .target_environment = &configured_compile_storage.target_environment,
+      .artifact_provider_registry = &kConfiguredArtifactProviderRegistry,
+  };
+  return iree_ok_status();
+}
+
+static void loom_tooling_configured_compile_initialize_once(void) {
+  IREE_CHECK_OK(loom_tooling_configured_compile_initialize_storage());
+}
+
+const loom_tooling_compile_environment_t*
+loom_tooling_configured_compile_environment(void) {
+  iree_call_once(&configured_compile_once,
+                 loom_tooling_configured_compile_initialize_once);
+  return &configured_compile_storage.environment;
+}

--- a/loom/src/loom/tooling/compile/configured.h
+++ b/loom/src/loom/tooling/compile/configured.h
@@ -1,0 +1,35 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Offline compiler providers selected by the Loom build configuration.
+
+#ifndef LOOM_TOOLING_COMPILE_CONFIGURED_H_
+#define LOOM_TOOLING_COMPILE_CONFIGURED_H_
+
+#include "loom/target/provider.h"
+#include "loom/tooling/compile/artifact.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Borrowed process-lifetime view of configured offline compiler providers.
+typedef struct loom_tooling_compile_environment_t {
+  // Target compiler environment, including portable command descriptors.
+  const loom_target_environment_t* target_environment;
+  // Loadable artifact providers selected by the build configuration.
+  const loom_artifact_provider_registry_t* artifact_provider_registry;
+} loom_tooling_compile_environment_t;
+
+// Returns the immutable configured offline compiler environment.
+const loom_tooling_compile_environment_t*
+loom_tooling_configured_compile_environment(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TOOLING_COMPILE_CONFIGURED_H_

--- a/loom/src/loom/tooling/compile/configured_test.cc
+++ b/loom/src/loom/tooling/compile/configured_test.cc
@@ -1,0 +1,56 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tooling/compile/configured.h"
+
+#include "iree/testing/gtest.h"
+
+#ifndef LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS
+#define LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS 0
+#endif  // LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS
+#ifndef LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS
+#define LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS 0
+#endif  // LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS
+
+namespace loom {
+namespace {
+
+TEST(ConfiguredCompileTest, ReturnsStableCompleteEnvironment) {
+  const loom_tooling_compile_environment_t* environment =
+      loom_tooling_configured_compile_environment();
+  ASSERT_NE(environment, nullptr);
+  EXPECT_EQ(environment, loom_tooling_configured_compile_environment());
+  ASSERT_NE(environment->target_environment, nullptr);
+  ASSERT_NE(environment->target_environment->provider_set, nullptr);
+  EXPECT_GT(environment->target_environment->provider_set->provider_count, 0u);
+
+  const loom_artifact_provider_registry_t* artifact_registry =
+      environment->artifact_provider_registry;
+  ASSERT_NE(artifact_registry, nullptr);
+  const iree_host_size_t expected_artifact_provider_count =
+      LOOM_CONFIG_COMPILE_HAVE_AMDGPU_ARTIFACTS +
+      LOOM_CONFIG_COMPILE_HAVE_SPIRV_ARTIFACTS;
+  ASSERT_EQ(artifact_registry->provider_count,
+            expected_artifact_provider_count);
+  EXPECT_EQ(artifact_registry->providers == nullptr,
+            expected_artifact_provider_count == 0);
+
+  for (iree_host_size_t i = 0; i < artifact_registry->provider_count; ++i) {
+    const loom_artifact_provider_t* provider = artifact_registry->providers[i];
+    ASSERT_NE(provider, nullptr);
+    EXPECT_FALSE(iree_string_view_is_empty(provider->name));
+    EXPECT_FALSE(iree_string_view_is_empty(provider->public_artifact_format));
+    ASSERT_NE(provider->target_profile_type, nullptr);
+    for (iree_host_size_t j = 0; j < i; ++j) {
+      EXPECT_FALSE(iree_string_view_equal(
+          provider->public_artifact_format,
+          artifact_registry->providers[j]->public_artifact_format));
+    }
+  }
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/tools/loom-check/BUILD.bazel
+++ b/loom/src/loom/tools/loom-check/BUILD.bazel
@@ -54,34 +54,6 @@ _EMIT_LLVMIR_CHECK_DEPS = iree_select({
     "//conditions:default": [],
 })
 
-_LLVMIR_AMDGPU_TARGET_ENV_COPTS = iree_select({
-    "//loom/config/target:llvmir_amdgpu_target_env": [
-        "-DLOOM_CHECK_HAVE_LLVMIR_AMDGPU_TARGET_ENV=1",
-    ],
-    "//conditions:default": [],
-})
-
-_LLVMIR_AMDGPU_TARGET_ENV_DEPS = iree_select({
-    "//loom/config/target:llvmir_amdgpu_target_env": [
-        "//loom/src/loom/target/emit/llvmir/amdgpu:target_env",
-    ],
-    "//conditions:default": [],
-})
-
-_LLVMIR_X86_TARGET_ENV_COPTS = iree_select({
-    "//loom/config/target:llvmir_x86_target_env": [
-        "-DLOOM_CHECK_HAVE_LLVMIR_X86_TARGET_ENV=1",
-    ],
-    "//conditions:default": [],
-})
-
-_LLVMIR_X86_TARGET_ENV_DEPS = iree_select({
-    "//loom/config/target:llvmir_x86_target_env": [
-        "//loom/src/loom/target/emit/llvmir/x86:target_env",
-    ],
-    "//conditions:default": [],
-})
-
 _TARGET_SPIRV_CHECK_COPTS = iree_select({
     "//loom/config/target/arch:spirv": [
         "-DLOOM_CHECK_HAVE_TARGET_SPIRV=1",
@@ -473,12 +445,11 @@ loom_cc_library(
     name = "llvmir_provider",
     srcs = ["llvmir_provider.c"],
     hdrs = ["llvmir_provider.h"],
-    copts = _LLVMIR_AMDGPU_TARGET_ENV_COPTS + _LLVMIR_X86_TARGET_ENV_COPTS,
     deps = [
         ":provider",
         "//loom/src/loom/target/emit/llvmir:loom_check",
         "//runtime/src/iree/base",
-    ] + _LLVMIR_AMDGPU_TARGET_ENV_DEPS + _LLVMIR_X86_TARGET_ENV_DEPS,
+    ],
 )
 
 loom_cc_library(

--- a/loom/src/loom/tools/loom-check/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-check/CMakeLists.txt
@@ -337,25 +337,9 @@ loom_cc_library(
   PUBLIC
 )
 
-set(_llvmir_provider_platform_copts "")
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_AMDGPU)
-  list(APPEND _llvmir_provider_platform_copts "-DLOOM_CHECK_HAVE_LLVMIR_AMDGPU_TARGET_ENV=1")
-endif()
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_X86)
-  list(APPEND _llvmir_provider_platform_copts "-DLOOM_CHECK_HAVE_LLVMIR_X86_TARGET_ENV=1")
-endif()
-set(_llvmir_provider_platform_deps "")
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_AMDGPU)
-  list(APPEND _llvmir_provider_platform_deps loom::target::emit::llvmir::amdgpu::target_env)
-endif()
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_X86)
-  list(APPEND _llvmir_provider_platform_deps loom::target::emit::llvmir::x86::target_env)
-endif()
 loom_cc_library(
   NAME
     llvmir_provider
-  COPTS
-    ${_llvmir_provider_platform_copts}
   HDRS
     "llvmir_provider.h"
   SRCS
@@ -364,7 +348,6 @@ loom_cc_library(
     ::provider
     iree::base
     loom::target::emit::llvmir::loom_check
-    ${_llvmir_provider_platform_deps}
   PUBLIC
 )
 

--- a/loom/src/loom/tools/loom-check/llvmir_provider.c
+++ b/loom/src/loom/tools/loom-check/llvmir_provider.c
@@ -7,40 +7,10 @@
 #include "loom/tools/loom-check/llvmir_provider.h"
 
 #include "loom/target/emit/llvmir/check/loom_check.h"
-#ifndef LOOM_CHECK_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-#define LOOM_CHECK_HAVE_LLVMIR_AMDGPU_TARGET_ENV 0
-#endif  // LOOM_CHECK_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-#ifndef LOOM_CHECK_HAVE_LLVMIR_X86_TARGET_ENV
-#define LOOM_CHECK_HAVE_LLVMIR_X86_TARGET_ENV 0
-#endif  // LOOM_CHECK_HAVE_LLVMIR_X86_TARGET_ENV
-
-#if LOOM_CHECK_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-#include "loom/target/emit/llvmir/amdgpu/target_env.h"
-#endif  // LOOM_CHECK_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-#if LOOM_CHECK_HAVE_LLVMIR_X86_TARGET_ENV
-#include "loom/target/emit/llvmir/x86/target_env.h"
-#endif  // LOOM_CHECK_HAVE_LLVMIR_X86_TARGET_ENV
-
-static const loom_llvmir_loom_check_target_profile_provider_fn_t
-    kLoomCheckLlvmirTargetProfileProviderFunctions[] = {
-#if LOOM_CHECK_HAVE_LLVMIR_X86_TARGET_ENV
-        loom_llvmir_x86_target_profile_provider,
-#endif  // LOOM_CHECK_HAVE_LLVMIR_X86_TARGET_ENV
-#if LOOM_CHECK_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-        loom_llvmir_amdgpu_target_profile_provider,
-#endif  // LOOM_CHECK_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-        NULL,
-};
-
-static const loom_llvmir_loom_check_emit_provider_t
-    kLoomCheckLlvmirEmitProvider =
-        LOOM_LLVMIR_LOOM_CHECK_EMIT_PROVIDER_INITIALIZER(
-            kLoomCheckLlvmirTargetProfileProviderFunctions,
-            IREE_ARRAYSIZE(kLoomCheckLlvmirTargetProfileProviderFunctions) - 1);
 
 static const loom_check_emit_provider_t* const kLoomLlvmirCheckEmitProviders[] =
     {
-        &kLoomCheckLlvmirEmitProvider.provider,
+        &loom_llvmir_loom_check_emit_provider,
 };
 
 static const loom_check_requirement_provider_t* const

--- a/loom/src/loom/tools/loom-compile/BUILD.bazel
+++ b/loom/src/loom/tools/loom-compile/BUILD.bazel
@@ -8,7 +8,6 @@ load("//build_tools/bazel:query.bzl", "iree_assert_dependency_boundary")
 load("//build_tools/testing:build_defs.bzl", "iree_execution_test_suite")
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
-    "iree_select",
     "loom_cc_binary",
     "loom_cc_library",
     "loom_cc_test",
@@ -20,79 +19,6 @@ package(
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
-
-_AMDGPU_COMPILE_COPTS = iree_select({
-    "//loom/config/target:amdgpu_artifacts": [
-        "-DLOOM_COMPILE_HAVE_AMDGPU=1",
-    ],
-    "//conditions:default": [],
-})
-
-_AMDGPU_COMPILE_DEPS = iree_select({
-    "//loom/config/target:amdgpu_artifacts": [
-        "//loom/src/loom/target/arch/amdgpu:provider",
-        "//loom/src/loom/tooling/target/amdgpu:artifact_provider",
-    ],
-    "//conditions:default": [],
-})
-
-_SPIRV_COMPILE_COPTS = iree_select({
-    "//loom/config/target:spirv_artifacts": [
-        "-DLOOM_COMPILE_HAVE_SPIRV=1",
-    ],
-    "//conditions:default": [],
-})
-
-_SPIRV_COMPILE_DEPS = iree_select({
-    "//loom/config/target:spirv_artifacts": [
-        "//loom/src/loom/target/arch/spirv:provider",
-        "//loom/src/loom/tooling/target/spirv:artifact_provider",
-    ],
-    "//conditions:default": [],
-})
-
-_LLVMIR_COMPILE_COPTS = iree_select({
-    "//loom/config/target:llvmir_artifacts": [
-        "-DLOOM_COMPILE_HAVE_LLVMIR=1",
-    ],
-    "//conditions:default": [],
-})
-
-_LLVMIR_COMPILE_DEPS = iree_select({
-    "//loom/config/target:llvmir_artifacts": [
-        "//loom/src/loom/target/arch/llvmir:provider",
-        "//loom/src/loom/target/emit/llvmir:artifact_emitter",
-    ],
-    "//conditions:default": [],
-})
-
-_LLVMIR_AMDGPU_TARGET_ENV_COPTS = iree_select({
-    "//loom/config/target:llvmir_amdgpu_target_env": [
-        "-DLOOM_COMPILE_HAVE_LLVMIR_AMDGPU_TARGET_ENV=1",
-    ],
-    "//conditions:default": [],
-})
-
-_LLVMIR_AMDGPU_TARGET_ENV_DEPS = iree_select({
-    "//loom/config/target:llvmir_amdgpu_target_env": [
-        "//loom/src/loom/target/emit/llvmir/amdgpu:target_env",
-    ],
-    "//conditions:default": [],
-})
-
-_LLVMIR_X86_TARGET_ENV_COPTS = iree_select({
-    "//loom/config/target:llvmir_x86_target_env": [
-        "-DLOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV=1",
-    ],
-    "//conditions:default": [],
-})
-
-_LLVMIR_X86_TARGET_ENV_DEPS = iree_select({
-    "//loom/config/target:llvmir_x86_target_env": [
-        "//loom/src/loom/target/emit/llvmir/x86:target_env",
-    ],
-    "//conditions:default": [],
-})
 
 _LLVMIR_ARTIFACTS_COMPATIBLE_WITH = loom_config_compatible_with([
     "//loom/config/target:llvmir_artifacts",
@@ -158,7 +84,6 @@ loom_cc_library(
 loom_cc_binary(
     name = "loom-compile",
     srcs = ["loom-compile.c"],
-    copts = _AMDGPU_COMPILE_COPTS + _SPIRV_COMPILE_COPTS + _LLVMIR_COMPILE_COPTS + _LLVMIR_AMDGPU_TARGET_ENV_COPTS + _LLVMIR_X86_TARGET_ENV_COPTS,
     deps = [
         ":command_backend",
         ":command_manifest",
@@ -175,16 +100,15 @@ loom_cc_binary(
         "//loom/src/loom/target:low_descriptor_registry",
         "//loom/src/loom/target:module_specialization",
         "//loom/src/loom/target/arch/cmd:artifact_set",
-        "//loom/src/loom/target/arch/cmd:provider",
         "//loom/src/loom/target/reporting:artifact_manifest",
         "//loom/src/loom/tooling/cli:help",
         "//loom/src/loom/tooling/compile:artifact",
+        "//loom/src/loom/tooling/compile:configured",
         "//loom/src/loom/tooling/compile:options",
         "//loom/src/loom/tooling/compile:pipeline",
         "//loom/src/loom/tooling/compile:report_capture",
         "//loom/src/loom/tooling/config",
         "//loom/src/loom/tooling/context",
-        "//loom/src/loom/tooling/execution:execution_provider",
         "//loom/src/loom/tooling/execution:session",
         "//loom/src/loom/tooling/io:file",
         "//loom/src/loom/tooling/io:source_path",
@@ -192,7 +116,7 @@ loom_cc_binary(
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/tooling:flags",
         "//runtime/src/iree/io:file_handle",
-    ] + _AMDGPU_COMPILE_DEPS + _SPIRV_COMPILE_DEPS + _LLVMIR_COMPILE_DEPS + _LLVMIR_AMDGPU_TARGET_ENV_DEPS + _LLVMIR_X86_TARGET_ENV_DEPS,
+    ],
 )
 
 iree_assert_dependency_boundary(

--- a/loom/src/loom/tools/loom-compile/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-compile/CMakeLists.txt
@@ -73,48 +73,11 @@ loom_cc_library(
   PUBLIC
 )
 
-set(_loom_compile_platform_copts "")
-if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU)
-  list(APPEND _loom_compile_platform_copts "-DLOOM_COMPILE_HAVE_AMDGPU=1")
-endif()
-if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV)
-  list(APPEND _loom_compile_platform_copts "-DLOOM_COMPILE_HAVE_SPIRV=1")
-endif()
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR)
-  list(APPEND _loom_compile_platform_copts "-DLOOM_COMPILE_HAVE_LLVMIR=1")
-endif()
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_AMDGPU)
-  list(APPEND _loom_compile_platform_copts "-DLOOM_COMPILE_HAVE_LLVMIR_AMDGPU_TARGET_ENV=1")
-endif()
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_X86)
-  list(APPEND _loom_compile_platform_copts "-DLOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV=1")
-endif()
-set(_loom_compile_platform_deps "")
-if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU)
-  list(APPEND _loom_compile_platform_deps loom::target::arch::amdgpu::provider)
-  list(APPEND _loom_compile_platform_deps loom::tooling::target::amdgpu::artifact_provider)
-endif()
-if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV)
-  list(APPEND _loom_compile_platform_deps loom::target::arch::spirv::provider)
-  list(APPEND _loom_compile_platform_deps loom::tooling::target::spirv::artifact_provider)
-endif()
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR)
-  list(APPEND _loom_compile_platform_deps loom::target::arch::llvmir::provider)
-  list(APPEND _loom_compile_platform_deps loom::target::emit::llvmir::artifact_emitter)
-endif()
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_AMDGPU)
-  list(APPEND _loom_compile_platform_deps loom::target::emit::llvmir::amdgpu::target_env)
-endif()
-if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR AND LOOM_TARGET_ARCH_X86)
-  list(APPEND _loom_compile_platform_deps loom::target::emit::llvmir::x86::target_env)
-endif()
 loom_cc_binary(
   NAME
     loom-compile
   SRCS
     "loom-compile.c"
-  COPTS
-    ${_loom_compile_platform_copts}
   DEPS
     ::command_backend
     ::command_manifest
@@ -131,24 +94,22 @@ loom_cc_binary(
     loom::ops::op_defs
     loom::sanitizer::options
     loom::target::arch::cmd::artifact_set
-    loom::target::arch::cmd::provider
     loom::target::entry_selection
     loom::target::low_descriptor_registry
     loom::target::module_specialization
     loom::target::reporting::artifact_manifest
     loom::tooling::cli::help
     loom::tooling::compile::artifact
+    loom::tooling::compile::configured
     loom::tooling::compile::options
     loom::tooling::compile::pipeline
     loom::tooling::compile::report_capture
     loom::tooling::config
     loom::tooling::context
-    loom::tooling::execution::execution_provider
     loom::tooling::execution::session
     loom::tooling::io::file
     loom::tooling::io::source_path
     loom::tooling::pass::trace_cli
-    ${_loom_compile_platform_deps}
 )
 
 loom_cc_test(

--- a/loom/src/loom/tools/loom-compile/loom-compile.c
+++ b/loom/src/loom/tools/loom-compile/loom-compile.c
@@ -20,17 +20,16 @@
 #include "loom/ops/op_defs.h"
 #include "loom/sanitizer/options.h"
 #include "loom/target/arch/cmd/artifact_set.h"
-#include "loom/target/arch/cmd/provider.h"
 #include "loom/target/entry_selection.h"
 #include "loom/target/module_specialization.h"
 #include "loom/target/reporting/artifact_manifest.h"
 #include "loom/tooling/cli/help.h"
 #include "loom/tooling/compile/artifact.h"
+#include "loom/tooling/compile/configured.h"
 #include "loom/tooling/compile/pipeline.h"
 #include "loom/tooling/compile/report_capture.h"
 #include "loom/tooling/config/config.h"
 #include "loom/tooling/context/context.h"
-#include "loom/tooling/execution/execution_provider.h"
 #include "loom/tooling/execution/session.h"
 #include "loom/tooling/io/file.h"
 #include "loom/tooling/io/source_path.h"
@@ -38,22 +37,6 @@
 #include "loom/tools/loom-compile/command_backend.h"
 #include "loom/tools/loom-compile/command_manifest.h"
 #include "loom/tools/loom-compile/request.h"
-
-#ifndef LOOM_COMPILE_HAVE_AMDGPU
-#define LOOM_COMPILE_HAVE_AMDGPU 0
-#endif  // LOOM_COMPILE_HAVE_AMDGPU
-#ifndef LOOM_COMPILE_HAVE_SPIRV
-#define LOOM_COMPILE_HAVE_SPIRV 0
-#endif  // LOOM_COMPILE_HAVE_SPIRV
-#ifndef LOOM_COMPILE_HAVE_LLVMIR
-#define LOOM_COMPILE_HAVE_LLVMIR 0
-#endif  // LOOM_COMPILE_HAVE_LLVMIR
-#ifndef LOOM_COMPILE_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-#define LOOM_COMPILE_HAVE_LLVMIR_AMDGPU_TARGET_ENV 0
-#endif  // LOOM_COMPILE_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-#ifndef LOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV
-#define LOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV 0
-#endif  // LOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV
 
 typedef struct loom_compile_diagnostic_sink_t {
   // Parsed module used for full type rendering.
@@ -103,28 +86,6 @@ static iree_status_t loom_compile_diagnostic_sink(
   }
   return status;
 }
-
-#define LOOM_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER \
-  (LOOM_COMPILE_HAVE_AMDGPU || LOOM_COMPILE_HAVE_SPIRV)
-
-#if LOOM_COMPILE_HAVE_AMDGPU
-#include "loom/target/arch/amdgpu/provider.h"
-#include "loom/tooling/target/amdgpu/artifact_provider.h"
-#endif  // LOOM_COMPILE_HAVE_AMDGPU
-#if LOOM_COMPILE_HAVE_SPIRV
-#include "loom/target/arch/spirv/provider.h"
-#include "loom/tooling/target/spirv/artifact_provider.h"
-#endif  // LOOM_COMPILE_HAVE_SPIRV
-#if LOOM_COMPILE_HAVE_LLVMIR
-#include "loom/target/arch/llvmir/provider.h"
-#include "loom/target/emit/llvmir/artifact_emitter.h"
-#if LOOM_COMPILE_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-#include "loom/target/emit/llvmir/amdgpu/target_env.h"
-#endif  // LOOM_COMPILE_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-#if LOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV
-#include "loom/target/emit/llvmir/x86/target_env.h"
-#endif  // LOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV
-#endif  // LOOM_COMPILE_HAVE_LLVMIR
 
 IREE_FLAG(string, product, "",
           "Optional product: 'kernel', 'command', or 'module'. With explicit "
@@ -207,101 +168,37 @@ IREE_FLAG_LIST_NAMED(
     "--source-prefix-map=old=new; entries are applied in reverse order so the\n"
     "last matching map wins. Use old= to strip a prefix.");
 
-#if LOOM_COMPILE_HAVE_AMDGPU
-static const loom_run_execution_provider_t kLoomCompileAmdgpuProvider = {
-    .name = IREE_SVL("amdgpu"),
-    .target_provider = &loom_amdgpu_target_provider,
-};
-#endif  // LOOM_COMPILE_HAVE_AMDGPU
-
-static const loom_run_execution_provider_t kLoomCompileCommandProvider = {
-    .name = IREE_SVL("command"),
-    .target_provider = &loom_cmd_target_provider,
-};
-
-#if LOOM_COMPILE_HAVE_SPIRV
-static const loom_run_execution_provider_t kLoomCompileSpirvProvider = {
-    .name = IREE_SVL("spirv"),
-    .target_provider = &loom_spirv_target_provider,
-};
-#endif  // LOOM_COMPILE_HAVE_SPIRV
-
-#if LOOM_COMPILE_HAVE_LLVMIR
-static const loom_run_execution_provider_t kLoomCompileLlvmirProvider = {
-    .name = IREE_SVL("llvmir"),
-    .target_provider = &loom_llvmir_target_provider,
-};
-
-static const loom_run_execution_provider_t
-    kLoomCompileLlvmirArtifactEmitterProvider = {
-        .name = IREE_SVL("llvmir-artifacts"),
-        .target_provider = &loom_llvmir_artifact_emitter_provider,
-};
-#endif  // LOOM_COMPILE_HAVE_LLVMIR
-
-static const loom_run_execution_provider_t* const kLoomCompileProviders[] = {
-    &kLoomCompileCommandProvider,
-#if LOOM_COMPILE_HAVE_AMDGPU
-    &kLoomCompileAmdgpuProvider,
-#endif  // LOOM_COMPILE_HAVE_AMDGPU
-#if LOOM_COMPILE_HAVE_SPIRV
-    &kLoomCompileSpirvProvider,
-#endif  // LOOM_COMPILE_HAVE_SPIRV
-#if LOOM_COMPILE_HAVE_LLVMIR
-    // Register the target executor and the artifact-only emitter.
-    &kLoomCompileLlvmirProvider,
-    &kLoomCompileLlvmirArtifactEmitterProvider,
-#endif  // LOOM_COMPILE_HAVE_LLVMIR
-};
-
-static const loom_run_execution_provider_set_t kLoomCompileProviderSet = {
-    .providers = kLoomCompileProviders,
-    .provider_count = IREE_ARRAYSIZE(kLoomCompileProviders),
-};
-
-#if LOOM_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER
-static const loom_artifact_provider_t* const kLoomCompileArtifactProviders[] = {
-#if LOOM_COMPILE_HAVE_AMDGPU
-    &loom_amdgpu_artifact_provider,
-#endif  // LOOM_COMPILE_HAVE_AMDGPU
-#if LOOM_COMPILE_HAVE_SPIRV
-    &loom_spirv_vulkan_artifact_provider,
-#endif  // LOOM_COMPILE_HAVE_SPIRV
-};
-#endif  // LOOM_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER
-
-static const loom_artifact_provider_registry_t
-    kLoomCompileArtifactProviderRegistry = {
-#if LOOM_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER
-        .providers = kLoomCompileArtifactProviders,
-        .provider_count = IREE_ARRAYSIZE(kLoomCompileArtifactProviders),
-#else
-        .providers = NULL,
-        .provider_count = 0,
-#endif  // LOOM_COMPILE_HAVE_ANY_ARTIFACT_PROVIDER
-};
-
 static iree_status_t loom_compile_register_context(void* user_data,
                                                    loom_context_t* context) {
-  loom_run_execution_environment_t* environment =
-      (loom_run_execution_environment_t*)user_data;
+  const loom_target_environment_t* target_environment =
+      (const loom_target_environment_t*)user_data;
   return loom_tooling_context_register_tool_dialects_with_target_environment(
-      loom_run_execution_environment_target_environment(environment), context);
+      target_environment, context);
+}
+
+static iree_status_t loom_compile_initialize_low_descriptor_registry(
+    void* user_data, loom_target_low_descriptor_registry_t* out_registry) {
+  const loom_target_environment_t* target_environment =
+      (const loom_target_environment_t*)user_data;
+  return loom_target_environment_initialize_low_descriptor_registry(
+      target_environment, out_registry);
 }
 
 static iree_status_t loom_compile_initialize_session(
-    loom_run_execution_environment_t* environment, iree_allocator_t allocator,
-    loom_run_session_t* out_session) {
+    const loom_target_environment_t* target_environment,
+    iree_allocator_t allocator, loom_run_session_t* out_session) {
   loom_run_session_options_t session_options = {0};
   loom_run_session_options_initialize(&session_options);
   session_options.host_allocator = allocator;
   session_options.register_context = (loom_run_register_context_callback_t){
       .fn = loom_compile_register_context,
-      .user_data = environment,
+      .user_data = (void*)target_environment,
   };
   session_options.initialize_low_descriptor_registry =
-      loom_run_execution_environment_low_descriptor_registry_callback(
-          environment);
+      (loom_run_initialize_low_descriptor_registry_callback_t){
+          .fn = loom_compile_initialize_low_descriptor_registry,
+          .user_data = (void*)target_environment,
+      };
   return loom_run_session_initialize(&session_options, out_session);
 }
 
@@ -535,7 +432,7 @@ static iree_status_t loom_compile_artifact_manifest_options_initialize(
 }
 
 static iree_status_t loom_compile_run_pass_pipeline(
-    const loom_run_execution_environment_t* environment,
+    const loom_target_environment_t* target_environment,
     loom_run_session_t* session, loom_run_module_t* run_module,
     loom_compile_default_pipeline_t default_pipeline,
     const loom_compile_options_t* compile_options,
@@ -548,8 +445,7 @@ static iree_status_t loom_compile_run_pass_pipeline(
   pipeline_options.default_pipeline = default_pipeline;
   pipeline_options.target_pipeline_options =
       compile_options->target_pipeline_options;
-  pipeline_options.target_environment =
-      loom_run_execution_environment_target_environment(environment);
+  pipeline_options.target_environment = target_environment;
   pipeline_options.low_descriptor_registry =
       loom_run_session_low_descriptor_registry(session);
   loom_compile_diagnostic_sink_t diagnostic_sink = {
@@ -816,21 +712,8 @@ static iree_string_view_t loom_compile_target_artifact_identifier(
              : output_path;
 }
 
-#if LOOM_COMPILE_HAVE_LLVMIR
-static bool loom_compile_target_emitter_is_llvmir(
-    const loom_target_emitter_t* target_emitter) {
-  switch (target_emitter->target_artifact_format) {
-    case LOOM_TARGET_ARTIFACT_FORMAT_LLVMIR_TEXT:
-    case LOOM_TARGET_ARTIFACT_FORMAT_LLVMIR_BITCODE:
-      return true;
-    default:
-      return false;
-  }
-}
-#endif  // LOOM_COMPILE_HAVE_LLVMIR
-
 static iree_status_t loom_compile_emit_target(
-    const loom_run_execution_environment_t* environment,
+    const loom_target_environment_t* target_environment,
     loom_run_session_t* session, const loom_target_emitter_t* target_emitter,
     loom_run_module_t* run_module,
     const loom_compile_options_t* compile_options, iree_allocator_t allocator,
@@ -870,31 +753,6 @@ static iree_status_t loom_compile_emit_target(
   const iree_string_view_t output_path = iree_make_cstring_view(FLAG_output);
   const iree_string_view_t identifier =
       loom_compile_target_artifact_identifier(output_path, target_emitter);
-#if LOOM_COMPILE_HAVE_LLVMIR
-  const loom_llvmir_target_profile_provider_t*
-      llvmir_target_profile_providers[] = {
-#if LOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV
-          loom_llvmir_x86_target_profile_provider(),
-#endif  // LOOM_COMPILE_HAVE_LLVMIR_X86_TARGET_ENV
-#if LOOM_COMPILE_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-          loom_llvmir_amdgpu_target_profile_provider(),
-#endif  // LOOM_COMPILE_HAVE_LLVMIR_AMDGPU_TARGET_ENV
-          NULL,
-      };
-  const loom_llvmir_target_profile_registry_t llvmir_target_profile_registry = {
-      .providers = llvmir_target_profile_providers,
-      .provider_count = IREE_ARRAYSIZE(llvmir_target_profile_providers) - 1,
-  };
-  loom_llvmir_artifact_emitter_options_t llvmir_options = {0};
-  const void* option_chain = NULL;
-  if (loom_compile_target_emitter_is_llvmir(target_emitter)) {
-    loom_llvmir_artifact_emitter_options_initialize(&llvmir_options);
-    llvmir_options.target_profile_registry = &llvmir_target_profile_registry;
-    option_chain = &llvmir_options;
-  }
-#else
-  const void* option_chain = NULL;
-#endif  // LOOM_COMPILE_HAVE_LLVMIR
   if (compile_options->report != NULL) {
     compile_options->report->artifact_kind =
         LOOM_TARGET_COMPILE_ARTIFACT_KIND_TARGET_ARTIFACT;
@@ -903,13 +761,11 @@ static iree_status_t loom_compile_emit_target(
         target_emitter->target_artifact_format);
   }
   const loom_target_emit_request_t request = {
-      .target_environment =
-          loom_run_execution_environment_target_environment(environment),
+      .target_environment = target_environment,
       .low_descriptor_registry =
           &loom_run_session_low_descriptor_registry(session)->registry,
       .module = run_module->module,
       .function_versions = compile_options->function_versions,
-      .option_chain = option_chain,
       .identifier = identifier,
       .compile_report = compile_options->report,
       .diagnostic_emitter = loom_target_entry_emitter(&diagnostic_emitter),
@@ -983,7 +839,7 @@ static iree_status_t loom_compile_validate_request_flags(
 }
 
 static iree_status_t loom_compile_specialize_explicit_target(
-    const loom_run_execution_environment_t* environment,
+    const loom_target_environment_t* target_environment,
     loom_run_session_t* session, loom_run_module_t* run_module,
     const loom_artifact_target_t* target,
     loom_compile_report_capture_t* compile_report_capture,
@@ -1010,8 +866,8 @@ static iree_status_t loom_compile_specialize_explicit_target(
 
   uint32_t error_count = 0;
   IREE_RETURN_IF_ERROR(loom_target_specialize_module_kernel_entries(
-      loom_run_execution_environment_target_environment(environment),
-      target->target_profile, loom_target_entry_emitter(&diagnostic_emitter),
+      target_environment, target->target_profile,
+      loom_target_entry_emitter(&diagnostic_emitter),
       loom_run_session_block_pool(session), allocator, &run_module->module,
       &error_count));
   if (error_count != 0) {
@@ -1165,9 +1021,9 @@ int main(int argc, char** argv) {
   const loom_tooling_source_path_options_t source_path_options = {
       .prefix_maps = FLAG_source_prefix_map_list(),
   };
-  loom_run_execution_environment_t environment = {0};
-  iree_status_t status = loom_run_execution_environment_initialize(
-      &kLoomCompileProviderSet, &environment);
+  const loom_tooling_compile_environment_t* compile_environment =
+      loom_tooling_configured_compile_environment();
+  iree_status_t status = iree_ok_status();
   loom_tooling_config_set_t config_set;
   loom_tooling_config_set_initialize(allocator, &config_set);
 
@@ -1187,7 +1043,8 @@ int main(int argc, char** argv) {
   int exit_code = 0;
 
   if (iree_status_is_ok(status)) {
-    status = loom_compile_initialize_session(&environment, allocator, &session);
+    status = loom_compile_initialize_session(
+        compile_environment->target_environment, allocator, &session);
   }
   if (iree_status_is_ok(status)) {
     status = loom_compile_append_config_files(&config_set, allocator);
@@ -1224,9 +1081,8 @@ int main(int argc, char** argv) {
     };
     status = loom_compile_request_resolve(
         run_module.module, &request_options,
-        &kLoomCompileArtifactProviderRegistry,
-        loom_run_execution_environment_target_environment(&environment),
-        &request);
+        compile_environment->artifact_provider_registry,
+        compile_environment->target_environment, &request);
     if (iree_status_is_ok(status)) {
       status = loom_compile_validate_request_flags(&request);
     }
@@ -1234,8 +1090,8 @@ int main(int argc, char** argv) {
   if (iree_status_is_ok(status) &&
       request.explicit_target.target_profile != NULL) {
     status = loom_compile_specialize_explicit_target(
-        &environment, &session, &run_module, &request.explicit_target,
-        &compile_report_capture, allocator);
+        compile_environment->target_environment, &session, &run_module,
+        &request.explicit_target, &compile_report_capture, allocator);
   }
   if (iree_status_is_ok(status)) {
     status =
@@ -1318,7 +1174,7 @@ int main(int argc, char** argv) {
                                   iree_make_cstring_view(FLAG_pipeline));
     if (run_pipeline) {
       status = loom_compile_run_pass_pipeline(
-          &environment, &session, &run_module,
+          compile_environment->target_environment, &session, &run_module,
           LOOM_COMPILE_DEFAULT_PIPELINE_PREPARED_LOW, &compile_options,
           &compile_report_capture, loom_tooling_pass_trace_options(&pass_trace),
           &pipeline_result);
@@ -1354,8 +1210,9 @@ int main(int argc, char** argv) {
         break;
       case LOOM_COMPILE_PRODUCER_TARGET_EMITTER:
         status = loom_compile_emit_target(
-            &environment, &session, request.producer.value.target_emitter,
-            &run_module, &compile_options, allocator, &emitted);
+            compile_environment->target_environment, &session,
+            request.producer.value.target_emitter, &run_module,
+            &compile_options, allocator, &emitted);
         break;
       case LOOM_COMPILE_PRODUCER_COMMAND:
         status = loom_compile_emit_command(
@@ -1397,7 +1254,6 @@ int main(int argc, char** argv) {
   iree_io_file_contents_free(contents);
   loom_tooling_config_set_deinitialize(&config_set);
   loom_run_session_deinitialize(&session);
-  loom_run_execution_environment_deinitialize(&environment);
   iree_allocator_free(allocator, artifact_manifest_output_path_storage);
 
   IREE_TRACE_ZONE_END(z0);

--- a/loom/src/loom/tools/loom-format/BUILD.bazel
+++ b/loom/src/loom/tools/loom-format/BUILD.bazel
@@ -42,7 +42,7 @@ loom_cc_binary(
         "//loom/src/loom/error:diagnostic",
         "//loom/src/loom/target:provider",
         "//loom/src/loom/target/arch/cmd:provider",
-        "//loom/src/loom/target/configured:provider",
+        "//loom/src/loom/target/configured:provider_set",
         "//loom/src/loom/target/test:provider",
         "//loom/src/loom/testing:test_file_format",
         "//loom/src/loom/tooling/cli:help",

--- a/loom/src/loom/tools/loom-format/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-format/CMakeLists.txt
@@ -46,7 +46,7 @@ loom_cc_binary(
     loom::codegen::low::text_asm
     loom::error::diagnostic
     loom::target::arch::cmd::provider
-    loom::target::configured::provider
+    loom::target::configured::provider_set
     loom::target::provider
     loom::target::test::provider
     loom::testing::test_file_format

--- a/loom/src/loom/tools/loom-format/loom-format.c
+++ b/loom/src/loom/tools/loom-format/loom-format.c
@@ -15,7 +15,7 @@
 #include "loom/codegen/low/text_asm.h"
 #include "loom/error/diagnostic.h"
 #include "loom/target/arch/cmd/provider.h"
-#include "loom/target/configured/provider.h"
+#include "loom/target/configured/provider_set.h"
 #include "loom/target/provider.h"
 #include "loom/target/test/provider.h"
 #include "loom/testing/test_file_format.h"


### PR DESCRIPTION
Offline Loom compilation now consumes one build-selected compiler environment instead of rebuilding target and artifact registries inside `loom-compile`. This makes target composition an owned tooling boundary and leaves the CLI independent of every concrete target implementation it can drive.

The configured target package now exposes its immutable provider set separately from its fully composed environment. Consumers that need to add tool-owned providers can reuse the canonical target selection without linking an otherwise unused second `loom_target_environment_t`, while ordinary consumers keep the existing process-lifetime configured environment.

`loom/tooling/compile` composes that provider set with portable command descriptors, optional target emitters, and loadable artifact providers once per process. The resulting borrowed view contains only generic target and artifact interfaces. Concrete AMDGPU, SPIR-V, and LLVMIR dependencies remain isolated in this build-selected composition unit, and disabled targets contribute neither code nor providers.

`loom-compile` no longer contains build-selection macros, concrete provider tables, LLVMIR-specific option handling, or an execution-provider environment used as compiler scaffolding. Its session, pipeline, specialization, and emission paths all consume the generic target environment directly, so another target can join offline compilation by contributing at the configured boundary rather than modifying the tool.

LLVMIR debug emission and `loom-check` now also share one immutable configured target-profile registry. The LLVMIR profile providers are static descriptors, eliminating the per-emission profile table, heap-backed wrapper state, and emitter-specific option chain that previously leaked LLVMIR setup into callers.

## Reviewer notes

- `loom/src/loom/target/configured/provider_set.{h,c}` separates build-selected target identity from environment composition.
- `loom/src/loom/tooling/compile/configured.{h,c}` is the only offline-compiler composition boundary; `loom-compile` should remain target-agnostic above it.
