### PR TITLE
[Loom] Make Bazel target profiles family-neutral

### DIFF
--- a/loom/build_tools/bazel/defs.bzl
+++ b/loom/build_tools/bazel/defs.bzl
@@ -27,9 +27,9 @@ load(
 )
 load(
     ":loom_target_profile.bzl",
-    _LoomAmdgpuTargetProfileInfo = "LoomAmdgpuTargetProfileInfo",
     _LoomTargetProfileInfo = "LoomTargetProfileInfo",
     _loom_amdgpu_target_profile = "loom_amdgpu_target_profile",
+    _loom_target_profile = "loom_target_profile",
 )
 load(
     ":loom_toolchain.bzl",
@@ -39,7 +39,6 @@ load(
 LoomBinaryInfo = _LoomBinaryInfo
 LoomExecutionTestInfo = _LoomExecutionTestInfo
 LoomLibraryInfo = _LoomLibraryInfo
-LoomAmdgpuTargetProfileInfo = _LoomAmdgpuTargetProfileInfo
 LoomTargetProfileInfo = _LoomTargetProfileInfo
 loom_amdgpu_target_profile = _loom_amdgpu_target_profile
 loom_command_binary = _loom_command_binary
@@ -48,5 +47,6 @@ loom_kernel_binary = _loom_kernel_binary
 loom_kernel_library = _loom_kernel_library
 loom_library = _loom_library
 loom_module = _loom_module
+loom_target_profile = _loom_target_profile
 loom_test = _loom_test
 loom_tools_toolchains = _loom_tools_toolchains

--- a/loom/build_tools/bazel/loom_binary.bzl
+++ b/loom/build_tools/bazel/loom_binary.bzl
@@ -13,7 +13,6 @@ load(
 )
 load(
     ":loom_target_profile.bzl",
-    "LoomAmdgpuTargetProfileInfo",
     "LoomTargetProfileInfo",
 )
 
@@ -36,7 +35,7 @@ def _require_binary_inputs(ctx):
     if not ctx.files.srcs and not ctx.attr.deps:
         fail("%s requires at least one source across srcs and deps" % ctx.label)
 
-def _amdgpu_target_profile(ctx, product_kind):
+def _require_amdgpu_target_profile(ctx, product_kind):
     target_profile = ctx.attr.target[LoomTargetProfileInfo]
     if target_profile.family != "amdgpu":
         fail(
@@ -48,12 +47,7 @@ def _amdgpu_target_profile(ctx, product_kind):
                 product_kind,
             ),
         )
-    if LoomAmdgpuTargetProfileInfo not in ctx.attr.target:
-        fail(
-            "%s target profile claims family amdgpu without an AMDGPU identity" %
-            ctx.label,
-        )
-    return ctx.attr.target[LoomAmdgpuTargetProfileInfo]
+    return target_profile
 
 def _declare_binary_linked_module(ctx, product_kind, target_profile = None):
     dependency_infos = [dep[LoomLibraryInfo] for dep in ctx.attr.deps]
@@ -91,7 +85,7 @@ def _declare_binary_linked_module(ctx, product_kind, target_profile = None):
 def _declare_amdgpu_kernel_product(
         ctx,
         linked_module,
-        amdgpu_profile,
+        target_profile,
         output_stem,
         mnemonic,
         progress_message):
@@ -101,10 +95,9 @@ def _declare_amdgpu_kernel_product(
     args.add(linked_module)
     args.add("--product=kernel")
     args.add("--format=amdgpu-hsaco")
-    target_profile = ctx.attr.target[LoomTargetProfileInfo]
     args.add("--target=%s:%s" % (
         target_profile.family,
-        amdgpu_profile.target,
+        target_profile.selector,
     ))
     args.add("--output=%s" % artifact.path)
     args.add("--compile-report=details")
@@ -156,19 +149,16 @@ def _declare_command_product(ctx, linked_module):
 
 def _loom_kernel_binary_impl(ctx):
     _require_binary_inputs(ctx)
-    amdgpu_profile = _amdgpu_target_profile(ctx, "kernel")
+    target_profile = _require_amdgpu_target_profile(ctx, "kernel")
     linked = _declare_binary_linked_module(
         ctx,
         "kernel",
-        target_profile = struct(
-            family = "amdgpu",
-            selector = amdgpu_profile.target,
-        ),
+        target_profile = target_profile,
     )
     product = _declare_amdgpu_kernel_product(
         ctx = ctx,
         linked_module = linked.linked_module,
-        amdgpu_profile = amdgpu_profile,
+        target_profile = target_profile,
         output_stem = ctx.label.name,
         mnemonic = "LoomKernelBinary",
         progress_message = "Compiling kernel binary %s for %s" % (
@@ -235,20 +225,17 @@ loom_kernel_binary = rule(
 
 def _loom_command_binary_impl(ctx):
     _require_binary_inputs(ctx)
-    amdgpu_profile = _amdgpu_target_profile(ctx, "command")
+    target_profile = _require_amdgpu_target_profile(ctx, "command")
     linked = _declare_binary_linked_module(
         ctx,
         "command",
-        target_profile = struct(
-            family = "amdgpu",
-            selector = amdgpu_profile.target,
-        ),
+        target_profile = target_profile,
     )
     command_product = _declare_command_product(ctx, linked.linked_module)
     kernel_product = _declare_amdgpu_kernel_product(
         ctx = ctx,
         linked_module = linked.linked_module,
-        amdgpu_profile = amdgpu_profile,
+        target_profile = target_profile,
         output_stem = ctx.label.name + ".kernels",
         mnemonic = "LoomCommandKernelBinary",
         progress_message = "Compiling command kernels for %s against %s" % (

--- a/loom/build_tools/bazel/loom_target_profile.bzl
+++ b/loom/build_tools/bazel/loom_target_profile.bzl
@@ -16,35 +16,57 @@ load(
 )
 
 LoomTargetProfileInfo = provider(
-    doc = "Family identity shared by every immutable Loom target profile.",
+    doc = "Immutable Loom target identity shared by all target families.",
     fields = {
         "family": "Target fact family, such as amdgpu or spirv.",
+        "selector": "Family-owned exact, generic, or overlay target selector.",
     },
 )
 
-LoomAmdgpuTargetProfileInfo = provider(
-    doc = "Structured AMDGPU identity used to construct a target profile.",
-    fields = {
-        "target": "Exact, generic, or overlay AMDGPU target selector.",
-    },
-)
-
-def _loom_amdgpu_target_profile_impl(ctx):
+def _loom_target_profile_impl(ctx):
     return [
-        LoomTargetProfileInfo(family = "amdgpu"),
-        LoomAmdgpuTargetProfileInfo(target = ctx.attr.target),
+        LoomTargetProfileInfo(
+            family = ctx.attr.family,
+            selector = ctx.attr.selector,
+        ),
     ]
 
-_loom_amdgpu_target_profile = rule(
-    implementation = _loom_amdgpu_target_profile_impl,
+_loom_target_profile = rule(
+    implementation = _loom_target_profile_impl,
     attrs = {
-        "target": attr.string(
+        "family": attr.string(
             mandatory = True,
-            doc = "Exact, generic, or overlay AMDGPU target selector.",
+            doc = "Target fact family accepted by the compiler.",
+        ),
+        "selector": attr.string(
+            mandatory = True,
+            doc = "Family-owned exact, generic, or overlay selector.",
         ),
     },
-    doc = "Declares one immutable AMDGPU target identity profile.",
+    doc = "Declares one immutable Loom target identity profile.",
 )
+
+def loom_target_profile(name, family, selector, **kwargs):
+    """Declares an immutable target profile understood by the compiler.
+
+    Args:
+      name: Bazel target name.
+      family: Target fact family accepted by the compiler.
+      selector: Family-owned exact, generic, or overlay selector.
+      **kwargs: Common rule attributes forwarded to the profile target.
+    """
+    if not family:
+        fail("Loom target profile family must not be empty")
+    if ":" in family:
+        fail("Loom target profile family must not contain ':'")
+    if not selector:
+        fail("Loom target profile selector must not be empty")
+    _loom_target_profile(
+        name = name,
+        family = family,
+        selector = selector,
+        **kwargs
+    )
 
 def loom_amdgpu_target_profile(name, target, **kwargs):
     """Declares an AMDGPU profile available with its descriptor contract.
@@ -60,9 +82,10 @@ def loom_amdgpu_target_profile(name, target, **kwargs):
     if descriptor_set_capability == None:
         fail("Unknown Loom AMDGPU target profile: %s" % target)
     target_compatible_with = kwargs.pop("target_compatible_with", [])
-    _loom_amdgpu_target_profile(
+    loom_target_profile(
         name = name,
-        target = target,
+        family = "amdgpu",
+        selector = target,
         target_compatible_with = target_compatible_with +
                                  loom_amdgpu_descriptor_set_compatible_with(
                                      descriptor_set_capability,

--- a/loom/build_tools/bazel/test/BUILD.bazel
+++ b/loom/build_tools/bazel/test/BUILD.bazel
@@ -15,13 +15,13 @@ load(
     "loom_kernel_library",
     "loom_library",
     "loom_module",
+    "loom_target_profile",
     "loom_test",
 )
 load("//loom/build_tools/bazel:loom_check.bzl", "loom_check_test")
 load(
     ":loom_binary_rules_test.bzl",
     "loom_binary_rules_test_suite",
-    "test_target_profile",
 )
 load(":loom_check_rules_test.bzl", "loom_check_rules_test_suite")
 load(
@@ -43,9 +43,10 @@ loom_amdgpu_target_profile(
     target = "gfx942",
 )
 
-test_target_profile(
+loom_target_profile(
     name = "test_spirv_profile",
     family = "spirv",
+    selector = "vulkan1.3+bda",
 )
 
 loom_kernel_library(

--- a/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
@@ -17,16 +17,6 @@ load(
     "loom_kernel_binary",
 )
 
-def _test_target_profile_impl(ctx):
-    return [LoomTargetProfileInfo(family = ctx.attr.family)]
-
-test_target_profile = rule(
-    implementation = _test_target_profile_impl,
-    attrs = {
-        "family": attr.string(mandatory = True),
-    },
-)
-
 def _find_action(env, actions, mnemonic):
     for action in actions:
         if action.mnemonic == mnemonic:
@@ -79,6 +69,9 @@ def _test_kernel_binary_roots_direct_library_exports_impl(env, target):
     env.expect.that_str(
         binary.target_profiles[0][LoomTargetProfileInfo].family,
     ).equals("amdgpu")
+    env.expect.that_str(
+        binary.target_profiles[0][LoomTargetProfileInfo].selector,
+    ).equals("gfx11-generic")
 
     default_files = target[DefaultInfo].files.to_list()
     if len(default_files) != 1:
@@ -255,6 +248,9 @@ def _test_command_binary_emits_composite_product_impl(env, target):
     env.expect.that_str(
         binary.target_profiles[0][LoomTargetProfileInfo].family,
     ).equals("amdgpu")
+    env.expect.that_str(
+        binary.target_profiles[0][LoomTargetProfileInfo].selector,
+    ).equals("gfx11-generic")
 
     artifacts = binary.artifacts.to_list()
     if len(artifacts) != 3:

--- a/loom/build_tools/bazel/test/loom_target_profile_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_target_profile_rules_test.bzl
@@ -9,7 +9,6 @@
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 load(
     "//loom/build_tools/bazel:defs.bzl",
-    "LoomAmdgpuTargetProfileInfo",
     "LoomTargetProfileInfo",
 )
 
@@ -24,8 +23,7 @@ def _test_amdgpu_profile_is_family_typed(name, **kwargs):
 def _test_amdgpu_profile_is_family_typed_impl(env, target):
     profile = target[LoomTargetProfileInfo]
     env.expect.that_str(profile.family).equals("amdgpu")
-    amdgpu_profile = target[LoomAmdgpuTargetProfileInfo]
-    env.expect.that_str(amdgpu_profile.target).equals("gfx942")
+    env.expect.that_str(profile.selector).equals("gfx942")
 
     if hasattr(profile, "backend"):
         env.fail("target profile must not select a compiler backend")
@@ -41,10 +39,22 @@ def _test_builtin_profile_preserves_overlay_identity(name, **kwargs):
     )
 
 def _test_builtin_profile_preserves_overlay_identity_impl(env, target):
-    env.expect.that_str(target[LoomTargetProfileInfo].family).equals("amdgpu")
-    env.expect.that_str(
-        target[LoomAmdgpuTargetProfileInfo].target,
-    ).equals("gfx1250-a0")
+    profile = target[LoomTargetProfileInfo]
+    env.expect.that_str(profile.family).equals("amdgpu")
+    env.expect.that_str(profile.selector).equals("gfx1250-a0")
+
+def _test_generic_profile_preserves_family_identity(name, **kwargs):
+    analysis_test(
+        name = name,
+        impl = _test_generic_profile_preserves_family_identity_impl,
+        target = ":test_spirv_profile",
+        **kwargs
+    )
+
+def _test_generic_profile_preserves_family_identity_impl(env, target):
+    profile = target[LoomTargetProfileInfo]
+    env.expect.that_str(profile.family).equals("spirv")
+    env.expect.that_str(profile.selector).equals("vulkan1.3+bda")
 
 def loom_target_profile_rules_test_suite(name):
     test_suite(
@@ -52,5 +62,6 @@ def loom_target_profile_rules_test_suite(name):
         tests = [
             _test_amdgpu_profile_is_family_typed,
             _test_builtin_profile_preserves_overlay_identity,
+            _test_generic_profile_preserves_family_identity,
         ],
     )


### PR DESCRIPTION
Bazel target-profile labels now carry the complete generic `family + selector` identity used by `loom-link` and `loom-compile`. Generic build rules no longer need a second AMDGPU-only provider or an anonymous translation object to construct `--target=family:selector`.

`LoomTargetProfileInfo` owns both identity fields, and the public `loom_target_profile` declaration allows downstream Bazel modules to publish any compiler-supported target without changing HRX’s Starlark. The provider remains immutable analysis metadata: it names a target but does not select a compiler implementation, enable a target package, or alter an authoring toolchain’s link graph.

The AMDGPU profile macro now delegates semantic identity to the generic declaration and retains only the family-specific policy it actually owns: validating known selectors and attaching descriptor-set compatibility constraints. The separate `LoomAmdgpuTargetProfileInfo` type is removed.

Binary and linking actions pass the common provider directly through their shared helpers. This PR deliberately preserves the current AMDGPU-only binary-format behavior; format compatibility and target-neutral kernel/command emission are isolated in the next stacked change rather than mixed into this provider contraction.

## Reviewer notes

The public extension boundary is `loom/build_tools/bazel/loom_target_profile.bzl`; its synthetic SPIR-V analysis case demonstrates that target identity itself has no AMDGPU dependency.
