### PR TITLE
[Infra] Harden developer setup, Windows launches, and CTest filtering

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -17,6 +17,11 @@ conversion is an explicit source-generation and presubmit step.
 
 ## Quick Start
 
+Developer environment setup selects Python 3.12, shared by the tested tool
+and importer environments. Install that interpreter before setup. Setup rejects
+an incompatible populated environment; move it aside or choose a new
+`--tool-root` before retrying.
+
 Bazel source-tree build:
 
 ```bash

--- a/build_tools/devtools/BUILD.bazel
+++ b/build_tools/devtools/BUILD.bazel
@@ -300,6 +300,7 @@ py_test(
         "__init__.py",
         "aliases.py",
         "command_plan.py",
+        "doctor.py",
         "environment.py",
         "hooks.py",
         "setup.py",

--- a/build_tools/devtools/bazel.py
+++ b/build_tools/devtools/bazel.py
@@ -12,7 +12,6 @@ import json
 import os
 import re
 import secrets
-import shlex
 import shutil
 import signal
 import subprocess
@@ -727,7 +726,7 @@ def create_bazel_argument_separator() -> str:
 
 def bazel_run_under_command(target_executable: Path) -> str:
     launcher_path = Path(bazel_launcher.__file__).resolve()
-    return shlex.join(
+    return quote_command(
         [
             Path(sys.executable).as_posix(),
             launcher_path.as_posix(),

--- a/build_tools/devtools/cli_test.py
+++ b/build_tools/devtools/cli_test.py
@@ -110,13 +110,13 @@ class CliTest(unittest.TestCase):
     def test_importers_setup_uses_locked_python_abi(self):
         with (
             mock.patch(
-                "build_tools.devtools.importers._interpreter_version",
+                "build_tools.devtools.environment.interpreter_version",
                 side_effect=lambda command: (
                     "3.12" if command == ("/tools/python3.12",) else "3.13"
                 ),
             ),
             mock.patch(
-                "build_tools.devtools.importers.shutil.which",
+                "build_tools.devtools.environment.shutil.which",
                 return_value="/tools/python3.12",
             ),
         ):

--- a/build_tools/devtools/doctor.py
+++ b/build_tools/devtools/doctor.py
@@ -24,6 +24,7 @@ COMMON_TOOLS = (
     ("clang-format", "--version", r"\b22\.1\.3\b"),
 )
 SEMGREP_WARNING_FILTER = "ignore:pkg_resources is deprecated as an API:UserWarning"
+SEMGREP_VERSION_PATTERN = r"\b1\.96\.0\b"
 SEMGREP_SETUP_HINT = (
     "run python dev.py bazel setup --venv to install the managed tool environment"
 )
@@ -35,7 +36,7 @@ OPTIONAL_COMMON_TOOLS = (
     (
         "semgrep",
         ("--disable-version-check", "--version"),
-        r"\b1\.96\.0\b",
+        SEMGREP_VERSION_PATTERN,
         SEMGREP_SETUP_HINT,
         SEMGREP_WARNING_FILTER,
     ),

--- a/build_tools/devtools/environment.py
+++ b/build_tools/devtools/environment.py
@@ -37,28 +37,6 @@ def _environment_value(
     return None
 
 
-def _read_windows_short_path(path: str) -> str | None:
-    """Returns the Win32 short spelling of an existing path when available."""
-    import ctypes
-
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    get_short_path_name = kernel32.GetShortPathNameW
-    get_short_path_name.argtypes = [
-        ctypes.c_wchar_p,
-        ctypes.c_wchar_p,
-        ctypes.c_uint32,
-    ]
-    get_short_path_name.restype = ctypes.c_uint32
-    required_length = get_short_path_name(path, None, 0)
-    if required_length == 0:
-        return None
-    buffer = ctypes.create_unicode_buffer(required_length)
-    written_length = get_short_path_name(path, buffer, required_length)
-    if written_length == 0 or written_length >= required_length:
-        return None
-    return buffer.value
-
-
 def _create_windows_directory_junction(link: Path, target: Path) -> None:
     """Creates a Windows directory junction without requiring symlink rights."""
     command_interpreter = os.environ.get("COMSPEC", "cmd.exe")
@@ -99,21 +77,19 @@ def bazel_compatible_windows_shell_path(
     path: str,
     *,
     platform_name: str | None = None,
-    short_path_reader: Callable[[str], str | None] | None = None,
     alias_root: Path | None = None,
     junction_creator: Callable[[Path, Path], None] | None = None,
 ) -> str:
     """Returns a shell path safe for Bazel's generated Windows batch files."""
     platform_name = os.name if platform_name is None else platform_name
-    if platform_name != "nt" or not any(character.isspace() for character in path):
+    if platform_name != "nt":
         return path
-    if short_path_reader is None:
-        short_path_reader = _read_windows_short_path
-    short_path = short_path_reader(path)
-    if short_path and not any(character.isspace() for character in short_path):
-        return short_path
 
+    # Bazel expands Windows short names before writing the unquoted shell path
+    # into its batch launcher. A directory junction preserves a space-free path.
     shell_path = Path(path).resolve()
+    if not any(character.isspace() for character in str(shell_path)):
+        return path
     install_root = _windows_shell_install_root(shell_path)
     relative_shell_path = shell_path.relative_to(install_root)
     if alias_root is None:

--- a/build_tools/devtools/environment.py
+++ b/build_tools/devtools/environment.py
@@ -291,6 +291,56 @@ def script_name(name: str) -> str:
     return name
 
 
+def interpreter_version(command: tuple[str, ...]) -> str | None:
+    """Returns the major.minor version reported by a Python command."""
+    try:
+        result = subprocess.run(
+            [
+                *command,
+                "-c",
+                (
+                    "import sys; "
+                    "print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+                ),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def resolve_python_interpreter(
+    required_version: str,
+    tool_env: ToolEnvironment,
+) -> tuple[str, ...]:
+    """Resolves an interpreter with the requested major.minor version."""
+    path = tool_env.path_env().get("PATH")
+    candidates = [(tool_env.python,), (sys.executable,)]
+    versioned_python = shutil.which(f"python{required_version}", path=path)
+    if versioned_python is not None:
+        candidates.append((versioned_python,))
+    if os.name == "nt":
+        py_launcher = shutil.which("py", path=path)
+        if py_launcher is not None:
+            candidates.append((py_launcher, f"-{required_version}"))
+
+    seen_commands = set()
+    for command in candidates:
+        if command in seen_commands:
+            continue
+        seen_commands.add(command)
+        if interpreter_version(command) == required_version:
+            return command
+    raise ValueError(
+        f"Python {required_version} is required; install that interpreter and retry"
+    )
+
+
 def default_venv_root() -> Path:
     return REPO_ROOT / ".venv"
 

--- a/build_tools/devtools/environment_test.py
+++ b/build_tools/devtools/environment_test.py
@@ -15,6 +15,27 @@ from build_tools.devtools import environment
 
 
 class EnvironmentTest(unittest.TestCase):
+    def test_resolve_python_interpreter_selects_required_version(self):
+        with (
+            mock.patch.object(
+                environment,
+                "interpreter_version",
+                side_effect=lambda command: (
+                    "3.12" if command == ("/tools/python3.12",) else "3.14"
+                ),
+            ),
+            mock.patch.object(
+                environment.shutil,
+                "which",
+                return_value="/tools/python3.12",
+            ),
+        ):
+            command = environment.resolve_python_interpreter(
+                "3.12", environment.ToolEnvironment(environment.ToolMode.SYSTEM, None)
+            )
+
+        self.assertEqual(command, ("/tools/python3.12",))
+
     def test_windows_bazel_shell_follows_git_for_windows_install(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             git_root = Path(temporary_directory) / "Git"

--- a/build_tools/devtools/environment_test.py
+++ b/build_tools/devtools/environment_test.py
@@ -91,25 +91,7 @@ class EnvironmentTest(unittest.TestCase):
 
         self.assertEqual(result, "C:/tools/bash.exe")
 
-    def test_windows_bazel_shell_uses_space_free_short_path(self):
-        long_path = "C:/Program Files/Git/bin/bash.exe"
-        short_path = "C:/PROGRA~1/Git/bin/bash.exe"
-        with mock.patch.object(
-            environment,
-            "_read_windows_short_path",
-            return_value=short_path,
-        ) as read_short_path:
-            result = environment.find_windows_bazel_sh(
-                {environment.BAZEL_SH_ENV: long_path},
-                platform_name="nt",
-            )
-
-        self.assertEqual(result, short_path)
-        read_short_path.assert_called_once_with(long_path)
-
-    def test_windows_bazel_shell_aliases_installation_when_short_names_are_disabled(
-        self,
-    ):
+    def test_windows_bazel_shell_aliases_installation_with_spaces(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
             git_root = temporary_path / "Program Files" / "Git"
@@ -129,7 +111,6 @@ class EnvironmentTest(unittest.TestCase):
             result = environment.bazel_compatible_windows_shell_path(
                 str(bash_executable),
                 platform_name="nt",
-                short_path_reader=lambda _path: None,
                 alias_root=alias_root,
                 junction_creator=create_test_junction,
             )
@@ -141,9 +122,8 @@ class EnvironmentTest(unittest.TestCase):
             self.assertEqual(created_junctions[0][1], git_root)
 
             repeated_result = environment.bazel_compatible_windows_shell_path(
-                str(bash_executable),
+                result,
                 platform_name="nt",
-                short_path_reader=lambda _path: None,
                 alias_root=alias_root,
                 junction_creator=create_test_junction,
             )

--- a/build_tools/devtools/importers.py
+++ b/build_tools/devtools/importers.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -26,6 +25,7 @@ from build_tools.devtools.environment import (
     LOCAL_TMP_ROOT,
     REPO_ROOT,
     ToolEnvironment,
+    resolve_python_interpreter,
     venv_bin_dir,
 )
 
@@ -344,66 +344,9 @@ class ImporterManifestStep:
         return 0
 
 
-def _interpreter_version(command: tuple[str, ...]) -> str | None:
-    try:
-        result = subprocess.run(
-            [
-                *command,
-                "-c",
-                (
-                    "import sys; "
-                    "print(f'{sys.version_info.major}.{sys.version_info.minor}')"
-                ),
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-    except OSError:
-        return None
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip()
-
-
-def resolve_python_interpreter(
-    importer_spec: ImporterEnvironmentSpec,
-    tool_env: ToolEnvironment,
-) -> tuple[str, ...]:
-    """Resolve the Python ABI used by Bazel and the importer package locks."""
-    path = tool_env.path_env().get("PATH")
-    candidates = [
-        (tool_env.python,),
-        (sys.executable,),
-    ]
-    versioned_python = shutil.which(
-        f"python{importer_spec.python_version}",
-        path=path,
-    )
-    if versioned_python is not None:
-        candidates.append((versioned_python,))
-    if os.name == "nt":
-        py_launcher = shutil.which("py", path=path)
-        if py_launcher is not None:
-            candidates.append((py_launcher, f"-{importer_spec.python_version}"))
-
-    seen_commands = set()
-    for command in candidates:
-        if command in seen_commands:
-            continue
-        seen_commands.add(command)
-        if _interpreter_version(command) == importer_spec.python_version:
-            return command
-    raise ValueError(
-        f"importer environment {importer_spec.name!r} requires Python "
-        f"{importer_spec.python_version}, matching the Bazel Python toolchain; "
-        f"install that interpreter and retry"
-    )
-
-
 def setup_plan(importer_name: str, tool_env: ToolEnvironment) -> CommandPlan:
     importer_spec = spec(importer_name)
-    python_command = resolve_python_interpreter(importer_spec, tool_env)
+    python_command = resolve_python_interpreter(importer_spec.python_version, tool_env)
     return CommandPlan(
         [
             EnsureDirectoryStep(importer_spec.state_dir),

--- a/build_tools/devtools/setup.py
+++ b/build_tools/devtools/setup.py
@@ -11,14 +11,43 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from build_tools.devtools import hooks
+from build_tools.devtools import doctor, hooks
 from build_tools.devtools.aliases import alias_steps
 from build_tools.devtools.command_plan import (
+    CheckCommandStep,
     CommandPlan,
     CommandStep,
     EnsureDirectoryStep,
 )
-from build_tools.devtools.environment import REPO_ROOT, ToolEnvironment, ToolMode
+from build_tools.devtools.environment import (
+    REPO_ROOT,
+    ToolEnvironment,
+    ToolMode,
+    interpreter_version,
+    resolve_python_interpreter,
+)
+
+MANAGED_PYTHON_VERSION = "3.12"
+
+
+def setup_python_command(tool_env: ToolEnvironment) -> tuple[str, ...] | None:
+    """Selects Python for a new environment, or returns None to reuse it."""
+    if tool_env.root.exists():
+        if not tool_env.root.is_dir():
+            raise ValueError(
+                f"managed tool environment path is not a directory: {tool_env.root}"
+            )
+        if any(tool_env.root.iterdir()):
+            actual_version = interpreter_version((tool_env.python,))
+            if actual_version != MANAGED_PYTHON_VERSION:
+                raise ValueError(
+                    f"managed tool environment {tool_env.root} requires Python "
+                    f"{MANAGED_PYTHON_VERSION}; found "
+                    f"{actual_version or 'no usable interpreter'}. "
+                    "Move it aside or choose a new --tool-root before setup."
+                )
+            return None
+    return resolve_python_interpreter(MANAGED_PYTHON_VERSION, tool_env)
 
 
 def common_setup_plan(
@@ -42,14 +71,16 @@ def common_setup_plan(
 
     if tool_env.root is None or tool_env.bin_dir is None:
         raise ValueError("managed setup requires a tool environment root")
+    python_command = setup_python_command(tool_env)
 
-    plan.add(
-        CommandStep(
-            [sys.executable, "-m", "venv", str(tool_env.root)],
-            cwd=REPO_ROOT,
-            label=f"create {tool_env.mode.value} tool environment",
+    if python_command is not None:
+        plan.add(
+            CommandStep(
+                [*python_command, "-m", "venv", str(tool_env.root)],
+                cwd=REPO_ROOT,
+                label=f"create {tool_env.mode.value} tool environment",
+            )
         )
-    )
     plan.add(
         CommandStep(
             [
@@ -98,6 +129,22 @@ def common_setup_plan(
                     if include_docs
                     else "install static-analysis tools"
                 ),
+            )
+        )
+        plan.add(
+            CheckCommandStep(
+                [
+                    tool_env.tool("semgrep"),
+                    "--disable-version-check",
+                    "--version",
+                ],
+                cwd=REPO_ROOT,
+                env={
+                    **tool_env.path_env(),
+                    "PYTHONWARNINGS": doctor.SEMGREP_WARNING_FILTER,
+                },
+                expected_pattern=doctor.SEMGREP_VERSION_PATTERN,
+                label="check semgrep",
             )
         )
     elif include_docs:

--- a/build_tools/devtools/setup_test.py
+++ b/build_tools/devtools/setup_test.py
@@ -9,12 +9,17 @@ from __future__ import annotations
 import re
 import tempfile
 import unittest
+import venv
 from pathlib import Path
 from unittest import mock
 
 from build_tools.devtools.command_plan import CommandStep, WriteFileStep
 from build_tools.devtools.environment import REPO_ROOT, ToolEnvironment, ToolMode
-from build_tools.devtools.setup import common_setup_plan, setup_plan
+from build_tools.devtools.setup import (
+    common_setup_plan,
+    setup_plan,
+    setup_python_command,
+)
 
 
 def locked_versions(path: Path) -> dict[str, str]:
@@ -28,6 +33,58 @@ def locked_versions(path: Path) -> dict[str, str]:
 
 
 class SetupPlanTest(unittest.TestCase):
+    def test_setup_reuses_the_populated_environment_interpreter(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            tool_env = ToolEnvironment(
+                ToolMode.VENV, Path(temporary_directory) / "venv"
+            )
+            venv.EnvBuilder(with_pip=False).create(tool_env.root)
+
+            plan = common_setup_plan(tool_env)
+            self.assertFalse(any("venv" in step.argv for step in plan.steps))
+
+    def test_setup_rejects_populated_directory_without_an_interpreter(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "retained.txt").write_text("caller data")
+            with self.assertRaisesRegex(ValueError, "no usable interpreter"):
+                common_setup_plan(ToolEnvironment(ToolMode.TOOL_ROOT, root))
+
+            self.assertEqual((root / "retained.txt").read_text(), "caller data")
+            self.assertEqual([path.name for path in root.iterdir()], ["retained.txt"])
+
+    def test_setup_selects_exact_managed_python_for_new_environment(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            tool_env = ToolEnvironment(
+                ToolMode.VENV, Path(temporary_directory) / "venv"
+            )
+            with mock.patch(
+                "build_tools.devtools.setup.resolve_python_interpreter",
+                return_value=("/tools/python3.12",),
+            ) as resolve_python:
+                command = setup_python_command(tool_env)
+
+        self.assertEqual(command, ("/tools/python3.12",))
+        resolve_python.assert_called_once_with(
+            "3.12",
+            tool_env,
+        )
+
+    def test_setup_rejects_populated_environment_with_wrong_python(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            venv_root = Path(temporary_directory) / "venv"
+            venv_root.mkdir()
+            (venv_root / "pyvenv.cfg").write_text("version = 3.14\n")
+            tool_env = ToolEnvironment(ToolMode.VENV, venv_root)
+            with (
+                mock.patch(
+                    "build_tools.devtools.setup.interpreter_version",
+                    return_value="3.14",
+                ),
+                self.assertRaisesRegex(ValueError, "requires Python 3.12; found 3.14"),
+            ):
+                setup_python_command(tool_env)
+
     def test_system_mode_does_not_create_venv_or_aliases_by_default(self):
         plan = setup_plan("bazel", ToolEnvironment(ToolMode.SYSTEM, None), None)
 
@@ -76,6 +133,11 @@ class SetupPlanTest(unittest.TestCase):
             self.assertTrue(
                 any("--only-binary=:all:" in step.describe() for step in commands)
             )
+            semgrep_probe = next(
+                step for step in plan.steps if step.label == "check semgrep"
+            )
+            self.assertIn("--disable-version-check", semgrep_probe.argv)
+            self.assertEqual(semgrep_probe.expected_pattern, r"\b1\.96\.0\b")
             self.assertTrue(
                 any("--group bazel" in step.describe() for step in commands)
             )

--- a/libhrx/build_tools/presubmit.py
+++ b/libhrx/build_tools/presubmit.py
@@ -29,6 +29,7 @@ GLOBAL_TEST_TRIGGERS = (
     "requirements",
 )
 RESOURCE_TEST_TAG_FILTERS = ("-iree-run-requirement=runtime.resource.amd_gpu",)
+CTEST_RESOURCE_LABEL_EXCLUDE_REGEX = "runtime-resource="
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -100,6 +101,8 @@ def run_cmake_tests() -> bool:
             "--output-on-failure",
             "-R",
             CMAKE_TEST_REGEX,
+            "-LE",
+            CTEST_RESOURCE_LABEL_EXCLUDE_REGEX,
         ],
         "CTest tests",
     )

--- a/libhrx/build_tools/presubmit_test.py
+++ b/libhrx/build_tools/presubmit_test.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import importlib.util
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 def load_presubmit_module():
@@ -35,6 +36,24 @@ class LibhrxPresubmitTest(unittest.TestCase):
             arg for arg in command if arg.startswith("--test_tag_filters=")
         )
         self.assertIn("-iree-run-requirement=runtime.resource.amd_gpu", tag_filter)
+
+    def test_cmake_tests_exclude_runtime_resource_requirements(self):
+        with (
+            mock.patch.object(
+                self.presubmit.project_presubmit,
+                "validate_cmake_build_tree",
+                return_value=True,
+            ),
+            mock.patch.object(
+                self.presubmit.project_presubmit, "run_command", return_value=True
+            ) as run_command,
+        ):
+            self.assertTrue(self.presubmit.run_cmake_tests())
+
+        command = run_command.call_args.args[1]
+        self.assertEqual(command[0], "ctest")
+        self.assertEqual(command[command.index("-R") + 1], "^libhrx/")
+        self.assertEqual(command[command.index("-LE") + 1], "runtime-resource=")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Select Python 3.12 before creating developer tool environments. Share interpreter discovery with importer setup, reuse compatible environments, and reject incompatible populated roots before installing tools. Static-analysis setup also checks that the installed Semgrep package starts and reports the locked version.

Preserve Windows tool paths in generated Bazel launchers. Use the existing platform quoting helper for Python paths containing spaces and the existing installation-directory junction for Git Bash. Windows short paths are insufficient because Bazel expands them before emitting its unquoted shell invocation.

Exclude tests carrying runtime-resource labels from the local libhrx CTest presubmit, matching its Bazel resource exclusion. Explicitly configured device test runs continue selecting those tests directly.
