### PR TITLE
[Loom] Generalize Bazel kernel binary products

### DIFF
--- a/loom/build_tools/bazel/loom_binary.bzl
+++ b/loom/build_tools/bazel/loom_binary.bzl
@@ -82,19 +82,21 @@ def _declare_binary_linked_module(ctx, product_kind, target_profile = None):
         linked_module = linked_module,
     )
 
-def _declare_amdgpu_kernel_product(
+def _declare_kernel_product(
         ctx,
         linked_module,
         target_profile,
-        output_stem,
+        artifact,
+        report_stem,
         mnemonic,
-        progress_message):
-    artifact = ctx.actions.declare_file(output_stem + ".hsaco")
-    compile_report = ctx.actions.declare_file(output_stem + ".compile.json")
+        progress_message,
+        exact_format = None):
+    compile_report = ctx.actions.declare_file(report_stem + ".compile.json")
     args = ctx.actions.args()
     args.add(linked_module)
     args.add("--product=kernel")
-    args.add("--format=amdgpu-hsaco")
+    if exact_format != None:
+        args.add("--format=%s" % exact_format)
     args.add("--target=%s:%s" % (
         target_profile.family,
         target_profile.selector,
@@ -149,17 +151,21 @@ def _declare_command_product(ctx, linked_module):
 
 def _loom_kernel_binary_impl(ctx):
     _require_binary_inputs(ctx)
-    target_profile = _require_amdgpu_target_profile(ctx, "kernel")
+    target_profile = ctx.attr.target[LoomTargetProfileInfo]
     linked = _declare_binary_linked_module(
         ctx,
         "kernel",
         target_profile = target_profile,
     )
-    product = _declare_amdgpu_kernel_product(
+    artifact = ctx.outputs.out
+    if artifact == None:
+        artifact = ctx.actions.declare_file(ctx.label.name)
+    product = _declare_kernel_product(
         ctx = ctx,
         linked_module = linked.linked_module,
         target_profile = target_profile,
-        output_stem = ctx.label.name,
+        artifact = artifact,
+        report_stem = ctx.label.name,
         mnemonic = "LoomKernelBinary",
         progress_message = "Compiling kernel binary %s for %s" % (
             ctx.label,
@@ -211,11 +217,18 @@ def _target_binary_attrs(target_doc):
     )
     return attrs
 
-loom_kernel_binary = rule(
-    implementation = _loom_kernel_binary_impl,
+def _kernel_binary_attrs():
     attrs = _target_binary_attrs(
         "Immutable target profile used for every emitted kernel.",
-    ),
+    )
+    attrs["out"] = attr.output(
+        doc = "Optional kernel artifact path. Defaults to the extensionless rule name.",
+    )
+    return attrs
+
+loom_kernel_binary = rule(
+    implementation = _loom_kernel_binary_impl,
+    attrs = _kernel_binary_attrs(),
     doc = "Links and emits one closed loader-ready kernel product.",
     toolchains = [
         _LOOM_COMPILE_TOOLCHAIN_TYPE,
@@ -232,16 +245,18 @@ def _loom_command_binary_impl(ctx):
         target_profile = target_profile,
     )
     command_product = _declare_command_product(ctx, linked.linked_module)
-    kernel_product = _declare_amdgpu_kernel_product(
+    kernel_product = _declare_kernel_product(
         ctx = ctx,
         linked_module = linked.linked_module,
         target_profile = target_profile,
-        output_stem = ctx.label.name + ".kernels",
+        artifact = ctx.actions.declare_file(ctx.label.name + ".kernels.hsaco"),
+        report_stem = ctx.label.name + ".kernels",
         mnemonic = "LoomCommandKernelBinary",
         progress_message = "Compiling command kernels for %s against %s" % (
             ctx.label,
             ctx.attr.target.label,
         ),
+        exact_format = "amdgpu-hsaco",
     )
     artifacts = [
         command_product.manifest,

--- a/loom/build_tools/bazel/test/BUILD.bazel
+++ b/loom/build_tools/bazel/test/BUILD.bazel
@@ -44,9 +44,9 @@ loom_amdgpu_target_profile(
 )
 
 loom_target_profile(
-    name = "test_spirv_profile",
-    family = "spirv",
-    selector = "vulkan1.3+bda",
+    name = "test_fake_profile",
+    family = "FakeTargetFamily123",
+    selector = "FakeTargetSelector123",
 )
 
 loom_kernel_library(
@@ -69,6 +69,7 @@ loom_library(
 
 loom_kernel_binary(
     name = "kernel_binary_deps",
+    out = "kernel_binary_deps.hsaco",
     tags = ["manual"],
     target = "//loom/target/amdgpu:gfx11-generic",
     deps = [":public_kernel_library"],
@@ -77,6 +78,7 @@ loom_kernel_binary(
 loom_kernel_binary(
     name = "kernel_binary_srcs",
     srcs = ["link_kernels.loom"],
+    out = "kernel_binary_srcs.hsaco",
     tags = ["manual"],
     target = "//loom/target/amdgpu:gfx11-generic",
 )
@@ -84,6 +86,7 @@ loom_kernel_binary(
 loom_kernel_binary(
     name = "kernel_binary_mixed",
     srcs = ["link_checks.loom"],
+    out = "kernel_binary_mixed.hsaco",
     configs = {
         "a.value": "1",
         "z.value": "2",
@@ -95,6 +98,7 @@ loom_kernel_binary(
 
 loom_kernel_binary(
     name = "kernel_binary_explicit_root",
+    out = "kernel_binary_explicit_root.hsaco",
     roots = ["@scale"],
     tags = ["manual"],
     target = "//loom/target/amdgpu:gfx11-generic",

--- a/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_binary_rules_test.bzl
@@ -47,6 +47,11 @@ def _expect_no_arg_with_suffix(env, args, prefix, suffix):
                 (prefix, suffix, args),
             )
 
+def _expect_no_arg_with_prefix(env, args, prefix):
+    for arg in args:
+        if arg.startswith(prefix):
+            env.fail("unexpected argument with prefix %r in %r" % (prefix, args))
+
 def _test_kernel_binary_roots_direct_library_exports(name, **kwargs):
     analysis_test(
         name = name,
@@ -99,7 +104,6 @@ def _test_kernel_binary_roots_direct_library_exports_impl(env, target):
     compile_action = _find_action(env, actions, "LoomKernelBinary")
     for expected_arg in [
         "--product=kernel",
-        "--format=amdgpu-hsaco",
         "--target=amdgpu:gfx11-generic",
         "--compile-report=details",
     ]:
@@ -108,6 +112,7 @@ def _test_kernel_binary_roots_direct_library_exports_impl(env, target):
                 "expected %r in compile arguments %r" %
                 (expected_arg, compile_action.argv),
             )
+    _expect_no_arg_with_prefix(env, compile_action.argv, "--format=")
 
     _expect_basename(
         env,
@@ -202,28 +207,49 @@ def _test_explicit_roots_replace_direct_exports_impl(env, target):
         "public_kernel_library.loombc",
     )
 
-def _test_kernel_binary_profile_mismatch(name, **kwargs):
+def _test_kernel_binary_accepts_generic_profile(name, **kwargs):
     subject = name + "_subject"
     util.helper_target(
         loom_kernel_binary,
         name = subject,
         deps = [":public_kernel_library"],
+        out = "ExecutableArtifact123.bin",
         tags = ["manual"],
-        target = ":test_spirv_profile",
+        target = ":test_fake_profile",
     )
     analysis_test(
         name = name,
-        expect_failure = True,
-        impl = _test_kernel_binary_profile_mismatch_impl,
+        impl = _test_kernel_binary_accepts_generic_profile_impl,
         target = subject,
         **kwargs
     )
 
-def _test_kernel_binary_profile_mismatch_impl(env, target):
-    env.expect.that_target(target).failures().contains_predicate(
-        matching.contains(
-            "cannot emit a kernel binary for target profile family \"spirv\"",
-        ),
+def _test_kernel_binary_accepts_generic_profile_impl(env, target):
+    binary = target[LoomBinaryInfo]
+    env.expect.that_str(binary.primary_artifact.basename).equals(
+        "ExecutableArtifact123.bin",
+    )
+    env.expect.that_str(
+        binary.target_profiles[0][LoomTargetProfileInfo].family,
+    ).equals("FakeTargetFamily123")
+    env.expect.that_str(
+        binary.target_profiles[0][LoomTargetProfileInfo].selector,
+    ).equals("FakeTargetSelector123")
+
+    actions = target[TestingAspectInfo].actions
+    for action_name in ["LoomBinaryLink", "LoomKernelBinary"]:
+        action = _find_action(env, actions, action_name)
+        if "--target=FakeTargetFamily123:FakeTargetSelector123" not in action.argv:
+            env.fail("expected generic target in %s arguments %r" % (action_name, action.argv))
+    compile_action = _find_action(env, actions, "LoomKernelBinary")
+    if "--product=kernel" not in compile_action.argv:
+        env.fail("expected kernel product in %r" % compile_action.argv)
+    _expect_no_arg_with_prefix(env, compile_action.argv, "--format=")
+    _expect_arg_with_suffix(
+        env,
+        compile_action.argv,
+        "--output=",
+        "ExecutableArtifact123.bin",
     )
 
 def _test_command_binary_emits_composite_product(name, **kwargs):
@@ -403,7 +429,7 @@ def _test_command_binary_profile_mismatch(name, **kwargs):
         name = subject,
         deps = [":public_kernel_library"],
         tags = ["manual"],
-        target = ":test_spirv_profile",
+        target = ":test_fake_profile",
     )
     analysis_test(
         name = name,
@@ -416,7 +442,8 @@ def _test_command_binary_profile_mismatch(name, **kwargs):
 def _test_command_binary_profile_mismatch_impl(env, target):
     env.expect.that_target(target).failures().contains_predicate(
         matching.contains(
-            "cannot emit a command binary for target profile family \"spirv\"",
+            "cannot emit a command binary for target profile family " +
+            "\"FakeTargetFamily123\"",
         ),
     )
 
@@ -429,7 +456,7 @@ def loom_binary_rules_test_suite(name):
             _test_command_binary_profile_mismatch,
             _test_command_binary_sources_are_an_implicit_library,
             _test_explicit_roots_replace_direct_exports,
-            _test_kernel_binary_profile_mismatch,
+            _test_kernel_binary_accepts_generic_profile,
             _test_kernel_binary_roots_direct_library_exports,
             _test_kernel_binary_sources_are_an_implicit_library,
         ],

--- a/loom/build_tools/bazel/test/loom_library_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_library_rules_test.bzl
@@ -260,7 +260,7 @@ def _test_generated_kernel_binary_is_testonly_impl(env, target):
 
     binary = target[LoomBinaryInfo]
     env.expect.that_str(binary.primary_artifact.basename).equals(
-        "public_kernel_library_kernel_binary_gfx11_generic.hsaco",
+        "public_kernel_library_kernel_binary_gfx11_generic",
     )
     _expect_basename(
         env,
@@ -271,11 +271,13 @@ def _test_generated_kernel_binary_is_testonly_impl(env, target):
     action = _find_action(env, target[TestingAspectInfo].actions, "LoomKernelBinary")
     for expected_arg in [
         "--product=kernel",
-        "--format=amdgpu-hsaco",
         "--target=amdgpu:gfx11-generic",
     ]:
         if expected_arg not in action.argv:
             env.fail("expected %r in kernel binary arguments %r" % (expected_arg, action.argv))
+    for arg in action.argv:
+        if arg.startswith("--format="):
+            env.fail("unexpected exact format in kernel binary arguments %r" % action.argv)
 
 def _test_execution_profile_contract(name, **kwargs):
     analysis_test(

--- a/loom/build_tools/bazel/test/loom_target_profile_rules_test.bzl
+++ b/loom/build_tools/bazel/test/loom_target_profile_rules_test.bzl
@@ -47,14 +47,14 @@ def _test_generic_profile_preserves_family_identity(name, **kwargs):
     analysis_test(
         name = name,
         impl = _test_generic_profile_preserves_family_identity_impl,
-        target = ":test_spirv_profile",
+        target = ":test_fake_profile",
         **kwargs
     )
 
 def _test_generic_profile_preserves_family_identity_impl(env, target):
     profile = target[LoomTargetProfileInfo]
-    env.expect.that_str(profile.family).equals("spirv")
-    env.expect.that_str(profile.selector).equals("vulkan1.3+bda")
+    env.expect.that_str(profile.family).equals("FakeTargetFamily123")
+    env.expect.that_str(profile.selector).equals("FakeTargetSelector123")
 
 def loom_target_profile_rules_test_suite(name):
     test_suite(

--- a/loom/build_tools/bazel/test/testdata/kernel_binary/BUILD.bazel
+++ b/loom/build_tools/bazel/test/testdata/kernel_binary/BUILD.bazel
@@ -46,6 +46,7 @@ loom_library(
 
 loom_kernel_binary(
     name = "transitive_subject",
+    out = "transitive_subject.hsaco",
     tags = ["manual"],
     target = "//loom/target/amdgpu:gfx11-generic",
     deps = [":interface"],

--- a/loom/docs/examples/elementwise-transform/BUILD.bazel
+++ b/loom/docs/examples/elementwise-transform/BUILD.bazel
@@ -39,6 +39,7 @@ loom_library(
 
 loom_kernel_binary(
     name = "elementwise_kernel",
+    out = "elementwise_kernel.hsaco",
     target = "@hrx//loom/target/amdgpu:gfx11-generic",
     deps = [":kernel"],
 )

--- a/loom/docs/src/workflows/build-with-bazel.md
+++ b/loom/docs/src/workflows/build-with-bazel.md
@@ -131,10 +131,16 @@ link boundary targetless.
 ## Kernel binaries are loader-ready executables
 
 `loom_kernel_binary` specializes the selected kernel closure for one immutable
-target profile and emits `<name>.hsaco` for the current AMDGPU product. The
-example's profile label carries the typed family and the target selector
-`gfx11-generic`; it is a Bazel target, not a source file or filename-like
-configuration blob.
+target profile and emits one artifact named by `out`. The compiler chooses the
+canonical kernel format for that target. The example therefore names
+`elementwise_kernel.hsaco` for its `gfx11-generic` AMDGPU profile, while a rule
+using `//loom/target/spirv:vulkan1.3+bda` can name an `.spv` output without
+changing the base rule.
+
+`out` controls only the Bazel artifact path; the compiler never infers the
+format from its suffix. When omitted, the artifact has the extensionless rule
+name. This is useful for higher-level macros that fan out target products but
+do not own target-specific filename conventions.
 
 ```shell
 bazel build //loom/docs/examples/elementwise-transform:elementwise_kernel

--- a/loom/target/spirv/BUILD.bazel
+++ b/loom/target/spirv/BUILD.bazel
@@ -1,0 +1,52 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# bazel-to-cmake: skip
+
+load("//build_tools/bazel:executable.bzl", "iree_executable_test")
+load("//loom/build_tools/bazel:build_defs.bzl", "loom_config_compatible_with")
+load(
+    "//loom/build_tools/bazel:defs.bzl",
+    "loom_kernel_binary",
+    "loom_target_profile",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+_SPIRV_ARTIFACTS_COMPATIBLE_WITH = loom_config_compatible_with([
+    "//loom/config/target:spirv_artifacts",
+])
+
+loom_target_profile(
+    name = "vulkan1.3+bda",
+    family = "spirv",
+    selector = "vulkan1.3+bda",
+    target_compatible_with = _SPIRV_ARTIFACTS_COMPATIBLE_WITH,
+)
+
+loom_kernel_binary(
+    name = "copy_i32_test_binary",
+    testonly = True,
+    srcs = ["copy_i32.loom"],
+    out = "copy_i32_test.spv",
+    target = ":vulkan1.3+bda",
+    target_compatible_with = _SPIRV_ARTIFACTS_COMPATIBLE_WITH,
+    visibility = ["//visibility:private"],
+)
+
+iree_executable_test(
+    name = "copy_i32_test",
+    src = "//third_party:spirv_val",
+    args = [
+        "--target-env",
+        "vulkan1.3",
+        "$(rootpath :copy_i32_test_binary)",
+    ],
+    data = [":copy_i32_test_binary"],
+    tags = ["hostonly"],
+    target_compatible_with = _SPIRV_ARTIFACTS_COMPATIBLE_WITH,
+    visibility = ["//visibility:private"],
+)

--- a/loom/target/spirv/copy_i32.loom
+++ b/loom/target/spirv/copy_i32.loom
@@ -1,0 +1,15 @@
+kernel.def export("copy_i32") @copy_i32() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 4 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer) {
+  %base = index.constant 0 : offset
+  %lane = kernel.workitem.id<x> : index
+  %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
+  %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<4xi32>
+  %output_view = buffer.view %output_aligned[%base] : buffer -> view<4xi32>
+  %value = view.load %input_view[%lane] : view<4xi32> -> i32
+  view.store %value, %output_view[%lane] : i32, view<4xi32>
+  kernel.return
+}


### PR DESCRIPTION
`loom_kernel_binary` now emits one loader-ready kernel artifact for any typed Loom target profile. The rule forwards `--product=kernel` and `--target=family:selector`, leaves canonical format selection to `loom-compile`, and accepts an optional `out` naming the Bazel artifact. The filename suffix is packaging policy only and never selects the compiler format.

Previously the shared rule rejected every non-AMDGPU profile, forced `--format=amdgpu-hsaco`, and manufactured a `.hsaco` filename. That embedded one target's artifact policy in the common product boundary even though `loom-compile` already owns canonical format selection from the product and target.

Direct declarations can now state the artifact name appropriate to their deployment:

```starlark
loom_kernel_binary(
    name = "elementwise_kernel",
    out = "elementwise_kernel.hsaco",
    target = "//loom/target/amdgpu:gfx11-generic",
    deps = [":kernel"],
)

loom_kernel_binary(
    name = "copy_i32_kernel",
    out = "copy_i32.spv",
    target = "//loom/target/spirv:vulkan1.3+bda",
    deps = [":kernel"],
)
```

`loom_kernel_library` remains the targetless, partially specialized `.loombc` abstraction. Its optional `targets` fanout still creates private native binaries; when that higher-level macro does not own a target-specific filename convention, the base rule uses the extensionless target name. `LoomBinaryInfo` and its artifact/report/profile contract are unchanged.

`loom_command_binary` remains deliberately separate in this tranche. Its composite product is still AMDGPU-only and continues to request the exact `amdgpu-hsaco` format for its kernel sidecar, so generalizing standalone kernel products does not silently change command-package semantics.

The new public `//loom/target/spirv:vulkan1.3+bda` profile is available only when SPIR-V artifact support is enabled. Its semantic test compiles a real aligned buffer-copy kernel through `loom_kernel_binary` and validates the resulting module for Vulkan 1.3 with `spirv-val`; target-disabled builds leave the package incompatible instead of enabling SPIR-V implicitly.

## Reviewer notes

The highest-value review surfaces are the generic kernel-product action in `loom_binary.bzl`, the preserved AMDGPU-specific command sidecar, and the extensionless fallback used only when a higher-level fanout does not provide `out`.
