### PR TITLE
[HAL/AMDGPU] Match host waits to exact producer epochs

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_atomic_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_atomic_test.cc
@@ -360,6 +360,78 @@ TEST_F(HostQueueAtomicTest,
   release_latch.Wait();
 }
 
+TEST_F(HostQueueAtomicTest, HostWaitForEarlierValueIgnoresLaterProducerEpoch) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(
+      test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+
+  iree_hal_queue_t* queue = test_device.queue(/*family_ordinal=*/0,
+                                              /*queue_ordinal=*/0);
+  ASSERT_NE(queue, nullptr);
+  alignas(64) std::array<std::atomic<uint32_t>, 2> wait_values = {};
+  ReleaseLatch release_latch(/*release_count=*/1);
+  Ref<iree_hal_buffer_t> buffer;
+  IREE_ASSERT_OK(ImportHostAtomicBuffer(
+      &test_device, /*physical_device_ordinal=*/0, wait_values.data(),
+      sizeof(wait_values), IREE_HAL_MEMORY_ACCESS_NONE,
+      /*minimum_alignment=*/64, release_latch.callback(), buffer.out()));
+
+  Ref<iree_hal_semaphore_t> timeline;
+  IREE_ASSERT_OK(CreateSemaphore(test_device.base_device(), timeline.out()));
+  iree_hal_semaphore_t* timeline_semaphore = timeline.get();
+  uint64_t first_value = 1;
+  const iree_hal_semaphore_list_t first_signal_list = {
+      /*.count=*/1,
+      /*.semaphores=*/&timeline_semaphore,
+      /*.payload_values=*/&first_value,
+  };
+  IREE_ASSERT_OK(iree_hal_queue_atomic_wait(
+      queue, iree_hal_semaphore_list_empty(), first_signal_list, buffer,
+      /*target_offset=*/0,
+      (iree_hal_atomic_wait_params_t){
+          /*.value=*/1,
+          /*.mask=*/UINT32_MAX,
+          /*.flags=*/IREE_HAL_ATOMIC_FLAG_ACQUIRE |
+              IREE_HAL_ATOMIC_FLAG_SYSTEM_SCOPE,
+          /*.width=*/IREE_HAL_ATOMIC_WIDTH_32,
+          /*.condition=*/IREE_HAL_ATOMIC_WAIT_CONDITION_EQUAL,
+      }));
+
+  uint64_t second_value = 2;
+  const iree_hal_semaphore_list_t second_signal_list = {
+      /*.count=*/1,
+      /*.semaphores=*/&timeline_semaphore,
+      /*.payload_values=*/&second_value,
+  };
+  IREE_ASSERT_OK(iree_hal_queue_atomic_wait(
+      queue, iree_hal_semaphore_list_empty(), second_signal_list, buffer,
+      /*target_offset=*/sizeof(wait_values[0]),
+      (iree_hal_atomic_wait_params_t){
+          /*.value=*/1,
+          /*.mask=*/UINT32_MAX,
+          /*.flags=*/IREE_HAL_ATOMIC_FLAG_ACQUIRE |
+              IREE_HAL_ATOMIC_FLAG_SYSTEM_SCOPE,
+          /*.width=*/IREE_HAL_ATOMIC_WIDTH_32,
+          /*.condition=*/IREE_HAL_ATOMIC_WAIT_CONDITION_EQUAL,
+      }));
+
+  wait_values[0].store(1, std::memory_order_release);
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(timeline, first_value,
+                                         iree_infinite_timeout(),
+                                         IREE_ASYNC_WAIT_FLAG_NONE));
+  wait_values[1].store(1, std::memory_order_release);
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(timeline, second_value,
+                                         iree_infinite_timeout(),
+                                         IREE_ASYNC_WAIT_FLAG_NONE));
+  EXPECT_EQ(wait_values[0].load(std::memory_order_acquire), 1u);
+  EXPECT_EQ(wait_values[1].load(std::memory_order_acquire), 1u);
+
+  buffer.reset();
+  release_latch.Wait();
+}
+
 TEST_F(HostQueueAtomicTest, DirectWaitBeforeStoreOnIndependentQueue) {
   iree_hal_amdgpu_logical_device_options_t options;
   iree_hal_amdgpu_logical_device_options_initialize(&options);

--- a/runtime/src/iree/hal/drivers/amdgpu/semaphore.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/semaphore.c
@@ -349,13 +349,15 @@ static iree_status_t iree_hal_amdgpu_semaphore_wait(
   iree_async_axis_t producer_axis = 0;
   uint64_t producer_epoch = 0;
   uint64_t producer_value = 0;
+  // A later producer may depend on host work performed after this wait
+  // returns. Its epoch is therefore not a safe substitute for this value.
   if (iree_hal_amdgpu_last_signal_load(&semaphore->last_signal,
                                        &last_signal_flags, &producer_axis,
                                        &producer_epoch, &producer_value) &&
       iree_all_bits_set(
           last_signal_flags,
           IREE_HAL_AMDGPU_LAST_SIGNAL_FLAG_PRODUCER_FRONTIER_EXACT) &&
-      producer_value >= value) {
+      producer_value == value) {
     iree_hal_amdgpu_host_queue_epoch_wait_t wait_state;
     if (iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
             semaphore->device, producer_axis, &wait_state)) {


### PR DESCRIPTION
Fixes https://github.com/ROCm/hrx-system/issues/559

  ## Summary

  Restricts the AMDGPU semaphore host-wait fast path to producer epochs that signal exactly the requested timeline value.

  The semaphore caches the producer of its most recently submitted signal. Previously, a host wait for an earlier value could use that newer producer whenever `producer_value >= requested_value`.
  Although completion of the newer value implies that the earlier value has been reached, waiting for the newer producer is not always a valid substitute: that producer may depend on host work
  intentionally sequenced after the earlier wait.

  This can create a dependency cycle and deadlock.

  ## Changes

  - Use the direct host-queue producer-epoch path only when `producer_value == requested_value`.
  - Fall back to the ordinary semaphore wait when the cached producer describes a newer value.
  - Add an AMDGPU-local regression test where:
    - one queued operation signals timeline value 1;
    - a later operation signals value 2 but depends on host work;
    - that host work is performed only after waiting for value 1.

  Exact-value waits retain the existing fast path. The change adds no state, locks, queue-submission work, HAL API changes, or ABI changes.

  ## Verification

  - Regression test times out with the previous predicate.
  - Regression test passes 20 consecutive runs with this change.
  - AMDGPU host-queue atomic tests: 11 passed, 1 hardware-capability skip.
  - AMDGPU semaphore tests: 5 passed.
  - AMDGPU Bazel clang-tidy checks passed.
  - Hygiene and Semgrep checks passed.