### PR TITLE
[Loom] Share compile request resolution

### DIFF
--- a/loom/src/loom/tooling/compile/BUILD.bazel
+++ b/loom/src/loom/tooling/compile/BUILD.bazel
@@ -131,6 +131,38 @@ loom_cc_test(
 )
 
 loom_cc_library(
+    name = "request",
+    srcs = ["request.c"],
+    hdrs = ["request.h"],
+    deps = [
+        ":artifact",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/ops:op_defs",
+        "//loom/src/loom/target:entry_selection",
+        "//loom/src/loom/target:projection",
+        "//loom/src/loom/target:provider",
+        "//loom/src/loom/target:selection",
+        "//runtime/src/iree/base",
+    ],
+)
+
+loom_cc_test(
+    name = "request_test",
+    srcs = ["request_test.cc"],
+    deps = [
+        ":request",
+        "//loom/src/loom/format/text:parser",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/ops/target",
+        "//loom/src/loom/testing:context",
+        "//loom/src/loom/testing:module_ptr",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_library(
     name = "report_capture",
     srcs = ["report_capture.c"],
     hdrs = ["report_capture.h"],

--- a/loom/src/loom/tooling/compile/CMakeLists.txt
+++ b/loom/src/loom/tooling/compile/CMakeLists.txt
@@ -125,6 +125,42 @@ loom_cc_test(
 
 loom_cc_library(
   NAME
+    request
+  HDRS
+    "request.h"
+  SRCS
+    "request.c"
+  DEPS
+    ::artifact
+    iree::base
+    loom::ir
+    loom::ops::op_defs
+    loom::target::entry_selection
+    loom::target::projection
+    loom::target::provider
+    loom::target::selection
+  PUBLIC
+)
+
+loom_cc_test(
+  NAME
+    request_test
+  SRCS
+    "request_test.cc"
+  DEPS
+    ::request
+    iree::base::internal::arena
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::format::text::parser
+    loom::ir
+    loom::ops::target
+    loom::testing::context
+    loom::testing::module_ptr
+)
+
+loom_cc_library(
+  NAME
     report_capture
   HDRS
     "report_capture.h"

--- a/loom/src/loom/tooling/compile/request.c
+++ b/loom/src/loom/tooling/compile/request.c
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "loom/tools/loom-compile/request.h"
+#include "loom/tooling/compile/request.h"
 
 #include "loom/ops/op_defs.h"
 #include "loom/target/entry_selection.h"

--- a/loom/src/loom/tooling/compile/request.h
+++ b/loom/src/loom/tooling/compile/request.h
@@ -4,10 +4,10 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Allocation-free loom-compile product and format request resolution.
+// Allocation-free product and format request resolution.
 
-#ifndef LOOM_TOOLS_LOOM_COMPILE_REQUEST_H_
-#define LOOM_TOOLS_LOOM_COMPILE_REQUEST_H_
+#ifndef LOOM_TOOLING_COMPILE_REQUEST_H_
+#define LOOM_TOOLING_COMPILE_REQUEST_H_
 
 #include "iree/base/api.h"
 #include "loom/ir/module.h"
@@ -111,4 +111,4 @@ iree_status_t loom_compile_request_resolve(
 }  // extern "C"
 #endif
 
-#endif  // LOOM_TOOLS_LOOM_COMPILE_REQUEST_H_
+#endif  // LOOM_TOOLING_COMPILE_REQUEST_H_

--- a/loom/src/loom/tooling/compile/request_test.cc
+++ b/loom/src/loom/tooling/compile/request_test.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "loom/tools/loom-compile/request.h"
+#include "loom/tooling/compile/request.h"
 
 #include "iree/base/internal/arena.h"
 #include "iree/testing/gtest.h"

--- a/loom/src/loom/tools/loom-compile/BUILD.bazel
+++ b/loom/src/loom/tools/loom-compile/BUILD.bazel
@@ -64,30 +64,12 @@ loom_cc_library(
     ],
 )
 
-loom_cc_library(
-    name = "request",
-    srcs = ["request.c"],
-    hdrs = ["request.h"],
-    visibility = ["//loom/src/loom/tools/loom-compile:__pkg__"],
-    deps = [
-        "//loom/src/loom/ir",
-        "//loom/src/loom/ops:op_defs",
-        "//loom/src/loom/target:entry_selection",
-        "//loom/src/loom/target:projection",
-        "//loom/src/loom/target:provider",
-        "//loom/src/loom/target:selection",
-        "//loom/src/loom/tooling/compile:artifact",
-        "//runtime/src/iree/base",
-    ],
-)
-
 loom_cc_binary(
     name = "loom-compile",
     srcs = ["loom-compile.c"],
     deps = [
         ":command_backend",
         ":command_manifest",
-        ":request",
         "//loom/src/loom/codegen/low:text_asm",
         "//loom/src/loom/error:diagnostic",
         "//loom/src/loom/format/text:printer",
@@ -107,6 +89,7 @@ loom_cc_binary(
         "//loom/src/loom/tooling/compile:options",
         "//loom/src/loom/tooling/compile:pipeline",
         "//loom/src/loom/tooling/compile:report_capture",
+        "//loom/src/loom/tooling/compile:request",
         "//loom/src/loom/tooling/config",
         "//loom/src/loom/tooling/context",
         "//loom/src/loom/tooling/execution:session",
@@ -133,22 +116,6 @@ loom_cc_test(
         "//loom/src/loom/target/arch/cmd:artifact_set",
         "//loom/src/loom/util:stream",
         "//runtime/src/iree/base",
-        "//runtime/src/iree/testing:gtest",
-        "//runtime/src/iree/testing:gtest_main",
-    ],
-)
-
-loom_cc_test(
-    name = "request_test",
-    srcs = ["request_test.cc"],
-    deps = [
-        ":request",
-        "//loom/src/loom/format/text:parser",
-        "//loom/src/loom/ir",
-        "//loom/src/loom/ops/target",
-        "//loom/src/loom/testing:context",
-        "//loom/src/loom/testing:module_ptr",
-        "//runtime/src/iree/base/internal:arena",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],

--- a/loom/src/loom/tools/loom-compile/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-compile/CMakeLists.txt
@@ -54,25 +54,6 @@ loom_cc_library(
   PUBLIC
 )
 
-loom_cc_library(
-  NAME
-    request
-  HDRS
-    "request.h"
-  SRCS
-    "request.c"
-  DEPS
-    iree::base
-    loom::ir
-    loom::ops::op_defs
-    loom::target::entry_selection
-    loom::target::projection
-    loom::target::provider
-    loom::target::selection
-    loom::tooling::compile::artifact
-  PUBLIC
-)
-
 loom_cc_binary(
   NAME
     loom-compile
@@ -81,7 +62,6 @@ loom_cc_binary(
   DEPS
     ::command_backend
     ::command_manifest
-    ::request
     iree::base
     iree::base::tooling::flags
     iree::io::file_handle
@@ -104,6 +84,7 @@ loom_cc_binary(
     loom::tooling::compile::options
     loom::tooling::compile::pipeline
     loom::tooling::compile::report_capture
+    loom::tooling::compile::request
     loom::tooling::config
     loom::tooling::context
     loom::tooling::execution::session
@@ -124,23 +105,6 @@ loom_cc_test(
     iree::testing::gtest_main
     loom::target::arch::cmd::artifact_set
     loom::util::stream
-)
-
-loom_cc_test(
-  NAME
-    request_test
-  SRCS
-    "request_test.cc"
-  DEPS
-    ::request
-    iree::base::internal::arena
-    iree::testing::gtest
-    iree::testing::gtest_main
-    loom::format::text::parser
-    loom::ir
-    loom::ops::target
-    loom::testing::context
-    loom::testing::module_ptr
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/loom-compile/loom-compile.c
+++ b/loom/src/loom/tools/loom-compile/loom-compile.c
@@ -28,6 +28,7 @@
 #include "loom/tooling/compile/configured.h"
 #include "loom/tooling/compile/pipeline.h"
 #include "loom/tooling/compile/report_capture.h"
+#include "loom/tooling/compile/request.h"
 #include "loom/tooling/config/config.h"
 #include "loom/tooling/context/context.h"
 #include "loom/tooling/execution/session.h"
@@ -36,7 +37,6 @@
 #include "loom/tooling/pass/trace_cli.h"
 #include "loom/tools/loom-compile/command_backend.h"
 #include "loom/tools/loom-compile/command_manifest.h"
-#include "loom/tools/loom-compile/request.h"
 
 typedef struct loom_compile_diagnostic_sink_t {
   // Parsed module used for full type rendering.


### PR DESCRIPTION
Move compile request resolution out of the `loom-compile` executable package and into shared compile tooling so offline and JIT entry points can consume one product, format, root, and explicit-target contract.

The resolver remains allocation-free and borrows the module, configured target environment, and artifact-provider registry. Its existing semantic tests move with it unchanged, and `loom-compile` becomes the first client of the shared library.

This is intentionally a behavior-neutral seam: it adds no target-specific storage, execution-provider registry, HAL dependency, or selection lifecycle. Those concerns remain outside this PR so the JIT migration can build on a small reviewed core.

## Reviewer Notes

The meaningful review surface is the new package boundary and dependency direction; the implementation and tests are 95–99% similarity renames.