### PR TITLE
[Loom] Centralize configured execution providers

### DIFF
--- a/loom/src/loom/tooling/execution/BUILD.bazel
+++ b/loom/src/loom/tooling/execution/BUILD.bazel
@@ -6,8 +6,56 @@
 
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
+    "iree_select",
     "loom_cc_library",
     "loom_cc_test",
+)
+
+_CONFIGURED_EXECUTION_COPTS = (
+    iree_select({
+        "//loom/config/execute:amdgpu_hal": [
+            "-DLOOM_CONFIG_EXECUTION_HAVE_AMDGPU=1",
+        ],
+        "//conditions:default": [],
+    }) +
+    iree_select({
+        "//loom/config/execute:spirv_vulkan_hal": [
+            "-DLOOM_CONFIG_EXECUTION_HAVE_SPIRV=1",
+        ],
+        "//conditions:default": [],
+    })
+)
+
+_CONFIGURED_EXECUTION_DEPS = (
+    iree_select({
+        "//loom/config/execute:amdgpu_hal": [
+            "//loom/src/loom/tooling/target/amdgpu:device_provider",
+            "//loom/src/loom/tooling/target/amdgpu:execution_provider",
+        ],
+        "//conditions:default": [],
+    }) +
+    iree_select({
+        "//loom/config/execute:spirv_vulkan_hal": [
+            "//loom/src/loom/tooling/target/spirv:device_provider",
+            "//loom/src/loom/tooling/target/spirv:execution_provider",
+        ],
+        "//conditions:default": [],
+    })
+)
+
+_CONFIGURED_TESTBENCH_DEPS = (
+    iree_select({
+        "//loom/config/execute:amdgpu_hal": [
+            "//loom/src/loom/tooling/target/amdgpu:testbench_requirements",
+        ],
+        "//conditions:default": [],
+    }) +
+    iree_select({
+        "//loom/config/execute:spirv_vulkan_hal": [
+            "//loom/src/loom/tooling/target/spirv:testbench_requirements",
+        ],
+        "//conditions:default": [],
+    })
 )
 
 package(
@@ -34,6 +82,51 @@ loom_cc_library(
         ":session",
         "//loom/src/loom/target:provider",
         "//runtime/src/iree/base",
+    ],
+)
+
+loom_cc_library(
+    name = "configured",
+    srcs = ["configured.c"],
+    hdrs = ["configured.h"],
+    copts = _CONFIGURED_EXECUTION_COPTS,
+    deps = [
+        ":execution_provider",
+        "//loom/src/loom/tooling/execution/hal:device_provider",
+        "//runtime/src/iree/base",
+    ] + _CONFIGURED_EXECUTION_DEPS,
+)
+
+loom_cc_test(
+    name = "configured_test",
+    srcs = ["configured_test.cc"],
+    copts = _CONFIGURED_EXECUTION_COPTS,
+    deps = [
+        ":configured",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_library(
+    name = "configured_testbench",
+    srcs = ["configured_testbench.c"],
+    hdrs = ["configured_testbench.h"],
+    copts = _CONFIGURED_EXECUTION_COPTS,
+    deps = [
+        "//loom/src/loom/tooling/execution/hal:testbench_requirement_provider",
+        "//runtime/src/iree/base",
+    ] + _CONFIGURED_TESTBENCH_DEPS,
+)
+
+loom_cc_test(
+    name = "configured_testbench_test",
+    srcs = ["configured_testbench_test.cc"],
+    copts = _CONFIGURED_EXECUTION_COPTS,
+    deps = [
+        ":configured_testbench",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )
 

--- a/loom/src/loom/tooling/execution/CMakeLists.txt
+++ b/loom/src/loom/tooling/execution/CMakeLists.txt
@@ -36,6 +36,109 @@ loom_cc_library(
   PUBLIC
 )
 
+set(_configured_platform_copts "")
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
+  list(APPEND _configured_platform_copts "-DLOOM_CONFIG_EXECUTION_HAVE_AMDGPU=1")
+endif()
+if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
+  list(APPEND _configured_platform_copts "-DLOOM_CONFIG_EXECUTION_HAVE_SPIRV=1")
+endif()
+set(_configured_platform_deps "")
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
+  list(APPEND _configured_platform_deps loom::tooling::target::amdgpu::device_provider)
+  list(APPEND _configured_platform_deps loom::tooling::target::amdgpu::execution_provider)
+endif()
+if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
+  list(APPEND _configured_platform_deps loom::tooling::target::spirv::device_provider)
+  list(APPEND _configured_platform_deps loom::tooling::target::spirv::execution_provider)
+endif()
+loom_cc_library(
+  NAME
+    configured
+  COPTS
+    ${_configured_platform_copts}
+  HDRS
+    "configured.h"
+  SRCS
+    "configured.c"
+  DEPS
+    ::execution_provider
+    iree::base
+    loom::tooling::execution::hal::device_provider
+    ${_configured_platform_deps}
+  PUBLIC
+)
+
+set(_configured_test_platform_copts "")
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
+  list(APPEND _configured_test_platform_copts "-DLOOM_CONFIG_EXECUTION_HAVE_AMDGPU=1")
+endif()
+if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
+  list(APPEND _configured_test_platform_copts "-DLOOM_CONFIG_EXECUTION_HAVE_SPIRV=1")
+endif()
+loom_cc_test(
+  NAME
+    configured_test
+  SRCS
+    "configured_test.cc"
+  COPTS
+    ${_configured_test_platform_copts}
+  DEPS
+    ::configured
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+set(_configured_testbench_platform_copts "")
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
+  list(APPEND _configured_testbench_platform_copts "-DLOOM_CONFIG_EXECUTION_HAVE_AMDGPU=1")
+endif()
+if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
+  list(APPEND _configured_testbench_platform_copts "-DLOOM_CONFIG_EXECUTION_HAVE_SPIRV=1")
+endif()
+set(_configured_testbench_platform_deps "")
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
+  list(APPEND _configured_testbench_platform_deps loom::tooling::target::amdgpu::testbench_requirements)
+endif()
+if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
+  list(APPEND _configured_testbench_platform_deps loom::tooling::target::spirv::testbench_requirements)
+endif()
+loom_cc_library(
+  NAME
+    configured_testbench
+  COPTS
+    ${_configured_testbench_platform_copts}
+  HDRS
+    "configured_testbench.h"
+  SRCS
+    "configured_testbench.c"
+  DEPS
+    iree::base
+    loom::tooling::execution::hal::testbench_requirement_provider
+    ${_configured_testbench_platform_deps}
+  PUBLIC
+)
+
+set(_configured_testbench_test_platform_copts "")
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
+  list(APPEND _configured_testbench_test_platform_copts "-DLOOM_CONFIG_EXECUTION_HAVE_AMDGPU=1")
+endif()
+if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
+  list(APPEND _configured_testbench_test_platform_copts "-DLOOM_CONFIG_EXECUTION_HAVE_SPIRV=1")
+endif()
+loom_cc_test(
+  NAME
+    configured_testbench_test
+  SRCS
+    "configured_testbench_test.cc"
+  COPTS
+    ${_configured_testbench_test_platform_copts}
+  DEPS
+    ::configured_testbench
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 loom_cc_library(
   NAME
     execution_backend

--- a/loom/src/loom/tooling/execution/configured.c
+++ b/loom/src/loom/tooling/execution/configured.c
@@ -1,0 +1,76 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tooling/execution/configured.h"
+
+#ifndef LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#define LOOM_CONFIG_EXECUTION_HAVE_AMDGPU 0
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#ifndef LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+#define LOOM_CONFIG_EXECUTION_HAVE_SPIRV 0
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+
+#define LOOM_CONFIG_EXECUTION_HAVE_ANY_PROVIDER \
+  (LOOM_CONFIG_EXECUTION_HAVE_AMDGPU || LOOM_CONFIG_EXECUTION_HAVE_SPIRV)
+
+#if LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#include "loom/tooling/target/amdgpu/device_provider.h"
+#include "loom/tooling/target/amdgpu/execution_provider.h"
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#if LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+#include "loom/tooling/target/spirv/device_provider.h"
+#include "loom/tooling/target/spirv/execution_provider.h"
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+
+#if LOOM_CONFIG_EXECUTION_HAVE_ANY_PROVIDER
+static const loom_run_execution_provider_t* const
+    kConfiguredExecutionProviders[] = {
+#if LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+        &loom_amdgpu_execution_provider,
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#if LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+        &loom_spirv_vulkan_execution_provider,
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+};
+
+static const loom_device_provider_t* const kConfiguredDeviceProviders[] = {
+#if LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+    &loom_amdgpu_device_provider,
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#if LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+    &loom_spirv_vulkan_device_provider,
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+};
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_ANY_PROVIDER
+
+static const loom_tooling_execution_providers_t
+    kConfiguredExecutionProviderTables = {
+        .execution_provider_set =
+            {
+#if LOOM_CONFIG_EXECUTION_HAVE_ANY_PROVIDER
+                .providers = kConfiguredExecutionProviders,
+                .provider_count = IREE_ARRAYSIZE(kConfiguredExecutionProviders),
+#else
+                .providers = NULL,
+                .provider_count = 0,
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_ANY_PROVIDER
+            },
+        .device_provider_registry =
+            {
+#if LOOM_CONFIG_EXECUTION_HAVE_ANY_PROVIDER
+                .providers = kConfiguredDeviceProviders,
+                .provider_count = IREE_ARRAYSIZE(kConfiguredDeviceProviders),
+#else
+                .providers = NULL,
+                .provider_count = 0,
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_ANY_PROVIDER
+            },
+};
+
+const loom_tooling_execution_providers_t*
+loom_tooling_configured_execution_providers(void) {
+  return &kConfiguredExecutionProviderTables;
+}

--- a/loom/src/loom/tooling/execution/configured.h
+++ b/loom/src/loom/tooling/execution/configured.h
@@ -1,0 +1,35 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Execution providers selected by the Loom build configuration.
+
+#ifndef LOOM_TOOLING_EXECUTION_CONFIGURED_H_
+#define LOOM_TOOLING_EXECUTION_CONFIGURED_H_
+
+#include "loom/tooling/execution/execution_provider.h"
+#include "loom/tooling/execution/hal/device_provider.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Process-lifetime execution provider tables selected by the build.
+typedef struct loom_tooling_execution_providers_t {
+  // Target and execution backend contributions.
+  loom_run_execution_provider_set_t execution_provider_set;
+  // Live HAL device adapters corresponding to the execution providers.
+  loom_device_provider_registry_t device_provider_registry;
+} loom_tooling_execution_providers_t;
+
+// Returns the immutable configured execution provider tables.
+const loom_tooling_execution_providers_t*
+loom_tooling_configured_execution_providers(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TOOLING_EXECUTION_CONFIGURED_H_

--- a/loom/src/loom/tooling/execution/configured_test.cc
+++ b/loom/src/loom/tooling/execution/configured_test.cc
@@ -1,0 +1,65 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tooling/execution/configured.h"
+
+#include "iree/testing/gtest.h"
+
+#ifndef LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#define LOOM_CONFIG_EXECUTION_HAVE_AMDGPU 0
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#ifndef LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+#define LOOM_CONFIG_EXECUTION_HAVE_SPIRV 0
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+
+namespace loom {
+namespace {
+
+TEST(ConfiguredExecutionTest, ReturnsMatchingProviderTables) {
+  const loom_tooling_execution_providers_t* providers =
+      loom_tooling_configured_execution_providers();
+  ASSERT_NE(providers, nullptr);
+  EXPECT_EQ(providers, loom_tooling_configured_execution_providers());
+
+  const iree_host_size_t expected_provider_count =
+      LOOM_CONFIG_EXECUTION_HAVE_AMDGPU + LOOM_CONFIG_EXECUTION_HAVE_SPIRV;
+  const loom_run_execution_provider_set_t* execution_providers =
+      &providers->execution_provider_set;
+  const loom_device_provider_registry_t* device_providers =
+      &providers->device_provider_registry;
+  ASSERT_EQ(execution_providers->provider_count, expected_provider_count);
+  ASSERT_EQ(device_providers->provider_count, expected_provider_count);
+  EXPECT_EQ(execution_providers->providers == nullptr,
+            expected_provider_count == 0);
+  EXPECT_EQ(device_providers->providers == nullptr,
+            expected_provider_count == 0);
+
+  for (iree_host_size_t i = 0; i < expected_provider_count; ++i) {
+    const loom_run_execution_provider_t* execution_provider =
+        execution_providers->providers[i];
+    const loom_device_provider_t* device_provider =
+        device_providers->providers[i];
+    ASSERT_NE(execution_provider, nullptr);
+    ASSERT_NE(device_provider, nullptr);
+    ASSERT_NE(execution_provider->target_provider, nullptr);
+    ASSERT_NE(device_provider->artifact_provider, nullptr);
+    EXPECT_FALSE(iree_string_view_is_empty(execution_provider->name));
+    EXPECT_FALSE(iree_string_view_is_empty(device_provider->driver_name));
+    bool found_matching_backend = false;
+    for (iree_host_size_t j = 0;
+         j < execution_provider->execution_backend_count; ++j) {
+      const loom_run_execution_backend_t* backend =
+          execution_provider->execution_backends[j];
+      ASSERT_NE(backend, nullptr);
+      found_matching_backend |= iree_string_view_equal(
+          backend->name, device_provider->artifact_provider->name);
+    }
+    EXPECT_TRUE(found_matching_backend);
+  }
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/tooling/execution/configured_testbench.c
+++ b/loom/src/loom/tooling/execution/configured_testbench.c
@@ -1,0 +1,54 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tooling/execution/configured_testbench.h"
+
+#ifndef LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#define LOOM_CONFIG_EXECUTION_HAVE_AMDGPU 0
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#ifndef LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+#define LOOM_CONFIG_EXECUTION_HAVE_SPIRV 0
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+
+#define LOOM_CONFIG_EXECUTION_HAVE_ANY_REQUIREMENT_PROVIDER \
+  (LOOM_CONFIG_EXECUTION_HAVE_AMDGPU || LOOM_CONFIG_EXECUTION_HAVE_SPIRV)
+
+#if LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#include "loom/tooling/target/amdgpu/testbench_requirements.h"
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#if LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+#include "loom/tooling/target/spirv/testbench_requirements.h"
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+
+#if LOOM_CONFIG_EXECUTION_HAVE_ANY_REQUIREMENT_PROVIDER
+static const loom_run_hal_testbench_requirement_provider_initializer_t
+    kConfiguredRequirementProviderInitializers[] = {
+#if LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+        loom_amdgpu_hal_testbench_requirement_provider_initialize,
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#if LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+        loom_spirv_vulkan_feature_testbench_requirement_provider_initialize,
+        loom_spirv_vulkan_cooperative_matrix_testbench_requirement_provider_initialize,
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+};
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_ANY_REQUIREMENT_PROVIDER
+
+static const loom_run_hal_testbench_requirement_initializer_set_t
+    kConfiguredRequirementProviderInitializerSet = {
+#if LOOM_CONFIG_EXECUTION_HAVE_ANY_REQUIREMENT_PROVIDER
+        .initializers = kConfiguredRequirementProviderInitializers,
+        .initializer_count =
+            IREE_ARRAYSIZE(kConfiguredRequirementProviderInitializers),
+#else
+        .initializers = NULL,
+        .initializer_count = 0,
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_ANY_REQUIREMENT_PROVIDER
+};
+
+const loom_run_hal_testbench_requirement_initializer_set_t*
+loom_tooling_configured_testbench_requirement_initializers(void) {
+  return &kConfiguredRequirementProviderInitializerSet;
+}

--- a/loom/src/loom/tooling/execution/configured_testbench.h
+++ b/loom/src/loom/tooling/execution/configured_testbench.h
@@ -1,0 +1,26 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// HAL testbench providers selected by the Loom build configuration.
+
+#ifndef LOOM_TOOLING_EXECUTION_CONFIGURED_TESTBENCH_H_
+#define LOOM_TOOLING_EXECUTION_CONFIGURED_TESTBENCH_H_
+
+#include "loom/tooling/execution/hal/testbench_requirement_provider.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Returns the immutable configured HAL requirement provider initializers.
+const loom_run_hal_testbench_requirement_initializer_set_t*
+loom_tooling_configured_testbench_requirement_initializers(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TOOLING_EXECUTION_CONFIGURED_TESTBENCH_H_

--- a/loom/src/loom/tooling/execution/configured_testbench_test.cc
+++ b/loom/src/loom/tooling/execution/configured_testbench_test.cc
@@ -1,0 +1,38 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tooling/execution/configured_testbench.h"
+
+#include "iree/testing/gtest.h"
+
+#ifndef LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#define LOOM_CONFIG_EXECUTION_HAVE_AMDGPU 0
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_AMDGPU
+#ifndef LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+#define LOOM_CONFIG_EXECUTION_HAVE_SPIRV 0
+#endif  // LOOM_CONFIG_EXECUTION_HAVE_SPIRV
+
+namespace loom {
+namespace {
+
+TEST(ConfiguredTestbenchTest, ExposesOnlyEnabledInitializers) {
+  const loom_run_hal_testbench_requirement_initializer_set_t* initializer_set =
+      loom_tooling_configured_testbench_requirement_initializers();
+  ASSERT_NE(initializer_set, nullptr);
+  EXPECT_EQ(initializer_set,
+            loom_tooling_configured_testbench_requirement_initializers());
+  const iree_host_size_t expected_initializer_count =
+      LOOM_CONFIG_EXECUTION_HAVE_AMDGPU + 2 * LOOM_CONFIG_EXECUTION_HAVE_SPIRV;
+  EXPECT_EQ(initializer_set->initializer_count, expected_initializer_count);
+  EXPECT_EQ(initializer_set->initializers == nullptr,
+            expected_initializer_count == 0);
+  for (iree_host_size_t i = 0; i < initializer_set->initializer_count; ++i) {
+    EXPECT_NE(initializer_set->initializers[i], nullptr);
+  }
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/tooling/execution/hal/BUILD.bazel
+++ b/loom/src/loom/tooling/execution/hal/BUILD.bazel
@@ -129,6 +129,16 @@ loom_cc_library(
 )
 
 loom_cc_library(
+    name = "testbench_requirement_provider",
+    srcs = ["testbench_requirement_provider.c"],
+    hdrs = ["testbench_requirement_provider.h"],
+    deps = [
+        "//loom/src/loom/tooling/testbench:requirements",
+        "//runtime/src/iree/base",
+    ],
+)
+
+loom_cc_library(
     name = "benchmark",
     srcs = ["benchmark.c"],
     hdrs = ["benchmark.h"],
@@ -228,6 +238,16 @@ loom_cc_test(
         "//loom/src/loom/tooling/testbench",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_test(
+    name = "testbench_requirement_provider_test",
+    srcs = ["testbench_requirement_provider_test.cc"],
+    deps = [
+        ":testbench_requirement_provider",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],

--- a/loom/src/loom/tooling/execution/hal/CMakeLists.txt
+++ b/loom/src/loom/tooling/execution/hal/CMakeLists.txt
@@ -134,6 +134,19 @@ loom_cc_library(
 
 loom_cc_library(
   NAME
+    testbench_requirement_provider
+  HDRS
+    "testbench_requirement_provider.h"
+  SRCS
+    "testbench_requirement_provider.c"
+  DEPS
+    iree::base
+    loom::tooling::testbench::requirements
+  PUBLIC
+)
+
+loom_cc_library(
+  NAME
     benchmark
   HDRS
     "benchmark.h"
@@ -245,6 +258,17 @@ loom_cc_test(
     loom::testing::module_ptr
     loom::tooling::execution::session
     loom::tooling::testbench
+)
+
+loom_cc_test(
+  NAME
+    testbench_requirement_provider_test
+  SRCS
+    "testbench_requirement_provider_test.cc"
+  DEPS
+    ::testbench_requirement_provider
+    iree::testing::gtest
+    iree::testing::gtest_main
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/loom/src/loom/tooling/execution/hal/testbench_requirement_provider.c
+++ b/loom/src/loom/tooling/execution/hal/testbench_requirement_provider.c
@@ -1,0 +1,31 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tooling/execution/hal/testbench_requirement_provider.h"
+
+iree_status_t loom_run_hal_testbench_requirement_providers_populate(
+    const loom_run_hal_testbench_requirement_initializer_set_t* initializer_set,
+    loom_run_hal_testbench_context_t* context,
+    iree_host_size_t provider_capacity,
+    loom_testbench_requirement_provider_t* providers,
+    iree_host_size_t* out_provider_count) {
+  IREE_ASSERT_ARGUMENT(initializer_set);
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(providers || initializer_set->initializer_count == 0);
+  IREE_ASSERT_ARGUMENT(out_provider_count);
+  *out_provider_count = 0;
+
+  if (initializer_set->initializer_count > provider_capacity) {
+    return iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "HAL testbench requirement provider capacity exceeded");
+  }
+  for (iree_host_size_t i = 0; i < initializer_set->initializer_count; ++i) {
+    initializer_set->initializers[i](context, &providers[i]);
+  }
+  *out_provider_count = initializer_set->initializer_count;
+  return iree_ok_status();
+}

--- a/loom/src/loom/tooling/execution/hal/testbench_requirement_provider.h
+++ b/loom/src/loom/tooling/execution/hal/testbench_requirement_provider.h
@@ -1,0 +1,49 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// HAL testbench requirement provider composition.
+
+#ifndef LOOM_TOOLING_EXECUTION_HAL_TESTBENCH_REQUIREMENT_PROVIDER_H_
+#define LOOM_TOOLING_EXECUTION_HAL_TESTBENCH_REQUIREMENT_PROVIDER_H_
+
+#include "iree/base/api.h"
+#include "loom/tooling/testbench/requirements.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct loom_run_hal_testbench_context_t
+    loom_run_hal_testbench_context_t;
+
+// Initializes one requirement provider against |context|.
+typedef void (*loom_run_hal_testbench_requirement_provider_initializer_t)(
+    loom_run_hal_testbench_context_t* context,
+    loom_testbench_requirement_provider_t* out_provider);
+
+// Static requirement provider initializers linked into a HAL testbench tool.
+typedef struct loom_run_hal_testbench_requirement_initializer_set_t {
+  // Initializers invoked in table order for each testbench evaluation.
+  const loom_run_hal_testbench_requirement_provider_initializer_t* initializers;
+  // Number of entries in |initializers|.
+  iree_host_size_t initializer_count;
+} loom_run_hal_testbench_requirement_initializer_set_t;
+
+// Populates |providers| from |initializer_set| and binds each provider to
+// |context|. Fails without invoking an initializer when |provider_capacity| is
+// insufficient.
+iree_status_t loom_run_hal_testbench_requirement_providers_populate(
+    const loom_run_hal_testbench_requirement_initializer_set_t* initializer_set,
+    loom_run_hal_testbench_context_t* context,
+    iree_host_size_t provider_capacity,
+    loom_testbench_requirement_provider_t* providers,
+    iree_host_size_t* out_provider_count);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TOOLING_EXECUTION_HAL_TESTBENCH_REQUIREMENT_PROVIDER_H_

--- a/loom/src/loom/tooling/execution/hal/testbench_requirement_provider_test.cc
+++ b/loom/src/loom/tooling/execution/hal/testbench_requirement_provider_test.cc
@@ -18,30 +18,27 @@ static iree_status_t QuerySyntheticRequirement(
   (void)user_data;
   (void)module;
   (void)attrs;
-  *out_result = (loom_testbench_requirement_provider_result_t){
-      .state = LOOM_TESTBENCH_REQUIREMENT_PROVIDER_STATE_SATISFIED,
-  };
+  *out_result = {};
+  out_result->state = LOOM_TESTBENCH_REQUIREMENT_PROVIDER_STATE_SATISFIED;
   return iree_ok_status();
 }
 
 static void InitializeSyntheticRequirementAlpha(
     loom_run_hal_testbench_context_t* context,
     loom_testbench_requirement_provider_t* out_provider) {
-  *out_provider = (loom_testbench_requirement_provider_t){
-      .name = IREE_SVL("synthetic.alpha"),
-      .user_data = context,
-      .query = QuerySyntheticRequirement,
-  };
+  *out_provider = {};
+  out_provider->name = IREE_SV("synthetic.alpha");
+  out_provider->user_data = context;
+  out_provider->query = QuerySyntheticRequirement;
 }
 
 static void InitializeSyntheticRequirementBeta(
     loom_run_hal_testbench_context_t* context,
     loom_testbench_requirement_provider_t* out_provider) {
-  *out_provider = (loom_testbench_requirement_provider_t){
-      .name = IREE_SVL("synthetic.beta"),
-      .user_data = context,
-      .query = QuerySyntheticRequirement,
-  };
+  *out_provider = {};
+  out_provider->name = IREE_SV("synthetic.beta");
+  out_provider->user_data = context;
+  out_provider->query = QuerySyntheticRequirement;
 }
 
 TEST(TestbenchRequirementProviderTest, PopulatesInInitializerOrder) {
@@ -50,10 +47,9 @@ TEST(TestbenchRequirementProviderTest, PopulatesInInitializerOrder) {
           InitializeSyntheticRequirementAlpha,
           InitializeSyntheticRequirementBeta,
       };
-  const loom_run_hal_testbench_requirement_initializer_set_t initializer_set = {
-      .initializers = initializers,
-      .initializer_count = IREE_ARRAYSIZE(initializers),
-  };
+  loom_run_hal_testbench_requirement_initializer_set_t initializer_set = {};
+  initializer_set.initializers = initializers;
+  initializer_set.initializer_count = IREE_ARRAYSIZE(initializers);
   int synthetic_context_storage = 0;
   auto* context = reinterpret_cast<loom_run_hal_testbench_context_t*>(
       &synthetic_context_storage);
@@ -71,8 +67,8 @@ TEST(TestbenchRequirementProviderTest, PopulatesInInitializerOrder) {
       iree_string_view_equal(providers[1].name, IREE_SV("synthetic.beta")));
   EXPECT_EQ(providers[0].user_data, context);
   EXPECT_EQ(providers[1].user_data, context);
-  EXPECT_EQ(providers[0].query, QuerySyntheticRequirement);
-  EXPECT_EQ(providers[1].query, QuerySyntheticRequirement);
+  EXPECT_EQ(providers[0].query, &QuerySyntheticRequirement);
+  EXPECT_EQ(providers[1].query, &QuerySyntheticRequirement);
 }
 
 TEST(TestbenchRequirementProviderTest, RejectsInsufficientCapacityAtomically) {
@@ -81,16 +77,14 @@ TEST(TestbenchRequirementProviderTest, RejectsInsufficientCapacityAtomically) {
           InitializeSyntheticRequirementAlpha,
           InitializeSyntheticRequirementBeta,
       };
-  const loom_run_hal_testbench_requirement_initializer_set_t initializer_set = {
-      .initializers = initializers,
-      .initializer_count = IREE_ARRAYSIZE(initializers),
-  };
+  loom_run_hal_testbench_requirement_initializer_set_t initializer_set = {};
+  initializer_set.initializers = initializers;
+  initializer_set.initializer_count = IREE_ARRAYSIZE(initializers);
   int synthetic_context_storage = 0;
   auto* context = reinterpret_cast<loom_run_hal_testbench_context_t*>(
       &synthetic_context_storage);
-  loom_testbench_requirement_provider_t provider = {
-      .name = IREE_SVL("synthetic.sentinel"),
-  };
+  loom_testbench_requirement_provider_t provider = {};
+  provider.name = IREE_SV("synthetic.sentinel");
   iree_host_size_t provider_count = 99;
 
   IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,

--- a/loom/src/loom/tooling/execution/hal/testbench_requirement_provider_test.cc
+++ b/loom/src/loom/tooling/execution/hal/testbench_requirement_provider_test.cc
@@ -1,0 +1,106 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tooling/execution/hal/testbench_requirement_provider.h"
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace loom {
+namespace {
+
+static iree_status_t QuerySyntheticRequirement(
+    void* user_data, const loom_module_t* module, loom_named_attr_slice_t attrs,
+    loom_testbench_requirement_provider_result_t* out_result) {
+  (void)user_data;
+  (void)module;
+  (void)attrs;
+  *out_result = (loom_testbench_requirement_provider_result_t){
+      .state = LOOM_TESTBENCH_REQUIREMENT_PROVIDER_STATE_SATISFIED,
+  };
+  return iree_ok_status();
+}
+
+static void InitializeSyntheticRequirementAlpha(
+    loom_run_hal_testbench_context_t* context,
+    loom_testbench_requirement_provider_t* out_provider) {
+  *out_provider = (loom_testbench_requirement_provider_t){
+      .name = IREE_SVL("synthetic.alpha"),
+      .user_data = context,
+      .query = QuerySyntheticRequirement,
+  };
+}
+
+static void InitializeSyntheticRequirementBeta(
+    loom_run_hal_testbench_context_t* context,
+    loom_testbench_requirement_provider_t* out_provider) {
+  *out_provider = (loom_testbench_requirement_provider_t){
+      .name = IREE_SVL("synthetic.beta"),
+      .user_data = context,
+      .query = QuerySyntheticRequirement,
+  };
+}
+
+TEST(TestbenchRequirementProviderTest, PopulatesInInitializerOrder) {
+  const loom_run_hal_testbench_requirement_provider_initializer_t
+      initializers[] = {
+          InitializeSyntheticRequirementAlpha,
+          InitializeSyntheticRequirementBeta,
+      };
+  const loom_run_hal_testbench_requirement_initializer_set_t initializer_set = {
+      .initializers = initializers,
+      .initializer_count = IREE_ARRAYSIZE(initializers),
+  };
+  int synthetic_context_storage = 0;
+  auto* context = reinterpret_cast<loom_run_hal_testbench_context_t*>(
+      &synthetic_context_storage);
+  loom_testbench_requirement_provider_t providers[2] = {};
+  iree_host_size_t provider_count = 0;
+
+  IREE_ASSERT_OK(loom_run_hal_testbench_requirement_providers_populate(
+      &initializer_set, context, IREE_ARRAYSIZE(providers), providers,
+      &provider_count));
+
+  ASSERT_EQ(provider_count, 2u);
+  EXPECT_TRUE(
+      iree_string_view_equal(providers[0].name, IREE_SV("synthetic.alpha")));
+  EXPECT_TRUE(
+      iree_string_view_equal(providers[1].name, IREE_SV("synthetic.beta")));
+  EXPECT_EQ(providers[0].user_data, context);
+  EXPECT_EQ(providers[1].user_data, context);
+  EXPECT_EQ(providers[0].query, QuerySyntheticRequirement);
+  EXPECT_EQ(providers[1].query, QuerySyntheticRequirement);
+}
+
+TEST(TestbenchRequirementProviderTest, RejectsInsufficientCapacityAtomically) {
+  const loom_run_hal_testbench_requirement_provider_initializer_t
+      initializers[] = {
+          InitializeSyntheticRequirementAlpha,
+          InitializeSyntheticRequirementBeta,
+      };
+  const loom_run_hal_testbench_requirement_initializer_set_t initializer_set = {
+      .initializers = initializers,
+      .initializer_count = IREE_ARRAYSIZE(initializers),
+  };
+  int synthetic_context_storage = 0;
+  auto* context = reinterpret_cast<loom_run_hal_testbench_context_t*>(
+      &synthetic_context_storage);
+  loom_testbench_requirement_provider_t provider = {
+      .name = IREE_SVL("synthetic.sentinel"),
+  };
+  iree_host_size_t provider_count = 99;
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
+                        loom_run_hal_testbench_requirement_providers_populate(
+                            &initializer_set, context, /*provider_capacity=*/1,
+                            &provider, &provider_count));
+  EXPECT_EQ(provider_count, 0u);
+  EXPECT_TRUE(
+      iree_string_view_equal(provider.name, IREE_SV("synthetic.sentinel")));
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/tools/iree-benchmark-loom/BUILD.bazel
+++ b/loom/src/loom/tools/iree-benchmark-loom/BUILD.bazel
@@ -7,7 +7,6 @@
 load("//build_tools/testing:build_defs.bzl", "iree_execution_test_suite")
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
-    "iree_select",
     "loom_cc_binary",
     "loom_cc_library",
     "loom_cc_test",
@@ -17,46 +16,6 @@ package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
-)
-
-_AMDGPU_TARGET_COPTS = iree_select({
-    "//loom/config/execute:amdgpu_hal": [
-        "-DIREE_BENCHMARK_LOOM_HAVE_AMDGPU=1",
-    ],
-    "//conditions:default": [],
-})
-
-_AMDGPU_TARGET_DEPS = iree_select({
-    "//loom/config/execute:amdgpu_hal": [
-        "//loom/src/loom/target/arch/amdgpu:provider",
-        "//loom/src/loom/tooling/target/amdgpu:device_provider",
-        "//loom/src/loom/tooling/target/amdgpu:testbench_requirements",
-    ],
-    "//conditions:default": [],
-})
-
-_SPIRV_VULKAN_TARGET_COPTS = iree_select({
-    "//loom/config/execute:spirv_vulkan_hal": [
-        "-DIREE_BENCHMARK_LOOM_HAVE_SPIRV=1",
-    ],
-    "//conditions:default": [],
-})
-
-_SPIRV_VULKAN_TARGET_DEPS = iree_select({
-    "//loom/config/execute:spirv_vulkan_hal": [
-        "//loom/src/loom/target/arch/spirv:provider",
-        "//loom/src/loom/tooling/target/spirv:device_provider",
-        "//loom/src/loom/tooling/target/spirv:testbench_requirements",
-    ],
-    "//conditions:default": [],
-})
-
-_IREE_BENCHMARK_LOOM_TARGET_COPTS = (
-    _AMDGPU_TARGET_COPTS + _SPIRV_VULKAN_TARGET_COPTS
-)
-
-_IREE_BENCHMARK_LOOM_TARGET_DEPS = (
-    _AMDGPU_TARGET_DEPS + _SPIRV_VULKAN_TARGET_DEPS
 )
 
 loom_cc_library(
@@ -147,6 +106,7 @@ loom_cc_library(
         "//loom/src/loom/tooling/execution/hal:invocation",
         "//loom/src/loom/tooling/execution/hal:runtime",
         "//loom/src/loom/tooling/execution/hal:testbench_actual",
+        "//loom/src/loom/tooling/execution/hal:testbench_requirement_provider",
         "//loom/src/loom/tooling/io:file",
         "//loom/src/loom/tooling/testbench",
         "//loom/src/loom/tooling/testbench:executor",
@@ -268,14 +228,13 @@ loom_cc_test(
 loom_cc_binary(
     name = "iree-benchmark-loom",
     srcs = ["iree-benchmark-loom.c"],
-    copts = _IREE_BENCHMARK_LOOM_TARGET_COPTS,
     deps = [
         ":main",
+        "//loom/src/loom/tooling/execution:configured",
+        "//loom/src/loom/tooling/execution:configured_testbench",
         "//loom/src/loom/tooling/execution:execution_provider",
-        "//loom/src/loom/tooling/execution/hal:artifact",
-        "//loom/src/loom/tooling/execution/hal:device_provider",
         "//runtime/src/iree/base",
-    ] + _IREE_BENCHMARK_LOOM_TARGET_DEPS,
+    ],
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/iree-benchmark-loom/CMakeLists.txt
+++ b/loom/src/loom/tools/iree-benchmark-loom/CMakeLists.txt
@@ -104,6 +104,7 @@ loom_cc_library(
     loom::tooling::execution::hal::invocation
     loom::tooling::execution::hal::runtime
     loom::tooling::execution::hal::testbench_actual
+    loom::tooling::execution::hal::testbench_requirement_provider
     loom::tooling::execution::one_shot
     loom::tooling::execution::session
     loom::tooling::io::file
@@ -221,38 +222,17 @@ loom_cc_test(
     loom::target::low_descriptor_registry_core_test
 )
 
-set(_iree_benchmark_loom_platform_copts "")
-if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
-  list(APPEND _iree_benchmark_loom_platform_copts "-DIREE_BENCHMARK_LOOM_HAVE_AMDGPU=1")
-endif()
-if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
-  list(APPEND _iree_benchmark_loom_platform_copts "-DIREE_BENCHMARK_LOOM_HAVE_SPIRV=1")
-endif()
-set(_iree_benchmark_loom_platform_deps "")
-if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
-  list(APPEND _iree_benchmark_loom_platform_deps loom::target::arch::amdgpu::provider)
-  list(APPEND _iree_benchmark_loom_platform_deps loom::tooling::target::amdgpu::device_provider)
-  list(APPEND _iree_benchmark_loom_platform_deps loom::tooling::target::amdgpu::testbench_requirements)
-endif()
-if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
-  list(APPEND _iree_benchmark_loom_platform_deps loom::target::arch::spirv::provider)
-  list(APPEND _iree_benchmark_loom_platform_deps loom::tooling::target::spirv::device_provider)
-  list(APPEND _iree_benchmark_loom_platform_deps loom::tooling::target::spirv::testbench_requirements)
-endif()
 loom_cc_binary(
   NAME
     iree-benchmark-loom
   SRCS
     "iree-benchmark-loom.c"
-  COPTS
-    ${_iree_benchmark_loom_platform_copts}
   DEPS
     ::main
     iree::base
+    loom::tooling::execution::configured
+    loom::tooling::execution::configured_testbench
     loom::tooling::execution::execution_provider
-    loom::tooling::execution::hal::artifact
-    loom::tooling::execution::hal::device_provider
-    ${_iree_benchmark_loom_platform_deps}
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/iree-benchmark-loom/configuration.h
+++ b/loom/src/loom/tools/iree-benchmark-loom/configuration.h
@@ -10,32 +10,15 @@
 #define LOOM_TOOLS_IREE_BENCHMARK_LOOM_CONFIGURATION_H_
 
 #include "iree/base/api.h"
+#include "loom/tooling/execution/hal/testbench_requirement_provider.h"
 #include "loom/tooling/execution/session.h"
-#include "loom/tooling/testbench/requirements.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct loom_device_provider_registry_t loom_device_provider_registry_t;
-typedef struct loom_run_hal_testbench_context_t
-    loom_run_hal_testbench_context_t;
 typedef struct loom_target_environment_t loom_target_environment_t;
-
-// Appends target-linked requirement providers to |providers|.
-typedef iree_status_t (
-    *iree_benchmark_loom_populate_requirement_providers_fn_t)(
-    void* user_data, loom_run_hal_testbench_context_t* hal_context,
-    iree_host_size_t provider_capacity,
-    loom_testbench_requirement_provider_t* providers,
-    iree_host_size_t* inout_provider_count);
-
-typedef struct iree_benchmark_loom_populate_requirement_providers_callback_t {
-  // Callback implementation, or NULL when no extra providers are linked.
-  iree_benchmark_loom_populate_requirement_providers_fn_t fn;
-  // Opaque callback state passed to |fn|.
-  void* user_data;
-} iree_benchmark_loom_populate_requirement_providers_callback_t;
 
 typedef struct iree_benchmark_loom_configuration_t {
   // Null-terminated executable name used in help and diagnostics.
@@ -46,9 +29,9 @@ typedef struct iree_benchmark_loom_configuration_t {
   const loom_target_environment_t* target_environment;
   // Device provider registry linked into this runner.
   const loom_device_provider_registry_t* device_provider_registry;
-  // Appends target-specific requirement providers linked into this runner.
-  iree_benchmark_loom_populate_requirement_providers_callback_t
-      populate_requirement_providers;
+  // Target-specific requirement provider initializers linked into this runner.
+  const loom_run_hal_testbench_requirement_initializer_set_t*
+      requirement_provider_initializers;
   // Target-low descriptor registry package linked into this runner.
   loom_run_initialize_low_descriptor_registry_callback_t
       initialize_low_descriptor_registry;

--- a/loom/src/loom/tools/iree-benchmark-loom/iree-benchmark-loom.c
+++ b/loom/src/loom/tools/iree-benchmark-loom/iree-benchmark-loom.c
@@ -6,151 +6,19 @@
 
 // iree-benchmark-loom binary with build-selected execution providers.
 
-#include <stddef.h>
 #include <stdio.h>
 
+#include "loom/tooling/execution/configured.h"
+#include "loom/tooling/execution/configured_testbench.h"
 #include "loom/tooling/execution/execution_provider.h"
-#include "loom/tooling/execution/hal/device_provider.h"
 #include "loom/tools/iree-benchmark-loom/main.h"
 
-#ifndef IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-#define IREE_BENCHMARK_LOOM_HAVE_AMDGPU 0
-#endif  // IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-#ifndef IREE_BENCHMARK_LOOM_HAVE_SPIRV
-#define IREE_BENCHMARK_LOOM_HAVE_SPIRV 0
-#endif  // IREE_BENCHMARK_LOOM_HAVE_SPIRV
-
-#define IREE_BENCHMARK_LOOM_HAVE_ANY_PROVIDER \
-  (IREE_BENCHMARK_LOOM_HAVE_AMDGPU || IREE_BENCHMARK_LOOM_HAVE_SPIRV)
-#define IREE_BENCHMARK_LOOM_HAVE_ANY_DEVICE_PROVIDER \
-  (IREE_BENCHMARK_LOOM_HAVE_AMDGPU || IREE_BENCHMARK_LOOM_HAVE_SPIRV)
-
-#if IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-#include "loom/target/arch/amdgpu/provider.h"
-#include "loom/tooling/target/amdgpu/device_provider.h"
-#include "loom/tooling/target/amdgpu/testbench_requirements.h"
-#endif  // IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-#if IREE_BENCHMARK_LOOM_HAVE_SPIRV
-#include "loom/target/arch/spirv/provider.h"
-#include "loom/tooling/target/spirv/device_provider.h"
-#include "loom/tooling/target/spirv/testbench_requirements.h"
-#endif  // IREE_BENCHMARK_LOOM_HAVE_SPIRV
-
-#if IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-static const loom_run_execution_provider_t kIreeBenchmarkLoomAmdgpuProvider = {
-    .name = IREE_SVL("amdgpu"),
-    .target_provider = &loom_amdgpu_target_provider,
-};
-#endif  // IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-
-#if IREE_BENCHMARK_LOOM_HAVE_SPIRV
-static const loom_run_execution_provider_t kIreeBenchmarkLoomSpirvProvider = {
-    .name = IREE_SVL("spirv"),
-    .target_provider = &loom_spirv_target_provider,
-};
-#endif  // IREE_BENCHMARK_LOOM_HAVE_SPIRV
-
-#if IREE_BENCHMARK_LOOM_HAVE_ANY_PROVIDER
-static const loom_run_execution_provider_t* const
-    kIreeBenchmarkLoomProviders[] = {
-#if IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-        &kIreeBenchmarkLoomAmdgpuProvider,
-#endif  // IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-#if IREE_BENCHMARK_LOOM_HAVE_SPIRV
-        &kIreeBenchmarkLoomSpirvProvider,
-#endif  // IREE_BENCHMARK_LOOM_HAVE_SPIRV
-};
-#endif  // IREE_BENCHMARK_LOOM_HAVE_ANY_PROVIDER
-
-static const loom_run_execution_provider_set_t kIreeBenchmarkLoomProviderSet = {
-#if IREE_BENCHMARK_LOOM_HAVE_ANY_PROVIDER
-    .providers = kIreeBenchmarkLoomProviders,
-    .provider_count = IREE_ARRAYSIZE(kIreeBenchmarkLoomProviders),
-#else
-    .providers = NULL,
-    .provider_count = 0,
-#endif  // IREE_BENCHMARK_LOOM_HAVE_ANY_PROVIDER
-};
-
-#if IREE_BENCHMARK_LOOM_HAVE_ANY_DEVICE_PROVIDER
-static const loom_device_provider_t* const kIreeBenchmarkLoomDeviceProviders[] =
-    {
-#if IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-        &loom_amdgpu_device_provider,
-#endif  // IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-#if IREE_BENCHMARK_LOOM_HAVE_SPIRV
-        &loom_spirv_vulkan_device_provider,
-#endif  // IREE_BENCHMARK_LOOM_HAVE_SPIRV
-};
-#endif  // IREE_BENCHMARK_LOOM_HAVE_ANY_DEVICE_PROVIDER
-
-static const loom_device_provider_registry_t
-    kIreeBenchmarkLoomDeviceProviderRegistry = {
-#if IREE_BENCHMARK_LOOM_HAVE_ANY_DEVICE_PROVIDER
-        .providers = kIreeBenchmarkLoomDeviceProviders,
-        .provider_count = IREE_ARRAYSIZE(kIreeBenchmarkLoomDeviceProviders),
-#else
-        .providers = NULL,
-        .provider_count = 0,
-#endif  // IREE_BENCHMARK_LOOM_HAVE_ANY_DEVICE_PROVIDER
-};
-
-#if IREE_BENCHMARK_LOOM_HAVE_AMDGPU || IREE_BENCHMARK_LOOM_HAVE_SPIRV
-static iree_status_t iree_benchmark_loom_append_requirement_provider(
-    iree_host_size_t provider_capacity,
-    loom_testbench_requirement_provider_t* providers,
-    iree_host_size_t* inout_provider_count,
-    loom_testbench_requirement_provider_t provider) {
-  if (*inout_provider_count >= provider_capacity) {
-    return iree_make_status(
-        IREE_STATUS_RESOURCE_EXHAUSTED,
-        "iree-benchmark-loom requirement provider capacity exceeded");
-  }
-  providers[(*inout_provider_count)++] = provider;
-  return iree_ok_status();
-}
-#endif  // IREE_BENCHMARK_LOOM_HAVE_AMDGPU || IREE_BENCHMARK_LOOM_HAVE_SPIRV
-
-static iree_status_t iree_benchmark_loom_populate_requirement_providers(
-    void* user_data, loom_run_hal_testbench_context_t* hal_context,
-    iree_host_size_t provider_capacity,
-    loom_testbench_requirement_provider_t* providers,
-    iree_host_size_t* inout_provider_count) {
-  (void)user_data;
-#if IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-  loom_testbench_requirement_provider_t amdgpu_provider = {0};
-  loom_amdgpu_hal_testbench_requirement_provider_initialize(hal_context,
-                                                            &amdgpu_provider);
-  IREE_RETURN_IF_ERROR(iree_benchmark_loom_append_requirement_provider(
-      provider_capacity, providers, inout_provider_count, amdgpu_provider));
-#endif  // IREE_BENCHMARK_LOOM_HAVE_AMDGPU
-#if IREE_BENCHMARK_LOOM_HAVE_SPIRV
-  loom_testbench_requirement_provider_t vulkan_feature_provider = {0};
-  loom_spirv_vulkan_feature_testbench_requirement_provider_initialize(
-      hal_context, &vulkan_feature_provider);
-  IREE_RETURN_IF_ERROR(iree_benchmark_loom_append_requirement_provider(
-      provider_capacity, providers, inout_provider_count,
-      vulkan_feature_provider));
-  loom_testbench_requirement_provider_t cooperative_matrix_provider = {0};
-  loom_spirv_vulkan_cooperative_matrix_testbench_requirement_provider_initialize(
-      hal_context, &cooperative_matrix_provider);
-  IREE_RETURN_IF_ERROR(iree_benchmark_loom_append_requirement_provider(
-      provider_capacity, providers, inout_provider_count,
-      cooperative_matrix_provider));
-#endif  // IREE_BENCHMARK_LOOM_HAVE_SPIRV
-#if !IREE_BENCHMARK_LOOM_HAVE_AMDGPU && !IREE_BENCHMARK_LOOM_HAVE_SPIRV
-  (void)hal_context;
-  (void)provider_capacity;
-  (void)providers;
-  (void)inout_provider_count;
-#endif  // !IREE_BENCHMARK_LOOM_HAVE_AMDGPU && !IREE_BENCHMARK_LOOM_HAVE_SPIRV
-  return iree_ok_status();
-}
-
 int main(int argc, char** argv) {
+  const loom_tooling_execution_providers_t* configured_providers =
+      loom_tooling_configured_execution_providers();
   loom_run_execution_environment_t environment;
   iree_status_t status = loom_run_execution_environment_initialize(
-      &kIreeBenchmarkLoomProviderSet, &environment);
+      &configured_providers->execution_provider_set, &environment);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_free(status);
@@ -164,11 +32,10 @@ int main(int argc, char** argv) {
               &environment),
       .target_environment =
           loom_run_execution_environment_target_environment(&environment),
-      .device_provider_registry = &kIreeBenchmarkLoomDeviceProviderRegistry,
-      .populate_requirement_providers =
-          {
-              .fn = iree_benchmark_loom_populate_requirement_providers,
-          },
+      .device_provider_registry =
+          &configured_providers->device_provider_registry,
+      .requirement_provider_initializers =
+          loom_tooling_configured_testbench_requirement_initializers(),
       .initialize_low_descriptor_registry =
           loom_run_execution_environment_low_descriptor_registry_callback(
               &environment),

--- a/loom/src/loom/tools/iree-benchmark-loom/testbench.c
+++ b/loom/src/loom/tools/iree-benchmark-loom/testbench.c
@@ -20,16 +20,11 @@ iree_status_t iree_benchmark_loom_evaluate_case_requirements(
       requirement_providers[IREE_BENCHMARK_LOOM_MAX_REQUIREMENT_PROVIDERS] = {
           0};
   iree_host_size_t requirement_provider_count = 0;
-  if (configuration->populate_requirement_providers.fn != NULL) {
-    IREE_RETURN_IF_ERROR(configuration->populate_requirement_providers.fn(
-        configuration->populate_requirement_providers.user_data, hal_context,
+  if (configuration->requirement_provider_initializers != NULL) {
+    IREE_RETURN_IF_ERROR(loom_run_hal_testbench_requirement_providers_populate(
+        configuration->requirement_provider_initializers, hal_context,
         IREE_ARRAYSIZE(requirement_providers), requirement_providers,
         &requirement_provider_count));
-  }
-  if (requirement_provider_count > IREE_ARRAYSIZE(requirement_providers)) {
-    return iree_make_status(
-        IREE_STATUS_RESOURCE_EXHAUSTED,
-        "iree-benchmark-loom requirement provider capacity exceeded");
   }
   loom_testbench_requirement_provider_registry_t requirement_registry = {0};
   loom_testbench_requirement_provider_registry_initialize(

--- a/loom/src/loom/tools/iree-run-loom/BUILD.bazel
+++ b/loom/src/loom/tools/iree-run-loom/BUILD.bazel
@@ -7,7 +7,6 @@
 load("//build_tools/testing:build_defs.bzl", "iree_execution_test_suite")
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
-    "iree_select",
     "loom_cc_binary",
     "loom_cc_library",
 )
@@ -16,42 +15,6 @@ package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
-)
-
-_AMDGPU_EXECUTE_COPTS = iree_select({
-    "//loom/config/execute:amdgpu_hal": [
-        "-DIREE_RUN_LOOM_HAVE_AMDGPU=1",
-    ],
-    "//conditions:default": [],
-})
-
-_AMDGPU_EXECUTE_DEPS = iree_select({
-    "//loom/config/execute:amdgpu_hal": [
-        "//loom/src/loom/tooling/target/amdgpu:execution_provider",
-    ],
-    "//conditions:default": [],
-})
-
-_SPIRV_VULKAN_EXECUTE_COPTS = iree_select({
-    "//loom/config/execute:spirv_vulkan_hal": [
-        "-DIREE_RUN_LOOM_HAVE_SPIRV=1",
-    ],
-    "//conditions:default": [],
-})
-
-_SPIRV_VULKAN_EXECUTE_DEPS = iree_select({
-    "//loom/config/execute:spirv_vulkan_hal": [
-        "//loom/src/loom/tooling/target/spirv:execution_provider",
-    ],
-    "//conditions:default": [],
-})
-
-_IREE_RUN_LOOM_EXECUTE_COPTS = (
-    _AMDGPU_EXECUTE_COPTS + _SPIRV_VULKAN_EXECUTE_COPTS
-)
-
-_IREE_RUN_LOOM_EXECUTE_DEPS = (
-    _AMDGPU_EXECUTE_DEPS + _SPIRV_VULKAN_EXECUTE_DEPS
 )
 
 loom_cc_library(
@@ -85,12 +48,12 @@ loom_cc_library(
 loom_cc_binary(
     name = "iree-run-loom",
     srcs = ["iree-run-loom.c"],
-    copts = _IREE_RUN_LOOM_EXECUTE_COPTS,
     deps = [
         ":main",
+        "//loom/src/loom/tooling/execution:configured",
         "//loom/src/loom/tooling/execution:execution_provider",
         "//runtime/src/iree/base",
-    ] + _IREE_RUN_LOOM_EXECUTE_DEPS,
+    ],
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/iree-run-loom/CMakeLists.txt
+++ b/loom/src/loom/tools/iree-run-loom/CMakeLists.txt
@@ -36,32 +36,16 @@ loom_cc_library(
   PUBLIC
 )
 
-set(_iree_run_loom_platform_copts "")
-if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
-  list(APPEND _iree_run_loom_platform_copts "-DIREE_RUN_LOOM_HAVE_AMDGPU=1")
-endif()
-if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
-  list(APPEND _iree_run_loom_platform_copts "-DIREE_RUN_LOOM_HAVE_SPIRV=1")
-endif()
-set(_iree_run_loom_platform_deps "")
-if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
-  list(APPEND _iree_run_loom_platform_deps loom::tooling::target::amdgpu::execution_provider)
-endif()
-if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
-  list(APPEND _iree_run_loom_platform_deps loom::tooling::target::spirv::execution_provider)
-endif()
 loom_cc_binary(
   NAME
     iree-run-loom
   SRCS
     "iree-run-loom.c"
-  COPTS
-    ${_iree_run_loom_platform_copts}
   DEPS
     ::main
     iree::base
+    loom::tooling::execution::configured
     loom::tooling::execution::execution_provider
-    ${_iree_run_loom_platform_deps}
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/iree-run-loom/iree-run-loom.c
+++ b/loom/src/loom/tools/iree-run-loom/iree-run-loom.c
@@ -6,54 +6,18 @@
 
 // iree-run-loom binary with build-selected execution providers.
 
-#include <stddef.h>
 #include <stdio.h>
 
+#include "loom/tooling/execution/configured.h"
 #include "loom/tooling/execution/execution_provider.h"
 #include "loom/tools/iree-run-loom/main.h"
 
-#ifndef IREE_RUN_LOOM_HAVE_AMDGPU
-#define IREE_RUN_LOOM_HAVE_AMDGPU 0
-#endif  // IREE_RUN_LOOM_HAVE_AMDGPU
-#ifndef IREE_RUN_LOOM_HAVE_SPIRV
-#define IREE_RUN_LOOM_HAVE_SPIRV 0
-#endif  // IREE_RUN_LOOM_HAVE_SPIRV
-
-#define IREE_RUN_LOOM_HAVE_ANY_PROVIDER \
-  (IREE_RUN_LOOM_HAVE_AMDGPU || IREE_RUN_LOOM_HAVE_SPIRV)
-
-#if IREE_RUN_LOOM_HAVE_AMDGPU
-#include "loom/tooling/target/amdgpu/execution_provider.h"
-#endif  // IREE_RUN_LOOM_HAVE_AMDGPU
-#if IREE_RUN_LOOM_HAVE_SPIRV
-#include "loom/tooling/target/spirv/execution_provider.h"
-#endif  // IREE_RUN_LOOM_HAVE_SPIRV
-
-#if IREE_RUN_LOOM_HAVE_ANY_PROVIDER
-static const loom_run_execution_provider_t* const kIreeRunLoomProviders[] = {
-#if IREE_RUN_LOOM_HAVE_AMDGPU
-    &loom_amdgpu_execution_provider,
-#endif  // IREE_RUN_LOOM_HAVE_AMDGPU
-#if IREE_RUN_LOOM_HAVE_SPIRV
-    &loom_spirv_vulkan_execution_provider,
-#endif  // IREE_RUN_LOOM_HAVE_SPIRV
-};
-#endif  // IREE_RUN_LOOM_HAVE_ANY_PROVIDER
-
-static const loom_run_execution_provider_set_t kIreeRunLoomProviderSet = {
-#if IREE_RUN_LOOM_HAVE_ANY_PROVIDER
-    .providers = kIreeRunLoomProviders,
-    .provider_count = IREE_ARRAYSIZE(kIreeRunLoomProviders),
-#else
-    .providers = NULL,
-    .provider_count = 0,
-#endif  // IREE_RUN_LOOM_HAVE_ANY_PROVIDER
-};
-
 int main(int argc, char** argv) {
+  const loom_tooling_execution_providers_t* configured_providers =
+      loom_tooling_configured_execution_providers();
   loom_run_execution_environment_t environment;
   iree_status_t status = loom_run_execution_environment_initialize(
-      &kIreeRunLoomProviderSet, &environment);
+      &configured_providers->execution_provider_set, &environment);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_free(status);

--- a/loom/src/loom/tools/iree-test-loom/BUILD.bazel
+++ b/loom/src/loom/tools/iree-test-loom/BUILD.bazel
@@ -7,7 +7,6 @@
 load("//build_tools/testing:build_defs.bzl", "iree_execution_test_suite")
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
-    "iree_select",
     "loom_cc_binary",
     "loom_cc_library",
 )
@@ -16,46 +15,6 @@ package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
-)
-
-_AMDGPU_TARGET_COPTS = iree_select({
-    "//loom/config/execute:amdgpu_hal": [
-        "-DIREE_TEST_LOOM_HAVE_AMDGPU=1",
-    ],
-    "//conditions:default": [],
-})
-
-_AMDGPU_TARGET_DEPS = iree_select({
-    "//loom/config/execute:amdgpu_hal": [
-        "//loom/src/loom/target/arch/amdgpu:provider",
-        "//loom/src/loom/tooling/target/amdgpu:device_provider",
-        "//loom/src/loom/tooling/target/amdgpu:testbench_requirements",
-    ],
-    "//conditions:default": [],
-})
-
-_SPIRV_VULKAN_TARGET_COPTS = iree_select({
-    "//loom/config/execute:spirv_vulkan_hal": [
-        "-DIREE_TEST_LOOM_HAVE_SPIRV=1",
-    ],
-    "//conditions:default": [],
-})
-
-_SPIRV_VULKAN_TARGET_DEPS = iree_select({
-    "//loom/config/execute:spirv_vulkan_hal": [
-        "//loom/src/loom/target/arch/spirv:provider",
-        "//loom/src/loom/tooling/target/spirv:device_provider",
-        "//loom/src/loom/tooling/target/spirv:testbench_requirements",
-    ],
-    "//conditions:default": [],
-})
-
-_IREE_TEST_LOOM_TARGET_COPTS = (
-    _AMDGPU_TARGET_COPTS + _SPIRV_VULKAN_TARGET_COPTS
-)
-
-_IREE_TEST_LOOM_TARGET_DEPS = (
-    _AMDGPU_TARGET_DEPS + _SPIRV_VULKAN_TARGET_DEPS
 )
 
 loom_cc_library(
@@ -78,6 +37,7 @@ loom_cc_library(
         "//loom/src/loom/tooling/execution:session",
         "//loom/src/loom/tooling/execution/hal:device_provider",
         "//loom/src/loom/tooling/execution/hal:testbench_actual",
+        "//loom/src/loom/tooling/execution/hal:testbench_requirement_provider",
         "//loom/src/loom/tooling/io:file",
         "//loom/src/loom/tooling/testbench:device_event",
         "//loom/src/loom/tooling/testbench:executor",
@@ -97,12 +57,13 @@ loom_cc_library(
 loom_cc_binary(
     name = "iree-test-loom",
     srcs = ["iree-test-loom.c"],
-    copts = _IREE_TEST_LOOM_TARGET_COPTS,
     deps = [
         ":main",
+        "//loom/src/loom/tooling/execution:configured",
+        "//loom/src/loom/tooling/execution:configured_testbench",
         "//loom/src/loom/tooling/execution:execution_provider",
         "//runtime/src/iree/base",
-    ] + _IREE_TEST_LOOM_TARGET_DEPS,
+    ],
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/iree-test-loom/CMakeLists.txt
+++ b/loom/src/loom/tools/iree-test-loom/CMakeLists.txt
@@ -31,6 +31,7 @@ loom_cc_library(
     loom::tooling::context
     loom::tooling::execution::hal::device_provider
     loom::tooling::execution::hal::testbench_actual
+    loom::tooling::execution::hal::testbench_requirement_provider
     loom::tooling::execution::session
     loom::tooling::io::file
     loom::tooling::testbench::device_event
@@ -44,36 +45,17 @@ loom_cc_library(
   PUBLIC
 )
 
-set(_iree_test_loom_platform_copts "")
-if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
-  list(APPEND _iree_test_loom_platform_copts "-DIREE_TEST_LOOM_HAVE_AMDGPU=1")
-endif()
-if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
-  list(APPEND _iree_test_loom_platform_copts "-DIREE_TEST_LOOM_HAVE_SPIRV=1")
-endif()
-set(_iree_test_loom_platform_deps "")
-if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
-  list(APPEND _iree_test_loom_platform_deps loom::target::arch::amdgpu::provider)
-  list(APPEND _iree_test_loom_platform_deps loom::tooling::target::amdgpu::device_provider)
-  list(APPEND _iree_test_loom_platform_deps loom::tooling::target::amdgpu::testbench_requirements)
-endif()
-if(LOOM_TARGET_ARCH_SPIRV AND LOOM_EMIT_SPIRV AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_VULKAN)
-  list(APPEND _iree_test_loom_platform_deps loom::target::arch::spirv::provider)
-  list(APPEND _iree_test_loom_platform_deps loom::tooling::target::spirv::device_provider)
-  list(APPEND _iree_test_loom_platform_deps loom::tooling::target::spirv::testbench_requirements)
-endif()
 loom_cc_binary(
   NAME
     iree-test-loom
   SRCS
     "iree-test-loom.c"
-  COPTS
-    ${_iree_test_loom_platform_copts}
   DEPS
     ::main
     iree::base
+    loom::tooling::execution::configured
+    loom::tooling::execution::configured_testbench
     loom::tooling::execution::execution_provider
-    ${_iree_test_loom_platform_deps}
 )
 
 iree_execution_test_suite(

--- a/loom/src/loom/tools/iree-test-loom/iree-test-loom.c
+++ b/loom/src/loom/tools/iree-test-loom/iree-test-loom.c
@@ -6,148 +6,19 @@
 
 // iree-test-loom binary with build-selected execution providers.
 
-#include <stddef.h>
 #include <stdio.h>
 
+#include "loom/tooling/execution/configured.h"
+#include "loom/tooling/execution/configured_testbench.h"
 #include "loom/tooling/execution/execution_provider.h"
 #include "loom/tools/iree-test-loom/main.h"
 
-#ifndef IREE_TEST_LOOM_HAVE_AMDGPU
-#define IREE_TEST_LOOM_HAVE_AMDGPU 0
-#endif  // IREE_TEST_LOOM_HAVE_AMDGPU
-#ifndef IREE_TEST_LOOM_HAVE_SPIRV
-#define IREE_TEST_LOOM_HAVE_SPIRV 0
-#endif  // IREE_TEST_LOOM_HAVE_SPIRV
-
-#define IREE_TEST_LOOM_HAVE_ANY_PROVIDER \
-  (IREE_TEST_LOOM_HAVE_AMDGPU || IREE_TEST_LOOM_HAVE_SPIRV)
-#define IREE_TEST_LOOM_HAVE_ANY_DEVICE_PROVIDER \
-  (IREE_TEST_LOOM_HAVE_AMDGPU || IREE_TEST_LOOM_HAVE_SPIRV)
-
-#if IREE_TEST_LOOM_HAVE_AMDGPU
-#include "loom/target/arch/amdgpu/provider.h"
-#include "loom/tooling/target/amdgpu/device_provider.h"
-#include "loom/tooling/target/amdgpu/testbench_requirements.h"
-#endif  // IREE_TEST_LOOM_HAVE_AMDGPU
-#if IREE_TEST_LOOM_HAVE_SPIRV
-#include "loom/target/arch/spirv/provider.h"
-#include "loom/tooling/target/spirv/device_provider.h"
-#include "loom/tooling/target/spirv/testbench_requirements.h"
-#endif  // IREE_TEST_LOOM_HAVE_SPIRV
-
-#if IREE_TEST_LOOM_HAVE_AMDGPU
-static const loom_run_execution_provider_t kIreeTestLoomAmdgpuProvider = {
-    .name = IREE_SVL("amdgpu"),
-    .target_provider = &loom_amdgpu_target_provider,
-};
-#endif  // IREE_TEST_LOOM_HAVE_AMDGPU
-
-#if IREE_TEST_LOOM_HAVE_SPIRV
-static const loom_run_execution_provider_t kIreeTestLoomSpirvProvider = {
-    .name = IREE_SVL("spirv"),
-    .target_provider = &loom_spirv_target_provider,
-};
-#endif  // IREE_TEST_LOOM_HAVE_SPIRV
-
-#if IREE_TEST_LOOM_HAVE_ANY_PROVIDER
-static const loom_run_execution_provider_t* const kIreeTestLoomProviders[] = {
-#if IREE_TEST_LOOM_HAVE_AMDGPU
-    &kIreeTestLoomAmdgpuProvider,
-#endif  // IREE_TEST_LOOM_HAVE_AMDGPU
-#if IREE_TEST_LOOM_HAVE_SPIRV
-    &kIreeTestLoomSpirvProvider,
-#endif  // IREE_TEST_LOOM_HAVE_SPIRV
-};
-#endif  // IREE_TEST_LOOM_HAVE_ANY_PROVIDER
-
-static const loom_run_execution_provider_set_t kIreeTestLoomProviderSet = {
-#if IREE_TEST_LOOM_HAVE_ANY_PROVIDER
-    .providers = kIreeTestLoomProviders,
-    .provider_count = IREE_ARRAYSIZE(kIreeTestLoomProviders),
-#else
-    .providers = NULL,
-    .provider_count = 0,
-#endif  // IREE_TEST_LOOM_HAVE_ANY_PROVIDER
-};
-
-#if IREE_TEST_LOOM_HAVE_ANY_DEVICE_PROVIDER
-static const loom_device_provider_t* const kIreeTestLoomDeviceProviders[] = {
-#if IREE_TEST_LOOM_HAVE_AMDGPU
-    &loom_amdgpu_device_provider,
-#endif  // IREE_TEST_LOOM_HAVE_AMDGPU
-#if IREE_TEST_LOOM_HAVE_SPIRV
-    &loom_spirv_vulkan_device_provider,
-#endif  // IREE_TEST_LOOM_HAVE_SPIRV
-};
-#endif  // IREE_TEST_LOOM_HAVE_ANY_DEVICE_PROVIDER
-
-static const loom_device_provider_registry_t
-    kIreeTestLoomDeviceProviderRegistry = {
-#if IREE_TEST_LOOM_HAVE_ANY_DEVICE_PROVIDER
-        .providers = kIreeTestLoomDeviceProviders,
-        .provider_count = IREE_ARRAYSIZE(kIreeTestLoomDeviceProviders),
-#else
-        .providers = NULL,
-        .provider_count = 0,
-#endif  // IREE_TEST_LOOM_HAVE_ANY_DEVICE_PROVIDER
-};
-
-#if IREE_TEST_LOOM_HAVE_AMDGPU || IREE_TEST_LOOM_HAVE_SPIRV
-static iree_status_t iree_test_loom_append_requirement_provider(
-    iree_host_size_t provider_capacity,
-    loom_testbench_requirement_provider_t* providers,
-    iree_host_size_t* inout_provider_count,
-    loom_testbench_requirement_provider_t provider) {
-  if (*inout_provider_count >= provider_capacity) {
-    return iree_make_status(
-        IREE_STATUS_RESOURCE_EXHAUSTED,
-        "iree-test-loom requirement provider capacity exceeded");
-  }
-  providers[(*inout_provider_count)++] = provider;
-  return iree_ok_status();
-}
-#endif  // IREE_TEST_LOOM_HAVE_AMDGPU || IREE_TEST_LOOM_HAVE_SPIRV
-
-static iree_status_t iree_test_loom_populate_requirement_providers(
-    void* user_data, loom_run_hal_testbench_context_t* hal_context,
-    iree_host_size_t provider_capacity,
-    loom_testbench_requirement_provider_t* providers,
-    iree_host_size_t* inout_provider_count) {
-  (void)user_data;
-#if IREE_TEST_LOOM_HAVE_AMDGPU
-  loom_testbench_requirement_provider_t amdgpu_provider = {0};
-  loom_amdgpu_hal_testbench_requirement_provider_initialize(hal_context,
-                                                            &amdgpu_provider);
-  IREE_RETURN_IF_ERROR(iree_test_loom_append_requirement_provider(
-      provider_capacity, providers, inout_provider_count, amdgpu_provider));
-#endif  // IREE_TEST_LOOM_HAVE_AMDGPU
-#if IREE_TEST_LOOM_HAVE_SPIRV
-  loom_testbench_requirement_provider_t vulkan_feature_provider = {0};
-  loom_spirv_vulkan_feature_testbench_requirement_provider_initialize(
-      hal_context, &vulkan_feature_provider);
-  IREE_RETURN_IF_ERROR(iree_test_loom_append_requirement_provider(
-      provider_capacity, providers, inout_provider_count,
-      vulkan_feature_provider));
-  loom_testbench_requirement_provider_t cooperative_matrix_provider = {0};
-  loom_spirv_vulkan_cooperative_matrix_testbench_requirement_provider_initialize(
-      hal_context, &cooperative_matrix_provider);
-  IREE_RETURN_IF_ERROR(iree_test_loom_append_requirement_provider(
-      provider_capacity, providers, inout_provider_count,
-      cooperative_matrix_provider));
-#endif  // IREE_TEST_LOOM_HAVE_SPIRV
-#if !IREE_TEST_LOOM_HAVE_AMDGPU && !IREE_TEST_LOOM_HAVE_SPIRV
-  (void)hal_context;
-  (void)provider_capacity;
-  (void)providers;
-  (void)inout_provider_count;
-#endif  // !IREE_TEST_LOOM_HAVE_AMDGPU && !IREE_TEST_LOOM_HAVE_SPIRV
-  return iree_ok_status();
-}
-
 int main(int argc, char** argv) {
+  const loom_tooling_execution_providers_t* configured_providers =
+      loom_tooling_configured_execution_providers();
   loom_run_execution_environment_t environment;
   iree_status_t status = loom_run_execution_environment_initialize(
-      &kIreeTestLoomProviderSet, &environment);
+      &configured_providers->execution_provider_set, &environment);
   if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_free(status);
@@ -161,11 +32,10 @@ int main(int argc, char** argv) {
               &environment),
       .target_environment =
           loom_run_execution_environment_target_environment(&environment),
-      .device_provider_registry = &kIreeTestLoomDeviceProviderRegistry,
-      .populate_requirement_providers =
-          {
-              .fn = iree_test_loom_populate_requirement_providers,
-          },
+      .device_provider_registry =
+          &configured_providers->device_provider_registry,
+      .requirement_provider_initializers =
+          loom_tooling_configured_testbench_requirement_initializers(),
       .initialize_low_descriptor_registry =
           loom_run_execution_environment_low_descriptor_registry_callback(
               &environment),

--- a/loom/src/loom/tools/iree-test-loom/main.c
+++ b/loom/src/loom/tools/iree-test-loom/main.c
@@ -345,16 +345,11 @@ static iree_status_t iree_test_loom_run_case_samples(
   loom_testbench_requirement_provider_t
       requirement_providers[IREE_TEST_LOOM_MAX_REQUIREMENT_PROVIDERS] = {0};
   iree_host_size_t requirement_provider_count = 0;
-  if (configuration->populate_requirement_providers.fn != NULL) {
-    IREE_RETURN_IF_ERROR(configuration->populate_requirement_providers.fn(
-        configuration->populate_requirement_providers.user_data, hal_context,
+  if (configuration->requirement_provider_initializers != NULL) {
+    IREE_RETURN_IF_ERROR(loom_run_hal_testbench_requirement_providers_populate(
+        configuration->requirement_provider_initializers, hal_context,
         IREE_ARRAYSIZE(requirement_providers), requirement_providers,
         &requirement_provider_count));
-  }
-  if (requirement_provider_count > IREE_ARRAYSIZE(requirement_providers)) {
-    return iree_make_status(
-        IREE_STATUS_RESOURCE_EXHAUSTED,
-        "iree-test-loom requirement provider capacity exceeded");
   }
   loom_testbench_requirement_provider_registry_t requirement_registry = {0};
   loom_testbench_requirement_provider_registry_initialize(

--- a/loom/src/loom/tools/iree-test-loom/main.h
+++ b/loom/src/loom/tools/iree-test-loom/main.h
@@ -12,29 +12,12 @@
 #include "iree/base/api.h"
 #include "loom/target/provider.h"
 #include "loom/tooling/execution/hal/device_provider.h"
+#include "loom/tooling/execution/hal/testbench_requirement_provider.h"
 #include "loom/tooling/execution/session.h"
-#include "loom/tooling/testbench/requirements.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct loom_run_hal_testbench_context_t
-    loom_run_hal_testbench_context_t;
-
-// Appends target-linked requirement providers to |providers|.
-typedef iree_status_t (*iree_test_loom_populate_requirement_providers_fn_t)(
-    void* user_data, loom_run_hal_testbench_context_t* hal_context,
-    iree_host_size_t provider_capacity,
-    loom_testbench_requirement_provider_t* providers,
-    iree_host_size_t* inout_provider_count);
-
-typedef struct iree_test_loom_populate_requirement_providers_callback_t {
-  // Callback implementation, or NULL when no extra providers are linked.
-  iree_test_loom_populate_requirement_providers_fn_t fn;
-  // Opaque callback state passed to |fn|.
-  void* user_data;
-} iree_test_loom_populate_requirement_providers_callback_t;
 
 typedef struct iree_test_loom_configuration_t {
   // Null-terminated executable name used in help and diagnostics.
@@ -45,9 +28,9 @@ typedef struct iree_test_loom_configuration_t {
   const loom_target_environment_t* target_environment;
   // Linked device providers available to kernel launches.
   const loom_device_provider_registry_t* device_provider_registry;
-  // Appends target-specific requirement providers linked into this runner.
-  iree_test_loom_populate_requirement_providers_callback_t
-      populate_requirement_providers;
+  // Target-specific requirement provider initializers linked into this runner.
+  const loom_run_hal_testbench_requirement_initializer_set_t*
+      requirement_provider_initializers;
   // Target-low descriptor registry package linked into this runner.
   loom_run_initialize_low_descriptor_registry_callback_t
       initialize_low_descriptor_registry;


### PR DESCRIPTION
Move build-selected execution and device providers behind one shared configuration boundary consumed by `iree-run-loom`, `iree-test-loom`, and `iree-benchmark-loom`. Adding an execution target no longer requires parallel preprocessor tables in all three binaries, and target-disabled builds expose genuinely empty provider tables.

Replace the separate test and benchmark requirement-population callbacks with one typed HAL testbench initializer set. The runners continue to materialize providers into caller-owned storage, but capacity handling and target-specific initializer composition now have one implementation. The testbench registry remains a separate dependency so ordinary run tooling does not depend on test-only requirement code.

The configured tables preserve the existing build-selected AMDGPU and SPIR-V behavior in both Bazel and CMake. Focused tests cover enabled provider matching, disabled-target emptiness, stable configured views, initializer ordering, and atomic capacity failure.