### PR TITLE
[Loom] Fold turns with deterministic math

### DIFF
--- a/loom/src/loom/ir/BUILD.bazel
+++ b/loom/src/loom/ir/BUILD.bazel
@@ -26,6 +26,7 @@ loom_cc_library(
         ":ir",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/math",
     ],
 )
 

--- a/loom/src/loom/ir/CMakeLists.txt
+++ b/loom/src/loom/ir/CMakeLists.txt
@@ -22,6 +22,7 @@ loom_cc_library(
     ::ir
     iree::base
     iree::base::internal
+    iree::math
   PUBLIC
 )
 

--- a/loom/src/loom/ir/float_facts.c
+++ b/loom/src/loom/ir/float_facts.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "iree/base/internal/math.h"
+#include "iree/math/trigonometry.h"
 
 static bool loom_float_type_uses_f32_arithmetic(
     loom_scalar_type_t scalar_type) {
@@ -199,15 +200,6 @@ void loom_value_facts_eval_float_ternary(loom_scalar_type_t scalar_type,
 // The quarter-turn divisor is exactly representable, so remquo preserves the
 // periodic position of every finite input while providing the low quotient
 // bits needed to recover the quadrant.
-static float loom_float_reduce_turns_f32(float input, int* out_quadrant) {
-  int quotient = 0;
-  const float residual = remquof(input, 0.25f, &quotient);
-  int quadrant = quotient % 4;
-  if (quadrant < 0) quadrant += 4;
-  *out_quadrant = quadrant;
-  return residual * 6.2831853071795864769252867665590057683943387987502f;
-}
-
 static double loom_float_reduce_turns_f64(double input, int* out_quadrant) {
   int quotient = 0;
   const double residual = remquo(input, 0.25, &quotient);
@@ -220,40 +212,8 @@ static double loom_float_reduce_turns_f64(double input, int* out_quadrant) {
 static float loom_float_eval_turns_f32(float input, const void* user_data) {
   const loom_float_turns_kind_t kind =
       *(const loom_float_turns_kind_t*)user_data;
-  int quadrant = 0;
-  const float angle = loom_float_reduce_turns_f32(input, &quadrant);
-  if (angle == 0.0f) {
-    if (kind == LOOM_FLOAT_TURNS_SIN) {
-      if (quadrant == 1) return 1.0f;
-      if (quadrant == 3) return -1.0f;
-      return copysignf(0.0f, input);
-    }
-    if (quadrant == 0) return 1.0f;
-    if (quadrant == 2) return -1.0f;
-    return 0.0f;
-  }
-  if (kind == LOOM_FLOAT_TURNS_SIN) {
-    switch (quadrant) {
-      case 0:
-        return sinf(angle);
-      case 1:
-        return cosf(angle);
-      case 2:
-        return -sinf(angle);
-      default:
-        return -cosf(angle);
-    }
-  }
-  switch (quadrant) {
-    case 0:
-      return cosf(angle);
-    case 1:
-      return -sinf(angle);
-    case 2:
-      return -cosf(angle);
-    default:
-      return sinf(angle);
-  }
+  return kind == LOOM_FLOAT_TURNS_SIN ? iree_math_sin_turns_f32_approx(input)
+                                      : iree_math_cos_turns_f32_approx(input);
 }
 
 static double loom_float_eval_turns_f64(double input, const void* user_data) {

--- a/loom/src/loom/ir/float_facts.h
+++ b/loom/src/loom/ir/float_facts.h
@@ -114,7 +114,9 @@ void loom_value_facts_eval_float_ternary(loom_scalar_type_t scalar_type,
 
 // Evaluates sine or cosine over turns with exact quarter-turn range reduction.
 // Finite inputs preserve periodicity and produce exact cardinal values with
-// OpenCL-compatible signed zeros. NaN and infinity produce arithmetic NaN.
+// OpenCL-compatible signed zeros. NaN and infinity produce arithmetic NaN. The
+// caller must establish non-trapping round-to-nearest-even arithmetic with
+// input and output subnormals preserved.
 void loom_value_facts_eval_float_turns(loom_scalar_type_t scalar_type,
                                        loom_float_turns_kind_t kind,
                                        const loom_value_facts_t* input,

--- a/loom/src/loom/ops/scalar/test/fold/mathf_structural.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/mathf_structural.loom-test
@@ -124,3 +124,20 @@ func.def @turn_trig_exact_quadrants() -> (f32, f32, f32, f32) {
   %cos_quarter = scalar.constant 0.0 : f32
   func.return %sin_zero, %cos_zero, %sin_quarter, %cos_quarter : f32, f32, f32, f32
 }
+
+// ====
+
+// This non-cardinal f32 input fixes the shared turns result payload. A host
+// libm evaluation differs by one f32 step and is not a valid folding oracle.
+func.def @turn_trig_frozen_f32_mapping() -> (i32) {
+  %input_bits = scalar.constant 1180433910 : i32
+  %input = scalar.bitcast %input_bits : i32 to f32
+  %result = scalar.sinturnsf %input : f32
+  %result_bits = scalar.bitcast %result : f32 to i32
+  func.return %result_bits : i32
+}
+// ----
+func.def @turn_trig_frozen_f32_mapping() -> (i32) {
+  %result_bits = scalar.constant 1031482228 : i32
+  func.return %result_bits : i32
+}

--- a/loom/src/loom/pass/BUILD.bazel
+++ b/loom/src/loom/pass/BUILD.bazel
@@ -221,6 +221,7 @@ loom_cc_library(
         "//loom/src/loom/ops/pass",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/base/internal:fpu_state",
     ],
 )
 

--- a/loom/src/loom/pass/CMakeLists.txt
+++ b/loom/src/loom/pass/CMakeLists.txt
@@ -255,6 +255,7 @@ loom_cc_library(
     ::value_facts
     iree::base
     iree::base::internal::arena
+    iree::base::internal::fpu_state
     loom::error::error_defs
     loom::ir
     loom::ops::op_defs

--- a/loom/src/loom/pass/interpreter.c
+++ b/loom/src/loom/pass/interpreter.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 
+#include "iree/base/internal/fpu_state.h"
 #include "loom/error/error_catalog.h"
 #include "loom/ir/context.h"
 #include "loom/ir/module.h"
@@ -70,6 +71,13 @@ typedef struct loom_pass_interpreter_diagnostic_counter_t {
   // Number of remark diagnostics emitted by the current pass invocation.
   uint32_t remark_count;
 } loom_pass_interpreter_diagnostic_counter_t;
+
+// Establishes the deterministic arithmetic profile used by compiler-owned
+// floating evaluation. This also clears FTZ selected by IREE task workers.
+static iree_fpu_state_t loom_pass_interpreter_push_fpu_state(void) {
+  return iree_fpu_state_push(IREE_FPU_STATE_FLAG_MASK_EXCEPTIONS |
+                             IREE_FPU_STATE_FLAG_ROUND_TO_NEAREST);
+}
 
 typedef struct loom_pass_interpreter_symbol_snapshot_entry_t {
   // Symbol entry captured before entering a pass.for body.
@@ -1035,6 +1043,7 @@ iree_status_t loom_pass_interpreter_run_module(
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "expected module-root pass program");
   }
+  const iree_fpu_state_t fpu_state = loom_pass_interpreter_push_fpu_state();
   *out_result = (loom_pass_run_result_t){0};
   loom_pass_interpreter_state_t state = {
       .program = program,
@@ -1051,6 +1060,7 @@ iree_status_t loom_pass_interpreter_run_module(
   iree_status_t status = loom_pass_interpreter_execute_range(
       &state, &frame, 0, program->instruction_count, &changed);
   loom_pass_value_fact_owner_deinitialize(&state.value_facts);
+  iree_fpu_state_pop(fpu_state);
   return status;
 }
 
@@ -1063,6 +1073,7 @@ iree_status_t loom_pass_interpreter_run_function(
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "expected function-root pass program");
   }
+  const iree_fpu_state_t fpu_state = loom_pass_interpreter_push_fpu_state();
   *out_result = (loom_pass_run_result_t){0};
   loom_pass_interpreter_state_t state = {
       .program = program,
@@ -1089,5 +1100,6 @@ iree_status_t loom_pass_interpreter_run_function(
   iree_status_t status = loom_pass_interpreter_execute_range(
       &state, &frame, 0, program->instruction_count, &changed);
   loom_pass_value_fact_owner_deinitialize(&state.value_facts);
+  iree_fpu_state_pop(fpu_state);
   return status;
 }

--- a/loom/src/loom/pass/interpreter.h
+++ b/loom/src/loom/pass/interpreter.h
@@ -9,7 +9,10 @@
 // Executes the compact instruction program produced by program.h. The
 // interpreter owns only transient execution state: per-invocation pass arenas,
 // deterministic symbol snapshots, current anchor context, and diagnostic
-// provenance. The compiled program remains immutable and reusable.
+// provenance. Each invocation establishes non-trapping round-to-nearest-even
+// arithmetic with subnormals preserved around all pass callbacks and restores
+// the caller's floating-point state before returning. The compiled program
+// remains immutable and reusable.
 
 #ifndef LOOM_PASS_INTERPRETER_H_
 #define LOOM_PASS_INTERPRETER_H_


### PR DESCRIPTION
Routes Loom's f32 turns-based sine and cosine facts through the deterministic numerical implementation introduced in #551. Exact scalar and vector folds now produce the same payload on every supported compiler host instead of depending on the platform `sinf`/`cosf` implementation, and the duplicate private range-reduction implementation is removed.

This deliberately consumes only the two shared operations whose result contract matches the generic Loom operation. `sin_turns_f32_approx` and `cos_turns_f32_approx` are correctly rounded for every f32 payload. The other machine-like leaves from #551 are not substituted into generic exp2, log2, reciprocal, rsqrt, or sqrt facts: Loom's `afn` and `arcp` flags grant transformation permission but do not select a numerical mapping. Those leaves become exact folding or execution oracles only after a target such as the VM explicitly selects them.

## Floating-point execution scope

The pass interpreter now establishes masked-exception, round-to-nearest-even arithmetic with subnormals preserved around each pass-program invocation and restores the caller's state on every return path. This boundary is on the actual compiler worker: IREE task workers normally enable flush-to-zero, so setting state on the thread that submitted compilation would not protect pass callbacks. The transition remains outside the numerical leaves and is paid once per pass-program drive rather than once per folded operation.

That scope also defines the arithmetic profile for other compiler-owned floating evaluation performed by pass callbacks. Direct users of the lower-level float-fact helpers retain the same caller-owned profile contract as direct users of `iree/math`.

## Result witness

The canonicalization test fixes a non-cardinal payload that distinguishes the shared mapping from the prior host-libm path:

```loom
%input_bits = scalar.constant 1180433910 : i32 // 0x465bfdf6
%input = scalar.bitcast %input_bits : i32 to f32
%result = scalar.sinturnsf %input : f32
%result_bits = scalar.bitcast %result : f32 to i32
```

The shared mapping folds `%result_bits` to `0x3d7b2b74`; the Linux host-libm evaluation produced the adjacent value `0x3d7b2b75`. The assertion is over the integer payload so a one-step drift cannot hide behind a floating comparison.

## Reviewer Notes

The highest-value review surfaces are the FPU-state lifetime around both interpreter entry points and the semantic boundary that keeps target-selected approximate leaves out of generic Loom facts.
