### PR TITLE
[Loom] Guard optional LLVMIR CMake targets

### DIFF
--- a/loom/build_tools/amdgpu/BUILD.bazel
+++ b/loom/build_tools/amdgpu/BUILD.bazel
@@ -13,6 +13,8 @@ package(
     licenses = ["notice"],
 )
 
+exports_files(["target_profile.bzl"])
+
 py_library(
     name = "target_config",
     srcs = ["target_config.py"],

--- a/loom/build_tools/amdgpu/target_profile.bzl
+++ b/loom/build_tools/amdgpu/target_profile.bzl
@@ -1,0 +1,54 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""AMDGPU target-profile declarations and compatibility policy."""
+
+load(
+    "//loom/build_tools/amdgpu:descriptor_sets.bzl",
+    "loom_amdgpu_descriptor_set_compatible_with",
+)
+load(
+    "//loom/build_tools/amdgpu:target_config.bzl",
+    "LOOM_AMDGPU_DESCRIPTOR_SET_CAPABILITY_BY_TARGET",
+)
+load("//loom/build_tools/bazel:loom_target_profile.bzl", "loom_target_profile")
+
+def loom_amdgpu_target_profile(
+        name,
+        target,
+        canonical_formats = [
+            "//loom/product/formats:amdgpu_hsaco",
+            "//loom/product/formats:loom_command",
+        ],
+        formats = [],
+        **kwargs):
+    """Declares an AMDGPU profile available with its descriptor contract.
+
+    Args:
+      name: Bazel target name.
+      target: Exact, generic, or overlay AMDGPU target selector.
+      canonical_formats: Canonical product formats for the profile.
+      formats: Additional noncanonical product formats for the profile.
+      **kwargs: Common rule attributes forwarded to the profile target.
+    """
+    descriptor_set_capability = (
+        LOOM_AMDGPU_DESCRIPTOR_SET_CAPABILITY_BY_TARGET.get(target)
+    )
+    if descriptor_set_capability == None:
+        fail("Unknown Loom AMDGPU target profile: %s" % target)
+    target_compatible_with = kwargs.pop("target_compatible_with", [])
+    loom_target_profile(
+        name = name,
+        canonical_formats = canonical_formats,
+        family = "amdgpu",
+        formats = formats,
+        selector = target,
+        target_compatible_with = target_compatible_with +
+                                 loom_amdgpu_descriptor_set_compatible_with(
+                                     descriptor_set_capability,
+                                 ),
+        **kwargs
+    )

--- a/loom/build_tools/bazel/BUILD.bazel
+++ b/loom/build_tools/bazel/BUILD.bazel
@@ -15,6 +15,7 @@ exports_files([
     "loom_library.bzl",
     "loom_linking.bzl",
     "loom_module.bzl",
+    "loom_product_format.bzl",
     "loom_target_profile.bzl",
     "loom_toolchain.bzl",
 ])

--- a/loom/build_tools/bazel/defs.bzl
+++ b/loom/build_tools/bazel/defs.bzl
@@ -26,9 +26,15 @@ load(
     _loom_module = "loom_module",
 )
 load(
+    ":loom_product_format.bzl",
+    _LoomProductFormatInfo = "LoomProductFormatInfo",
+    _loom_artifact_set_product_format = "loom_artifact_set_product_format",
+    _loom_file_product_format = "loom_file_product_format",
+)
+load(
     ":loom_target_profile.bzl",
+    _LoomTargetFormatSupportInfo = "LoomTargetFormatSupportInfo",
     _LoomTargetProfileInfo = "LoomTargetProfileInfo",
-    _loom_amdgpu_target_profile = "loom_amdgpu_target_profile",
     _loom_target_profile = "loom_target_profile",
 )
 load(
@@ -39,10 +45,13 @@ load(
 LoomBinaryInfo = _LoomBinaryInfo
 LoomExecutionTestInfo = _LoomExecutionTestInfo
 LoomLibraryInfo = _LoomLibraryInfo
+LoomProductFormatInfo = _LoomProductFormatInfo
+LoomTargetFormatSupportInfo = _LoomTargetFormatSupportInfo
 LoomTargetProfileInfo = _LoomTargetProfileInfo
-loom_amdgpu_target_profile = _loom_amdgpu_target_profile
+loom_artifact_set_product_format = _loom_artifact_set_product_format
 loom_command_binary = _loom_command_binary
 loom_execution_profile = _loom_execution_profile
+loom_file_product_format = _loom_file_product_format
 loom_kernel_binary = _loom_kernel_binary
 loom_kernel_library = _loom_kernel_library
 loom_library = _loom_library

--- a/loom/build_tools/bazel/defs.bzl
+++ b/loom/build_tools/bazel/defs.bzl
@@ -27,9 +27,9 @@ load(
 )
 load(
     ":loom_target_profile.bzl",
-    _LoomAmdgpuTargetProfileInfo = "LoomAmdgpuTargetProfileInfo",
     _LoomTargetProfileInfo = "LoomTargetProfileInfo",
     _loom_amdgpu_target_profile = "loom_amdgpu_target_profile",
+    _loom_target_profile = "loom_target_profile",
 )
 load(
     ":loom_toolchain.bzl",
@@ -39,7 +39,6 @@ load(
 LoomBinaryInfo = _LoomBinaryInfo
 LoomExecutionTestInfo = _LoomExecutionTestInfo
 LoomLibraryInfo = _LoomLibraryInfo
-LoomAmdgpuTargetProfileInfo = _LoomAmdgpuTargetProfileInfo
 LoomTargetProfileInfo = _LoomTargetProfileInfo
 loom_amdgpu_target_profile = _loom_amdgpu_target_profile
 loom_command_binary = _loom_command_binary
@@ -48,5 +47,6 @@ loom_kernel_binary = _loom_kernel_binary
 loom_kernel_library = _loom_kernel_library
 loom_library = _loom_library
 loom_module = _loom_module
+loom_target_profile = _loom_target_profile
 loom_test = _loom_test
 loom_tools_toolchains = _loom_tools_toolchains

--- a/loom/build_tools/bazel/loom_binary.bzl
+++ b/loom/build_tools/bazel/loom_binary.bzl
@@ -13,7 +13,6 @@ load(
 )
 load(
     ":loom_target_profile.bzl",
-    "LoomAmdgpuTargetProfileInfo",
     "LoomTargetProfileInfo",
 )
 
@@ -36,7 +35,7 @@ def _require_binary_inputs(ctx):
     if not ctx.files.srcs and not ctx.attr.deps:
         fail("%s requires at least one source across srcs and deps" % ctx.label)
 
-def _amdgpu_target_profile(ctx, product_kind):
+def _require_amdgpu_target_profile(ctx, product_kind):
     target_profile = ctx.attr.target[LoomTargetProfileInfo]
     if target_profile.family != "amdgpu":
         fail(
@@ -48,12 +47,7 @@ def _amdgpu_target_profile(ctx, product_kind):
                 product_kind,
             ),
         )
-    if LoomAmdgpuTargetProfileInfo not in ctx.attr.target:
-        fail(
-            "%s target profile claims family amdgpu without an AMDGPU identity" %
-            ctx.label,
-        )
-    return ctx.attr.target[LoomAmdgpuTargetProfileInfo]
+    return target_profile
 
 def _declare_binary_linked_module(ctx, product_kind, target_profile = None):
     dependency_infos = [dep[LoomLibraryInfo] for dep in ctx.attr.deps]
@@ -91,7 +85,7 @@ def _declare_binary_linked_module(ctx, product_kind, target_profile = None):
 def _declare_amdgpu_kernel_product(
         ctx,
         linked_module,
-        amdgpu_profile,
+        target_profile,
         output_stem,
         mnemonic,
         progress_message):
@@ -101,10 +95,9 @@ def _declare_amdgpu_kernel_product(
     args.add(linked_module)
     args.add("--product=kernel")
     args.add("--format=amdgpu-hsaco")
-    target_profile = ctx.attr.target[LoomTargetProfileInfo]
     args.add("--target=%s:%s" % (
         target_profile.family,
-        amdgpu_profile.target,
+        target_profile.selector,
     ))
     args.add("--output=%s" % artifact.path)
     args.add("--compile-report=details")
@@ -156,19 +149,16 @@ def _declare_command_product(ctx, linked_module):
 
 def _loom_kernel_binary_impl(ctx):
     _require_binary_inputs(ctx)
-    amdgpu_profile = _amdgpu_target_profile(ctx, "kernel")
+    target_profile = _require_amdgpu_target_profile(ctx, "kernel")
     linked = _declare_binary_linked_module(
         ctx,
         "kernel",
-        target_profile = struct(
-            family = "amdgpu",
-            selector = amdgpu_profile.target,
-        ),
+        target_profile = target_profile,
     )
     product = _declare_amdgpu_kernel_product(
         ctx = ctx,
         linked_module = linked.linked_module,
-        amdgpu_profile = amdgpu_profile,
+        target_profile = target_profile,
         output_stem = ctx.label.name,
         mnemonic = "LoomKernelBinary",
         progress_message = "Compiling kernel binary %s for %s" % (
@@ -235,20 +225,17 @@ loom_kernel_binary = rule(
 
 def _loom_command_binary_impl(ctx):
     _require_binary_inputs(ctx)
-    amdgpu_profile = _amdgpu_target_profile(ctx, "command")
+    target_profile = _require_amdgpu_target_profile(ctx, "command")
     linked = _declare_binary_linked_module(
         ctx,
         "command",
-        target_profile = struct(
-            family = "amdgpu",
-            selector = amdgpu_profile.target,
-        ),
+        target_profile = target_profile,
     )
     command_product = _declare_command_product(ctx, linked.linked_module)
     kernel_product = _declare_amdgpu_kernel_product(
         ctx = ctx,
         linked_module = linked.linked_module,
-        amdgpu_profile = amdgpu_profile,
+        target_profile = target_profile,
         output_stem = ctx.label.name + ".kernels",
         mnemonic = "LoomCommandKernelBinary",
         progress_message = "Compiling command kernels for %s against %s" % (

--- a/loom/build_tools/bazel/loom_binary.bzl
+++ b/loom/build_tools/bazel/loom_binary.bzl
@@ -11,8 +11,10 @@ load(
     "LoomLibraryInfo",
     "loom_linking",
 )
+load(":loom_product_format.bzl", "LoomProductFormatInfo")
 load(
     ":loom_target_profile.bzl",
+    "LoomTargetFormatSupportInfo",
     "LoomTargetProfileInfo",
 )
 
@@ -26,6 +28,7 @@ LoomBinaryInfo = provider(
         "kind": "Deployment product kind: kernel or command.",
         "linked_module": "Closed Loom bytecode module used for emission.",
         "primary_artifact": "Primary runtime artifact produced by this binary.",
+        "product_formats": "Product-name keyed selected format targets.",
         "reports": "Depset of compile reports for emitted artifacts.",
         "target_profiles": "Ordered configured target-profile targets used for compilation.",
     },
@@ -35,19 +38,99 @@ def _require_binary_inputs(ctx):
     if not ctx.files.srcs and not ctx.attr.deps:
         fail("%s requires at least one source across srcs and deps" % ctx.label)
 
-def _require_amdgpu_target_profile(ctx, product_kind):
-    target_profile = ctx.attr.target[LoomTargetProfileInfo]
-    if target_profile.family != "amdgpu":
+def _require_product_format(ctx, format_target, product, output_kind):
+    format_info = format_target[LoomProductFormatInfo]
+    if not format_info.format:
+        fail("%s format %s has an empty public format name" % (ctx.label, format_target.label))
+    if format_info.product != product:
         fail(
-            ("%s cannot emit a %s binary for target profile family %r; " +
-             "only amdgpu-backed %s products are available") % (
+            "%s format %s describes product %r, expected %r" % (
                 ctx.label,
-                product_kind,
-                target_profile.family,
-                product_kind,
+                format_target.label,
+                format_info.product,
+                product,
             ),
         )
-    return target_profile
+    if format_info.output_kind != output_kind:
+        fail(
+            "%s format %s has output kind %r, expected %r for product %r" % (
+                ctx.label,
+                format_target.label,
+                format_info.output_kind,
+                output_kind,
+                product,
+            ),
+        )
+    if not format_info.output_extension.startswith("."):
+        fail(
+            "%s format %s output extension must begin with '.'" %
+            (ctx.label, format_target.label),
+        )
+    if "/" in format_info.output_extension or "\\" in format_info.output_extension:
+        fail(
+            "%s format %s output extension must not contain a path" %
+            (ctx.label, format_target.label),
+        )
+    if output_kind == "file" and format_info.artifact_directory_extension:
+        fail(
+            "%s single-file format %s has an artifact directory extension" %
+            (ctx.label, format_target.label),
+        )
+    if output_kind == "artifact_set":
+        if not format_info.artifact_directory_extension.startswith("."):
+            fail(
+                "%s artifact-set format %s directory extension must begin with '.'" %
+                (ctx.label, format_target.label),
+            )
+        if ("/" in format_info.artifact_directory_extension or
+            "\\" in format_info.artifact_directory_extension):
+            fail(
+                "%s artifact-set format %s directory extension must not contain a path" %
+                (ctx.label, format_target.label),
+            )
+    return format_info
+
+def _resolve_target_product_format(ctx, product, output_kind, explicit_format):
+    support = ctx.attr.target[LoomTargetFormatSupportInfo]
+    selected_format = explicit_format
+    if selected_format == None:
+        selected_format = support.canonical_formats.get(product)
+        if selected_format == None:
+            fail(
+                "%s target profile %s has no canonical format for product %r" %
+                (ctx.label, ctx.attr.target.label, product),
+            )
+
+    match_count = 0
+    for supported_format in support.formats:
+        if supported_format.label == selected_format.label:
+            match_count += 1
+    if match_count == 0:
+        fail(
+            "%s target profile %s does not support product format %s" % (
+                ctx.label,
+                ctx.attr.target.label,
+                selected_format.label,
+            ),
+        )
+    if match_count != 1:
+        fail(
+            "%s target profile %s declares product format %s more than once" % (
+                ctx.label,
+                ctx.attr.target.label,
+                selected_format.label,
+            ),
+        )
+
+    return struct(
+        info = _require_product_format(
+            ctx,
+            selected_format,
+            product,
+            output_kind,
+        ),
+        target = selected_format,
+    )
 
 def _declare_binary_linked_module(ctx, product_kind, target_profile = None):
     dependency_infos = [dep[LoomLibraryInfo] for dep in ctx.attr.deps]
@@ -82,19 +165,22 @@ def _declare_binary_linked_module(ctx, product_kind, target_profile = None):
         linked_module = linked_module,
     )
 
-def _declare_amdgpu_kernel_product(
+def _declare_kernel_product(
         ctx,
         linked_module,
+        product_format,
         target_profile,
         output_stem,
         mnemonic,
         progress_message):
-    artifact = ctx.actions.declare_file(output_stem + ".hsaco")
+    artifact = ctx.actions.declare_file(
+        output_stem + product_format.info.output_extension,
+    )
     compile_report = ctx.actions.declare_file(output_stem + ".compile.json")
     args = ctx.actions.args()
     args.add(linked_module)
     args.add("--product=kernel")
-    args.add("--format=amdgpu-hsaco")
+    args.add("--format=%s" % product_format.info.format)
     args.add("--target=%s:%s" % (
         target_profile.family,
         target_profile.selector,
@@ -115,18 +201,24 @@ def _declare_amdgpu_kernel_product(
     return struct(
         artifact = artifact,
         compile_report = compile_report,
+        format = product_format.target,
     )
 
-def _declare_command_product(ctx, linked_module):
-    manifest = ctx.actions.declare_file(ctx.label.name + ".commands.json")
-    artifacts = ctx.actions.declare_directory(ctx.label.name + ".commands")
+def _declare_command_product(ctx, linked_module, product_format):
+    format_info = product_format.info
+    manifest = ctx.actions.declare_file(
+        ctx.label.name + format_info.output_extension,
+    )
+    artifacts = ctx.actions.declare_directory(
+        ctx.label.name + format_info.artifact_directory_extension,
+    )
     compile_report = ctx.actions.declare_file(
         ctx.label.name + ".commands.compile.json",
     )
     args = ctx.actions.args()
     args.add(linked_module)
     args.add("--product=command")
-    args.add("--format=loom-command")
+    args.add("--format=%s" % format_info.format)
     args.add("--output=%s" % manifest.path)
     args.add("--emit-command-artifacts=%s" % artifacts.path)
     args.add("--compile-report=details")
@@ -144,20 +236,28 @@ def _declare_command_product(ctx, linked_module):
     return struct(
         artifacts = artifacts,
         compile_report = compile_report,
+        format = product_format.target,
         manifest = manifest,
     )
 
 def _loom_kernel_binary_impl(ctx):
     _require_binary_inputs(ctx)
-    target_profile = _require_amdgpu_target_profile(ctx, "kernel")
+    target_profile = ctx.attr.target[LoomTargetProfileInfo]
+    product_format = _resolve_target_product_format(
+        ctx,
+        "kernel",
+        "file",
+        ctx.attr.format,
+    )
     linked = _declare_binary_linked_module(
         ctx,
         "kernel",
         target_profile = target_profile,
     )
-    product = _declare_amdgpu_kernel_product(
+    product = _declare_kernel_product(
         ctx = ctx,
         linked_module = linked.linked_module,
+        product_format = product_format,
         target_profile = target_profile,
         output_stem = ctx.label.name,
         mnemonic = "LoomKernelBinary",
@@ -179,6 +279,7 @@ def _loom_kernel_binary_impl(ctx):
             kind = "kernel",
             linked_module = linked.linked_module,
             primary_artifact = product.artifact,
+            product_formats = {"kernel": product.format},
             reports = depset([product.compile_report]),
             target_profiles = [ctx.attr.target],
         ),
@@ -202,11 +303,15 @@ def _binary_link_attrs():
         ),
     }
 
-def _target_binary_attrs(target_doc):
+def _target_binary_attrs(target_doc, format_doc):
     attrs = _binary_link_attrs()
+    attrs["format"] = attr.label(
+        providers = [LoomProductFormatInfo],
+        doc = format_doc,
+    )
     attrs["target"] = attr.label(
         mandatory = True,
-        providers = [LoomTargetProfileInfo],
+        providers = [LoomTargetFormatSupportInfo, LoomTargetProfileInfo],
         doc = target_doc,
     )
     return attrs
@@ -215,6 +320,7 @@ loom_kernel_binary = rule(
     implementation = _loom_kernel_binary_impl,
     attrs = _target_binary_attrs(
         "Immutable target profile used for every emitted kernel.",
+        "Optional kernel format; the target's canonical format is used when omitted.",
     ),
     doc = "Links and emits one closed loader-ready kernel product.",
     toolchains = [
@@ -225,18 +331,35 @@ loom_kernel_binary = rule(
 
 def _loom_command_binary_impl(ctx):
     _require_binary_inputs(ctx)
-    target_profile = _require_amdgpu_target_profile(ctx, "command")
+    target_profile = ctx.attr.target[LoomTargetProfileInfo]
+    command_format = _resolve_target_product_format(
+        ctx,
+        "command",
+        "artifact_set",
+        ctx.attr.format,
+    )
+    kernel_format = _resolve_target_product_format(
+        ctx,
+        "kernel",
+        "file",
+        ctx.attr.kernel_format,
+    )
     linked = _declare_binary_linked_module(
         ctx,
         "command",
         target_profile = target_profile,
     )
-    command_product = _declare_command_product(ctx, linked.linked_module)
-    kernel_product = _declare_amdgpu_kernel_product(
+    command_product = _declare_command_product(
+        ctx,
+        linked.linked_module,
+        command_format,
+    )
+    kernel_product = _declare_kernel_product(
         ctx = ctx,
         linked_module = linked.linked_module,
-        target_profile = target_profile,
+        product_format = kernel_format,
         output_stem = ctx.label.name + ".kernels",
+        target_profile = target_profile,
         mnemonic = "LoomCommandKernelBinary",
         progress_message = "Compiling command kernels for %s against %s" % (
             ctx.label,
@@ -272,16 +395,27 @@ def _loom_command_binary_impl(ctx):
             kind = "command",
             linked_module = linked.linked_module,
             primary_artifact = command_product.manifest,
+            product_formats = {
+                "command": command_product.format,
+                "kernel": kernel_product.format,
+            },
             reports = depset(reports),
             target_profiles = [ctx.attr.target],
         ),
     ]
 
+_COMMAND_BINARY_ATTRS = _target_binary_attrs(
+    "Immutable target profile used for every emitted kernel entry.",
+    "Optional command format; the target's canonical format is used when omitted.",
+)
+_COMMAND_BINARY_ATTRS["kernel_format"] = attr.label(
+    providers = [LoomProductFormatInfo],
+    doc = "Optional kernel format; the target's canonical format is used when omitted.",
+)
+
 loom_command_binary = rule(
     implementation = _loom_command_binary_impl,
-    attrs = _target_binary_attrs(
-        "Immutable target profile used for every emitted kernel entry.",
-    ),
+    attrs = _COMMAND_BINARY_ATTRS,
     doc = "Links and emits portable command programs with their kernel executable.",
     toolchains = [
         _LOOM_COMPILE_TOOLCHAIN_TYPE,

--- a/loom/build_tools/bazel/loom_product_format.bzl
+++ b/loom/build_tools/bazel/loom_product_format.bzl
@@ -1,0 +1,111 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Public rules describing Loom product artifact formats."""
+
+LoomProductFormatInfo = provider(
+    doc = "One public Loom product format and its persisted output shape.",
+    fields = {
+        "artifact_directory_extension": "Artifact directory suffix, or empty for a single-file format.",
+        "format": "Public loom-compile --format value.",
+        "output_extension": "Primary output file suffix including its leading period.",
+        "output_kind": "Persistence shape: file or artifact_set.",
+        "product": "Semantic product emitted by this format.",
+    },
+)
+
+def _loom_product_format_impl(ctx):
+    return [
+        LoomProductFormatInfo(
+            artifact_directory_extension = ctx.attr.artifact_directory_extension,
+            format = ctx.attr.format,
+            output_extension = ctx.attr.output_extension,
+            output_kind = ctx.attr.output_kind,
+            product = ctx.attr.product,
+        ),
+    ]
+
+_loom_product_format = rule(
+    implementation = _loom_product_format_impl,
+    attrs = {
+        "artifact_directory_extension": attr.string(),
+        "format": attr.string(mandatory = True),
+        "output_extension": attr.string(mandatory = True),
+        "output_kind": attr.string(
+            mandatory = True,
+            values = ["artifact_set", "file"],
+        ),
+        "product": attr.string(mandatory = True),
+    },
+    doc = "Declares one public product format and persisted output shape.",
+)
+
+def _validate_product_format(product, format, output_extension):
+    if not product:
+        fail("Loom product format product must not be empty")
+    if not format:
+        fail("Loom product format name must not be empty")
+    if not output_extension.startswith("."):
+        fail("Loom product format output extension must begin with '.'")
+    if "/" in output_extension or "\\" in output_extension:
+        fail("Loom product format output extension must not contain a path")
+
+def loom_file_product_format(
+        name,
+        product,
+        format,
+        output_extension,
+        **kwargs):
+    """Declares a product format persisted as one file.
+
+    Args:
+      name: Bazel target name.
+      product: Semantic product accepted by loom-compile.
+      format: Public loom-compile --format value.
+      output_extension: Output filename suffix including its leading period.
+      **kwargs: Common rule attributes forwarded to the format target.
+    """
+    _validate_product_format(product, format, output_extension)
+    _loom_product_format(
+        name = name,
+        format = format,
+        output_extension = output_extension,
+        output_kind = "file",
+        product = product,
+        **kwargs
+    )
+
+def loom_artifact_set_product_format(
+        name,
+        product,
+        format,
+        manifest_extension,
+        artifact_directory_extension,
+        **kwargs):
+    """Declares a product format persisted as a manifest and artifact tree.
+
+    Args:
+      name: Bazel target name.
+      product: Semantic product accepted by loom-compile.
+      format: Public loom-compile --format value.
+      manifest_extension: Manifest filename suffix including its leading period.
+      artifact_directory_extension: Artifact directory suffix including its leading period.
+      **kwargs: Common rule attributes forwarded to the format target.
+    """
+    _validate_product_format(product, format, manifest_extension)
+    if not artifact_directory_extension.startswith("."):
+        fail("Loom artifact directory extension must begin with '.'")
+    if "/" in artifact_directory_extension or "\\" in artifact_directory_extension:
+        fail("Loom artifact directory extension must not contain a path")
+    _loom_product_format(
+        name = name,
+        artifact_directory_extension = artifact_directory_extension,
+        format = format,
+        output_extension = manifest_extension,
+        output_kind = "artifact_set",
+        product = product,
+        **kwargs
+    )

--- a/loom/build_tools/bazel/loom_target_profile.bzl
+++ b/loom/build_tools/bazel/loom_target_profile.bzl
@@ -16,35 +16,57 @@ load(
 )
 
 LoomTargetProfileInfo = provider(
-    doc = "Family identity shared by every immutable Loom target profile.",
+    doc = "Immutable Loom target identity shared by all target families.",
     fields = {
         "family": "Target fact family, such as amdgpu or spirv.",
+        "selector": "Family-owned exact, generic, or overlay target selector.",
     },
 )
 
-LoomAmdgpuTargetProfileInfo = provider(
-    doc = "Structured AMDGPU identity used to construct a target profile.",
-    fields = {
-        "target": "Exact, generic, or overlay AMDGPU target selector.",
-    },
-)
-
-def _loom_amdgpu_target_profile_impl(ctx):
+def _loom_target_profile_impl(ctx):
     return [
-        LoomTargetProfileInfo(family = "amdgpu"),
-        LoomAmdgpuTargetProfileInfo(target = ctx.attr.target),
+        LoomTargetProfileInfo(
+            family = ctx.attr.family,
+            selector = ctx.attr.selector,
+        ),
     ]
 
-_loom_amdgpu_target_profile = rule(
-    implementation = _loom_amdgpu_target_profile_impl,
+_loom_target_profile = rule(
+    implementation = _loom_target_profile_impl,
     attrs = {
-        "target": attr.string(
+        "family": attr.string(
             mandatory = True,
-            doc = "Exact, generic, or overlay AMDGPU target selector.",
+            doc = "Target fact family accepted by the compiler.",
+        ),
+        "selector": attr.string(
+            mandatory = True,
+            doc = "Family-owned exact, generic, or overlay selector.",
         ),
     },
-    doc = "Declares one immutable AMDGPU target identity profile.",
+    doc = "Declares one immutable Loom target identity profile.",
 )
+
+def loom_target_profile(name, family, selector, **kwargs):
+    """Declares an immutable target profile understood by the compiler.
+
+    Args:
+      name: Bazel target name.
+      family: Target fact family accepted by the compiler.
+      selector: Family-owned exact, generic, or overlay selector.
+      **kwargs: Common rule attributes forwarded to the profile target.
+    """
+    if not family:
+        fail("Loom target profile family must not be empty")
+    if ":" in family:
+        fail("Loom target profile family must not contain ':'")
+    if not selector:
+        fail("Loom target profile selector must not be empty")
+    _loom_target_profile(
+        name = name,
+        family = family,
+        selector = selector,
+        **kwargs
+    )
 
 def loom_amdgpu_target_profile(name, target, **kwargs):
     """Declares an AMDGPU profile available with its descriptor contract.
@@ -60,9 +82,10 @@ def loom_amdgpu_target_profile(name, target, **kwargs):
     if descriptor_set_capability == None:
         fail("Unknown Loom AMDGPU target profile: %s" % target)
     target_compatible_with = kwargs.pop("target_compatible_with", [])
-    _loom_amdgpu_target_profile(
+    loom_target_profile(
         name = name,
-        target = target,
+        family = "amdgpu",
+        selector = target,
         target_compatible_with = target_compatible_with +
                                  loom_amdgpu_descriptor_set_compatible_with(
                                      descriptor_set_capability,

--- a/loom/build_tools/bazel/loom_target_profile.bzl
+++ b/loom/build_tools/bazel/loom_target_profile.bzl
@@ -6,34 +6,70 @@
 
 """Public rules for immutable Loom target profiles."""
 
-load(
-    "//loom/build_tools/amdgpu:descriptor_sets.bzl",
-    "loom_amdgpu_descriptor_set_compatible_with",
-)
-load(
-    "//loom/build_tools/amdgpu:target_config.bzl",
-    "LOOM_AMDGPU_DESCRIPTOR_SET_CAPABILITY_BY_TARGET",
-)
+load(":loom_product_format.bzl", "LoomProductFormatInfo")
 
 LoomTargetProfileInfo = provider(
     doc = "Immutable Loom target identity shared by all target families.",
     fields = {
-        "family": "Target fact family, such as amdgpu or spirv.",
+        "family": "Target fact family understood by the compiler.",
         "selector": "Family-owned exact, generic, or overlay target selector.",
     },
 )
 
+LoomTargetFormatSupportInfo = provider(
+    doc = "Product formats supported by one immutable target profile.",
+    fields = {
+        "canonical_formats": "Product-name keyed canonical format targets.",
+        "formats": "Ordered compatible product format targets.",
+    },
+)
+
 def _loom_target_profile_impl(ctx):
+    canonical_formats = {}
+    for format_target in ctx.attr.canonical_formats:
+        format_info = format_target[LoomProductFormatInfo]
+        if format_info.product in canonical_formats:
+            fail(
+                "%s declares multiple canonical formats for product %r" %
+                (ctx.label, format_info.product),
+            )
+        canonical_formats[format_info.product] = format_target
+
+    formats = ctx.attr.canonical_formats + ctx.attr.formats
+    seen_formats = {}
+    for format_target in formats:
+        format_info = format_target[LoomProductFormatInfo]
+        key = "%s\n%s" % (format_info.product, format_info.format)
+        if key in seen_formats:
+            fail(
+                "%s declares product format %s/%s more than once via %s and %s" % (
+                    ctx.label,
+                    format_info.product,
+                    format_info.format,
+                    seen_formats[key].label,
+                    format_target.label,
+                ),
+            )
+        seen_formats[key] = format_target
+
     return [
         LoomTargetProfileInfo(
             family = ctx.attr.family,
             selector = ctx.attr.selector,
+        ),
+        LoomTargetFormatSupportInfo(
+            canonical_formats = canonical_formats,
+            formats = formats,
         ),
     ]
 
 _loom_target_profile = rule(
     implementation = _loom_target_profile_impl,
     attrs = {
+        "canonical_formats": attr.label_list(
+            providers = [LoomProductFormatInfo],
+            doc = "Canonical product formats, at most one for each product.",
+        ),
         "family": attr.string(
             mandatory = True,
             doc = "Target fact family accepted by the compiler.",
@@ -42,17 +78,29 @@ _loom_target_profile = rule(
             mandatory = True,
             doc = "Family-owned exact, generic, or overlay selector.",
         ),
+        "formats": attr.label_list(
+            providers = [LoomProductFormatInfo],
+            doc = "Additional noncanonical formats supported by this profile.",
+        ),
     },
     doc = "Declares one immutable Loom target identity profile.",
 )
 
-def loom_target_profile(name, family, selector, **kwargs):
+def loom_target_profile(
+        name,
+        family,
+        selector,
+        canonical_formats = [],
+        formats = [],
+        **kwargs):
     """Declares an immutable target profile understood by the compiler.
 
     Args:
       name: Bazel target name.
       family: Target fact family accepted by the compiler.
       selector: Family-owned exact, generic, or overlay selector.
+      canonical_formats: Canonical format labels, at most one for each product.
+      formats: Additional noncanonical format labels supported by this profile.
       **kwargs: Common rule attributes forwarded to the profile target.
     """
     if not family:
@@ -63,32 +111,9 @@ def loom_target_profile(name, family, selector, **kwargs):
         fail("Loom target profile selector must not be empty")
     _loom_target_profile(
         name = name,
+        canonical_formats = canonical_formats,
         family = family,
+        formats = formats,
         selector = selector,
-        **kwargs
-    )
-
-def loom_amdgpu_target_profile(name, target, **kwargs):
-    """Declares an AMDGPU profile available with its descriptor contract.
-
-    Args:
-      name: Bazel target name.
-      target: Exact, generic, or overlay AMDGPU target selector.
-      **kwargs: Common rule attributes forwarded to the profile target.
-    """
-    descriptor_set_capability = (
-        LOOM_AMDGPU_DESCRIPTOR_SET_CAPABILITY_BY_TARGET.get(target)
-    )
-    if descriptor_set_capability == None:
-        fail("Unknown Loom AMDGPU target profile: %s" % target)
-    target_compatible_with = kwargs.pop("target_compatible_with", [])
-    loom_target_profile(
-        name = name,
-        family = "amdgpu",
-        selector = target,
-        target_compatible_with = target_compatible_with +
-                                 loom_amdgpu_descriptor_set_compatible_with(
-                                     descriptor_set_capability,
-                                 ),
         **kwargs
     )

--- a/loom/build_tools/bazel/test/BUILD.bazel
+++ b/loom/build_tools/bazel/test/BUILD.bazel
@@ -15,13 +15,13 @@ load(
     "loom_kernel_library",
     "loom_library",
     "loom_module",
+    "loom_target_profile",
     "loom_test",
 )
 load("//loom/build_tools/bazel:loom_check.bzl", "loom_check_test")
 load(
     ":loom_binary_rules_test.bzl",
     "loom_binary_rules_test_suite",
-    "test_target_profile",
 )
 load(":loom_check_rules_test.bzl", "loom_check_rules_test_suite")
 load(
@@ -43,9 +43,10 @@ loom_amdgpu_target_profile(
     target = "gfx942",
 )
 
-test_target_profile(
+loom_target_profile(
     name = "test_spirv_profile",
     family = "spirv",
+    selector = "vulkan1.3+bda",
 )
 
 loom_kernel_library(

--- a/loom/build_tools/bazel/test/BUILD.bazel
+++ b/loom/build_tools/bazel/test/BUILD.bazel
@@ -9,8 +9,13 @@
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//build_tools/bazel:executable.bzl", "iree_executable_test")
 load(
-    "//loom/build_tools/bazel:defs.bzl",
+    "//loom/build_tools/amdgpu:target_profile.bzl",
     "loom_amdgpu_target_profile",
+)
+load(
+    "//loom/build_tools/bazel:defs.bzl",
+    "loom_artifact_set_product_format",
+    "loom_file_product_format",
     "loom_kernel_binary",
     "loom_kernel_library",
     "loom_library",
@@ -43,10 +48,61 @@ loom_amdgpu_target_profile(
     target = "gfx942",
 )
 
+loom_file_product_format(
+    name = "test_kernel_format",
+    format = "test-kernel-format",
+    output_extension = ".tbin",
+    product = "kernel",
+)
+
+loom_file_product_format(
+    name = "test_alternate_kernel_format",
+    format = "test-alternate-kernel-format",
+    output_extension = ".alt",
+    product = "kernel",
+)
+
+loom_file_product_format(
+    name = "test_unsupported_kernel_format",
+    format = "test-unsupported-kernel-format",
+    output_extension = ".unsupported",
+    product = "kernel",
+)
+
+loom_artifact_set_product_format(
+    name = "test_command_format",
+    artifact_directory_extension = ".test.commands",
+    format = "test-command-format",
+    manifest_extension = ".test.commands.json",
+    product = "command",
+)
+
 loom_target_profile(
-    name = "test_spirv_profile",
-    family = "spirv",
-    selector = "vulkan1.3+bda",
+    name = "test_target_profile",
+    canonical_formats = [
+        ":test_command_format",
+        ":test_kernel_format",
+    ],
+    family = "test-family",
+    formats = [":test_alternate_kernel_format"],
+    selector = "test-selector",
+)
+
+loom_target_profile(
+    name = "test_empty_profile",
+    family = "test-empty",
+    selector = "empty",
+)
+
+loom_target_profile(
+    name = "test_duplicate_canonical_profile",
+    canonical_formats = [
+        ":test_alternate_kernel_format",
+        ":test_kernel_format",
+    ],
+    family = "test-invalid",
+    selector = "duplicate-canonical",
+    tags = ["manual"],
 )
 
 loom_kernel_library(
@@ -99,6 +155,13 @@ loom_kernel_binary(
     tags = ["manual"],
     target = "//loom/target/amdgpu:gfx11-generic",
     deps = [":public_kernel_library"],
+)
+
+loom_kernel_binary(
+    name = "kernel_binary_spirv",
+    srcs = ["link_kernels.loom"],
+    tags = ["manual"],
+    target = "//loom/target/spirv:vulkan1.3+bda",
 )
 
 loom_library(

--- a/loom/build_tools/bazel/test/link_kernels.loom
+++ b/loom/build_tools/bazel/test/link_kernels.loom
@@ -5,8 +5,10 @@ kernel.def export("scale") @scale() {
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %input_view = buffer.view %input[%base] : buffer -> view<4xi32>
-  %output_view = buffer.view %output[%base] : buffer -> view<4xi32>
+  %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
+  %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<4xi32>
+  %output_view = buffer.view %output_aligned[%base] : buffer -> view<4xi32>
   %value = view.load %input_view[%lane] : view<4xi32> -> i32
   %scaled = scalar.addi %value, %value : i32
   view.store %scaled, %output_view[%lane] : i32, view<4xi32>

--- a/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
@@ -202,29 +202,152 @@ def _test_explicit_roots_replace_direct_exports_impl(env, target):
         "public_kernel_library.loombc",
     )
 
-def _test_kernel_binary_profile_mismatch(name, **kwargs):
+def _test_kernel_binary_accepts_generic_profile(name, **kwargs):
     subject = name + "_subject"
     util.helper_target(
         loom_kernel_binary,
         name = subject,
         deps = [":public_kernel_library"],
         tags = ["manual"],
-        target = ":test_spirv_profile",
+        target = ":test_target_profile",
     )
     analysis_test(
         name = name,
-        expect_failure = True,
-        impl = _test_kernel_binary_profile_mismatch_impl,
+        impl = _test_kernel_binary_accepts_generic_profile_impl,
         target = subject,
         **kwargs
     )
 
-def _test_kernel_binary_profile_mismatch_impl(env, target):
-    env.expect.that_target(target).failures().contains_predicate(
-        matching.contains(
-            "cannot emit a kernel binary for target profile family \"spirv\"",
-        ),
+def _test_kernel_binary_accepts_generic_profile_impl(env, target):
+    binary = target[LoomBinaryInfo]
+    env.expect.that_str(binary.primary_artifact.basename).equals(
+        target.label.name + ".tbin",
     )
+    env.expect.that_str(
+        binary.product_formats["kernel"].label.name,
+    ).equals("test_kernel_format")
+    actions = target[TestingAspectInfo].actions
+    link_action = _find_action(env, actions, "LoomBinaryLink")
+    if "--target=test-family:test-selector" not in link_action.argv:
+        env.fail("expected generic target in link arguments %r" % link_action.argv)
+    compile_action = _find_action(env, actions, "LoomKernelBinary")
+    for expected_arg in [
+        "--product=kernel",
+        "--format=test-kernel-format",
+        "--target=test-family:test-selector",
+    ]:
+        if expected_arg not in compile_action.argv:
+            env.fail(
+                "expected %r in compile arguments %r" %
+                (expected_arg, compile_action.argv),
+            )
+
+def _test_kernel_binary_accepts_explicit_format(name, **kwargs):
+    subject = name + "_subject"
+    util.helper_target(
+        loom_kernel_binary,
+        name = subject,
+        deps = [":public_kernel_library"],
+        format = ":test_alternate_kernel_format",
+        tags = ["manual"],
+        target = ":test_target_profile",
+    )
+    analysis_test(
+        name = name,
+        impl = _test_kernel_binary_accepts_explicit_format_impl,
+        target = subject,
+        **kwargs
+    )
+
+def _test_kernel_binary_accepts_explicit_format_impl(env, target):
+    binary = target[LoomBinaryInfo]
+    env.expect.that_str(binary.primary_artifact.basename).equals(
+        target.label.name + ".alt",
+    )
+    env.expect.that_str(
+        binary.product_formats["kernel"].label.name,
+    ).equals("test_alternate_kernel_format")
+    compile_action = _find_action(
+        env,
+        target[TestingAspectInfo].actions,
+        "LoomKernelBinary",
+    )
+    if "--format=test-alternate-kernel-format" not in compile_action.argv:
+        env.fail("expected explicit format in %r" % compile_action.argv)
+
+def _test_kernel_binary_rejects_unsupported_format(name, **kwargs):
+    subject = name + "_subject"
+    util.helper_target(
+        loom_kernel_binary,
+        name = subject,
+        deps = [":public_kernel_library"],
+        format = ":test_unsupported_kernel_format",
+        tags = ["manual"],
+        target = ":test_target_profile",
+    )
+    analysis_test(
+        name = name,
+        expect_failure = True,
+        impl = _test_kernel_binary_rejects_unsupported_format_impl,
+        target = subject,
+        **kwargs
+    )
+
+def _test_kernel_binary_rejects_unsupported_format_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.contains("does not support product format"),
+    )
+
+def _test_kernel_binary_requires_canonical_format(name, **kwargs):
+    subject = name + "_subject"
+    util.helper_target(
+        loom_kernel_binary,
+        name = subject,
+        deps = [":public_kernel_library"],
+        tags = ["manual"],
+        target = ":test_empty_profile",
+    )
+    analysis_test(
+        name = name,
+        expect_failure = True,
+        impl = _test_kernel_binary_requires_canonical_format_impl,
+        target = subject,
+        **kwargs
+    )
+
+def _test_kernel_binary_requires_canonical_format_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.contains("has no canonical format for product \"kernel\""),
+    )
+
+def _test_kernel_binary_uses_builtin_spirv_format(name, **kwargs):
+    subject = name + "_subject"
+    util.helper_target(
+        loom_kernel_binary,
+        name = subject,
+        deps = [":public_kernel_library"],
+        tags = ["manual"],
+        target = "//loom/target/spirv:vulkan1.3+bda",
+    )
+    analysis_test(
+        name = name,
+        impl = _test_kernel_binary_uses_builtin_spirv_format_impl,
+        target = subject,
+        **kwargs
+    )
+
+def _test_kernel_binary_uses_builtin_spirv_format_impl(env, target):
+    binary = target[LoomBinaryInfo]
+    env.expect.that_str(binary.primary_artifact.basename).equals(
+        target.label.name + ".spv",
+    )
+    compile_action = _find_action(
+        env,
+        target[TestingAspectInfo].actions,
+        "LoomKernelBinary",
+    )
+    if "--format=spirv-binary" not in compile_action.argv:
+        env.fail("expected SPIR-V format in %r" % compile_action.argv)
 
 def _test_command_binary_emits_composite_product(name, **kwargs):
     analysis_test(
@@ -396,29 +519,54 @@ def _test_command_binary_explicit_roots_replace_exports_impl(env, target):
         "interface.loombc",
     )
 
-def _test_command_binary_profile_mismatch(name, **kwargs):
+def _test_command_binary_uses_generic_profile_canonical_formats(name, **kwargs):
     subject = name + "_subject"
     util.helper_target(
         loom_command_binary,
         name = subject,
         deps = [":public_kernel_library"],
         tags = ["manual"],
-        target = ":test_spirv_profile",
+        target = ":test_target_profile",
     )
     analysis_test(
         name = name,
-        expect_failure = True,
-        impl = _test_command_binary_profile_mismatch_impl,
+        impl = _test_command_binary_uses_generic_profile_canonical_formats_impl,
         target = subject,
         **kwargs
     )
 
-def _test_command_binary_profile_mismatch_impl(env, target):
-    env.expect.that_target(target).failures().contains_predicate(
-        matching.contains(
-            "cannot emit a command binary for target profile family \"spirv\"",
-        ),
+def _test_command_binary_uses_generic_profile_canonical_formats_impl(env, target):
+    binary = target[LoomBinaryInfo]
+    env.expect.that_str(binary.primary_artifact.basename).equals(
+        target.label.name + ".test.commands.json",
     )
+    env.expect.that_str(
+        binary.product_formats["command"].label.name,
+    ).equals("test_command_format")
+    env.expect.that_str(
+        binary.product_formats["kernel"].label.name,
+    ).equals("test_kernel_format")
+    for basename in [
+        target.label.name + ".kernels.tbin",
+        target.label.name + ".test.commands",
+        target.label.name + ".test.commands.json",
+    ]:
+        _expect_basename(env, binary.artifacts.to_list(), basename)
+
+    actions = target[TestingAspectInfo].actions
+    command_action = _find_action(env, actions, "LoomCommandBinary")
+    if "--format=test-command-format" not in command_action.argv:
+        env.fail("expected generic command format in %r" % command_action.argv)
+    kernel_action = _find_action(env, actions, "LoomCommandKernelBinary")
+    for expected_arg in [
+        "--format=test-kernel-format",
+        "--target=test-family:test-selector",
+    ]:
+        if expected_arg not in kernel_action.argv:
+            env.fail(
+                "expected %r in kernel arguments %r" %
+                (expected_arg, kernel_action.argv),
+            )
 
 def loom_binary_rules_test_suite(name):
     test_suite(
@@ -426,11 +574,15 @@ def loom_binary_rules_test_suite(name):
         tests = [
             _test_command_binary_emits_composite_product,
             _test_command_binary_explicit_roots_replace_exports,
-            _test_command_binary_profile_mismatch,
             _test_command_binary_sources_are_an_implicit_library,
+            _test_command_binary_uses_generic_profile_canonical_formats,
             _test_explicit_roots_replace_direct_exports,
-            _test_kernel_binary_profile_mismatch,
+            _test_kernel_binary_accepts_explicit_format,
+            _test_kernel_binary_accepts_generic_profile,
             _test_kernel_binary_roots_direct_library_exports,
+            _test_kernel_binary_requires_canonical_format,
+            _test_kernel_binary_rejects_unsupported_format,
             _test_kernel_binary_sources_are_an_implicit_library,
+            _test_kernel_binary_uses_builtin_spirv_format,
         ],
     )

--- a/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
@@ -17,16 +17,6 @@ load(
     "loom_kernel_binary",
 )
 
-def _test_target_profile_impl(ctx):
-    return [LoomTargetProfileInfo(family = ctx.attr.family)]
-
-test_target_profile = rule(
-    implementation = _test_target_profile_impl,
-    attrs = {
-        "family": attr.string(mandatory = True),
-    },
-)
-
 def _find_action(env, actions, mnemonic):
     for action in actions:
         if action.mnemonic == mnemonic:
@@ -79,6 +69,9 @@ def _test_kernel_binary_roots_direct_library_exports_impl(env, target):
     env.expect.that_str(
         binary.target_profiles[0][LoomTargetProfileInfo].family,
     ).equals("amdgpu")
+    env.expect.that_str(
+        binary.target_profiles[0][LoomTargetProfileInfo].selector,
+    ).equals("gfx11-generic")
 
     default_files = target[DefaultInfo].files.to_list()
     if len(default_files) != 1:
@@ -255,6 +248,9 @@ def _test_command_binary_emits_composite_product_impl(env, target):
     env.expect.that_str(
         binary.target_profiles[0][LoomTargetProfileInfo].family,
     ).equals("amdgpu")
+    env.expect.that_str(
+        binary.target_profiles[0][LoomTargetProfileInfo].selector,
+    ).equals("gfx11-generic")
 
     artifacts = binary.artifacts.to_list()
     if len(artifacts) != 3:

--- a/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
@@ -519,7 +519,7 @@ def _test_command_binary_explicit_roots_replace_exports_impl(env, target):
         "interface.loombc",
     )
 
-def _test_command_binary_uses_generic_profile_canonical_formats(name, **kwargs):
+def _test_command_binary_profile_defaults(name, **kwargs):
     subject = name + "_subject"
     util.helper_target(
         loom_command_binary,
@@ -530,12 +530,12 @@ def _test_command_binary_uses_generic_profile_canonical_formats(name, **kwargs):
     )
     analysis_test(
         name = name,
-        impl = _test_command_binary_uses_generic_profile_canonical_formats_impl,
+        impl = _test_command_binary_profile_defaults_impl,
         target = subject,
         **kwargs
     )
 
-def _test_command_binary_uses_generic_profile_canonical_formats_impl(env, target):
+def _test_command_binary_profile_defaults_impl(env, target):
     binary = target[LoomBinaryInfo]
     env.expect.that_str(binary.primary_artifact.basename).equals(
         target.label.name + ".test.commands.json",
@@ -575,7 +575,7 @@ def loom_binary_rules_test_suite(name):
             _test_command_binary_emits_composite_product,
             _test_command_binary_explicit_roots_replace_exports,
             _test_command_binary_sources_are_an_implicit_library,
-            _test_command_binary_uses_generic_profile_canonical_formats,
+            _test_command_binary_profile_defaults,
             _test_explicit_roots_replace_direct_exports,
             _test_kernel_binary_accepts_explicit_format,
             _test_kernel_binary_accepts_generic_profile,

--- a/loom/build_tools/bazel/test/loom_target_profile_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_target_profile_rules_test.bzl
@@ -9,7 +9,6 @@
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 load(
     "//loom/build_tools/bazel:defs.bzl",
-    "LoomAmdgpuTargetProfileInfo",
     "LoomTargetProfileInfo",
 )
 
@@ -24,8 +23,7 @@ def _test_amdgpu_profile_is_family_typed(name, **kwargs):
 def _test_amdgpu_profile_is_family_typed_impl(env, target):
     profile = target[LoomTargetProfileInfo]
     env.expect.that_str(profile.family).equals("amdgpu")
-    amdgpu_profile = target[LoomAmdgpuTargetProfileInfo]
-    env.expect.that_str(amdgpu_profile.target).equals("gfx942")
+    env.expect.that_str(profile.selector).equals("gfx942")
 
     if hasattr(profile, "backend"):
         env.fail("target profile must not select a compiler backend")
@@ -41,10 +39,22 @@ def _test_builtin_profile_preserves_overlay_identity(name, **kwargs):
     )
 
 def _test_builtin_profile_preserves_overlay_identity_impl(env, target):
-    env.expect.that_str(target[LoomTargetProfileInfo].family).equals("amdgpu")
-    env.expect.that_str(
-        target[LoomAmdgpuTargetProfileInfo].target,
-    ).equals("gfx1250-a0")
+    profile = target[LoomTargetProfileInfo]
+    env.expect.that_str(profile.family).equals("amdgpu")
+    env.expect.that_str(profile.selector).equals("gfx1250-a0")
+
+def _test_generic_profile_preserves_family_identity(name, **kwargs):
+    analysis_test(
+        name = name,
+        impl = _test_generic_profile_preserves_family_identity_impl,
+        target = ":test_spirv_profile",
+        **kwargs
+    )
+
+def _test_generic_profile_preserves_family_identity_impl(env, target):
+    profile = target[LoomTargetProfileInfo]
+    env.expect.that_str(profile.family).equals("spirv")
+    env.expect.that_str(profile.selector).equals("vulkan1.3+bda")
 
 def loom_target_profile_rules_test_suite(name):
     test_suite(
@@ -52,5 +62,6 @@ def loom_target_profile_rules_test_suite(name):
         tests = [
             _test_amdgpu_profile_is_family_typed,
             _test_builtin_profile_preserves_overlay_identity,
+            _test_generic_profile_preserves_family_identity,
         ],
     )

--- a/loom/build_tools/bazel/test/loom_target_profile_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_target_profile_rules_test.bzl
@@ -7,8 +7,11 @@
 """Analysis tests for immutable Loom target profiles."""
 
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
+load("@rules_testing//lib:truth.bzl", "matching")
 load(
     "//loom/build_tools/bazel:defs.bzl",
+    "LoomProductFormatInfo",
+    "LoomTargetFormatSupportInfo",
     "LoomTargetProfileInfo",
 )
 
@@ -24,6 +27,16 @@ def _test_amdgpu_profile_is_family_typed_impl(env, target):
     profile = target[LoomTargetProfileInfo]
     env.expect.that_str(profile.family).equals("amdgpu")
     env.expect.that_str(profile.selector).equals("gfx942")
+
+    format_support = target[LoomTargetFormatSupportInfo]
+    env.expect.that_str(
+        format_support.canonical_formats["kernel"].label.name,
+    ).equals("amdgpu_hsaco")
+    env.expect.that_str(
+        format_support.canonical_formats["command"].label.name,
+    ).equals("loom_command")
+    if len(format_support.formats) != 2:
+        env.fail("expected two AMDGPU product formats, got %r" % format_support.formats)
 
     if hasattr(profile, "backend"):
         env.fail("target profile must not select a compiler backend")
@@ -47,14 +60,59 @@ def _test_generic_profile_preserves_family_identity(name, **kwargs):
     analysis_test(
         name = name,
         impl = _test_generic_profile_preserves_family_identity_impl,
-        target = ":test_spirv_profile",
+        target = ":test_target_profile",
         **kwargs
     )
 
 def _test_generic_profile_preserves_family_identity_impl(env, target):
     profile = target[LoomTargetProfileInfo]
+    env.expect.that_str(profile.family).equals("test-family")
+    env.expect.that_str(profile.selector).equals("test-selector")
+    support = target[LoomTargetFormatSupportInfo]
+    env.expect.that_str(
+        support.canonical_formats["kernel"].label.name,
+    ).equals("test_kernel_format")
+    env.expect.that_str(
+        support.canonical_formats["command"].label.name,
+    ).equals("test_command_format")
+    if len(support.formats) != 3:
+        env.fail("expected three synthetic formats, got %r" % support.formats)
+
+def _test_builtin_spirv_profile_owns_canonical_format(name, **kwargs):
+    analysis_test(
+        name = name,
+        impl = _test_builtin_spirv_profile_owns_canonical_format_impl,
+        target = "//loom/target/spirv:vulkan1.3+bda",
+        **kwargs
+    )
+
+def _test_builtin_spirv_profile_owns_canonical_format_impl(env, target):
+    profile = target[LoomTargetProfileInfo]
     env.expect.that_str(profile.family).equals("spirv")
     env.expect.that_str(profile.selector).equals("vulkan1.3+bda")
+    support = target[LoomTargetFormatSupportInfo]
+    format_target = support.canonical_formats["kernel"]
+    env.expect.that_str(format_target.label.name).equals("spirv_binary")
+    format_info = format_target[LoomProductFormatInfo]
+    env.expect.that_str(format_info.format).equals("spirv-binary")
+    env.expect.that_str(format_info.output_extension).equals(".spv")
+    env.expect.that_str(
+        support.canonical_formats["command"].label.name,
+    ).equals("loom_command")
+
+def _test_duplicate_canonical_product_fails(name, **kwargs):
+    analysis_test(
+        name = name,
+        expect_failure = True,
+        impl = _test_duplicate_canonical_product_fails_impl,
+        target = ":test_duplicate_canonical_profile",
+        **kwargs
+    )
+
+def _test_duplicate_canonical_product_fails_impl(env, target):
+    env.expect.that_target(target).failures().contains_predicate(
+        matching.contains("declares multiple canonical formats for product \"kernel\""),
+    )
 
 def loom_target_profile_rules_test_suite(name):
     test_suite(
@@ -62,6 +120,8 @@ def loom_target_profile_rules_test_suite(name):
         tests = [
             _test_amdgpu_profile_is_family_typed,
             _test_builtin_profile_preserves_overlay_identity,
+            _test_builtin_spirv_profile_owns_canonical_format,
+            _test_duplicate_canonical_product_fails,
             _test_generic_profile_preserves_family_identity,
         ],
     )

--- a/loom/build_tools/bazel/test/testdata/command_binary/BUILD.bazel
+++ b/loom/build_tools/bazel/test/testdata/command_binary/BUILD.bazel
@@ -70,6 +70,13 @@ loom_command_binary(
     ],
 )
 
+loom_command_binary(
+    name = "spirv_subject",
+    tags = ["manual"],
+    target = "//loom/target/spirv:vulkan1.3+bda",
+    deps = [":interface"],
+)
+
 filegroup(
     name = "deps_subject_command_report",
     srcs = [":deps_subject"],

--- a/loom/product/formats/BUILD.bazel
+++ b/loom/product/formats/BUILD.bazel
@@ -1,0 +1,50 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# bazel-to-cmake: skip
+
+load(
+    "//loom/build_tools/bazel:loom_product_format.bzl",
+    "loom_artifact_set_product_format",
+    "loom_file_product_format",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+loom_file_product_format(
+    name = "amdgpu_hsaco",
+    format = "amdgpu-hsaco",
+    output_extension = ".hsaco",
+    product = "kernel",
+)
+
+loom_file_product_format(
+    name = "spirv_binary",
+    format = "spirv-binary",
+    output_extension = ".spv",
+    product = "kernel",
+)
+
+loom_file_product_format(
+    name = "llvmir_text",
+    format = "llvmir-text",
+    output_extension = ".ll",
+    product = "kernel",
+)
+
+loom_file_product_format(
+    name = "llvmir_bitcode",
+    format = "llvmir-bitcode",
+    output_extension = ".bc",
+    product = "kernel",
+)
+
+loom_artifact_set_product_format(
+    name = "loom_command",
+    artifact_directory_extension = ".commands",
+    format = "loom-command",
+    manifest_extension = ".commands.json",
+    product = "command",
+)

--- a/loom/requirements/package_policy.bzl
+++ b/loom/requirements/package_policy.bzl
@@ -42,6 +42,10 @@ PACKAGE_POLICIES = [
         build_requirements = [TARGET_ARCH_LLVMIR],
     ),
     package_policy(
+        packages = ["loom/src/loom/ops/llvmir/..."],
+        build_requirements = [TARGET_ARCH_LLVMIR],
+    ),
+    package_policy(
         packages = ["loom/src/loom/target/arch/spirv/..."],
         build_requirements = [TARGET_ARCH_SPIRV],
     ),

--- a/loom/src/loom/ops/llvmir/CMakeLists.txt
+++ b/loom/src/loom/ops/llvmir/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 iree_add_all_subdirs()
 
+if(LOOM_TARGET_ARCH_LLVMIR)
 loom_generated_cc_library(
   NAME
     llvmir
@@ -39,5 +40,6 @@ loom_generated_cc_library(
     loom::target::arch::llvmir::facts
     loom::target::types
 )
+endif()
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/loom/src/loom/tools/loom-check/BUILD.bazel
+++ b/loom/src/loom/tools/loom-check/BUILD.bazel
@@ -4,6 +4,7 @@ load(
     "loom_cc_binary",
     "loom_cc_library",
     "loom_cc_test",
+    "loom_config_compatible_with",
 )
 
 package(
@@ -11,6 +12,10 @@ package(
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )
+
+_LLVMIR_ARTIFACTS_COMPATIBLE_WITH = loom_config_compatible_with([
+    "//loom/config/target:llvmir_artifacts",
+])
 
 _EMIT_AMDGPU_CHECK_COPTS = iree_select({
     "//loom/config/emit:amdgpu": [
@@ -445,6 +450,7 @@ loom_cc_library(
     name = "llvmir_provider",
     srcs = ["llvmir_provider.c"],
     hdrs = ["llvmir_provider.h"],
+    target_compatible_with = _LLVMIR_ARTIFACTS_COMPATIBLE_WITH,
     deps = [
         ":provider",
         "//loom/src/loom/target/emit/llvmir:loom_check",

--- a/loom/src/loom/tools/loom-check/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-check/CMakeLists.txt
@@ -337,6 +337,7 @@ loom_cc_library(
   PUBLIC
 )
 
+if(LOOM_TARGET_ARCH_LLVMIR AND LOOM_EMIT_LLVMIR)
 loom_cc_library(
   NAME
     llvmir_provider
@@ -350,6 +351,7 @@ loom_cc_library(
     loom::target::emit::llvmir::loom_check
   PUBLIC
 )
+endif()
 
 loom_cc_library(
   NAME

--- a/loom/target/amdgpu/BUILD.bazel
+++ b/loom/target/amdgpu/BUILD.bazel
@@ -11,7 +11,7 @@ load(
     "LOOM_AMDGPU_SUPPORTED_TARGETS",
 )
 load(
-    "//loom/build_tools/bazel:defs.bzl",
+    "//loom/build_tools/amdgpu:target_profile.bzl",
     "loom_amdgpu_target_profile",
 )
 

--- a/loom/target/spirv/BUILD.bazel
+++ b/loom/target/spirv/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# bazel-to-cmake: skip
+
+load("//loom/build_tools/bazel:loom_target_profile.bzl", "loom_target_profile")
+
+package(default_visibility = ["//visibility:public"])
+
+loom_target_profile(
+    name = "vulkan1.3+bda",
+    canonical_formats = [
+        "//loom/product/formats:loom_command",
+        "//loom/product/formats:spirv_binary",
+    ],
+    family = "spirv",
+    selector = "vulkan1.3+bda",
+)


### PR DESCRIPTION
Target-disabled CMake configurations now omit LLVMIR-owned code instead of retaining dangling references to targets that were never declared. This restores `LOOM_TARGET_DEFAULTS=OFF` as a valid configuration and keeps optional target families genuinely optional.

The LLVMIR operation package now declares its architecture requirement, while the LLVMIR provider inside the otherwise target-independent `loom-check` package declares target-local artifact compatibility. Those Bazel ownership declarations drive the generated CMake guards, so both build systems share one source of truth.

## Reviewer Notes

- `ops/llvmir` is wholly architecture-owned; `loom-check` is a mixed package and therefore requires the narrower per-target guard.