### PR TITLE
[HIP] Implement virtual memory management

### DIFF
--- a/libhrx/cts/tests/virtual_memory/virtual_memory_test.cpp
+++ b/libhrx/cts/tests/virtual_memory/virtual_memory_test.cpp
@@ -100,7 +100,7 @@ TEST_CASE_METHOD(HrxTestFixture, "virtual memory lifecycle",
   resources.is_mapped = true;
   REQUIRE_OK(hrx().allocator_virtual_memory_protect(
       alloc, resources.virtual_buffer, /*virtual_offset=*/0, resources.size,
-      HRX_MEMORY_PROTECTION_READ_WRITE));
+      HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL, HRX_MEMORY_PROTECTION_READ_WRITE));
 
   REQUIRE_OK(hrx().allocator_virtual_memory_unmap(
       alloc, resources.virtual_buffer, /*virtual_offset=*/0, resources.size));

--- a/libhrx/include/hrx_runtime.h
+++ b/libhrx/include/hrx_runtime.h
@@ -199,6 +199,7 @@ typedef uint32_t hrx_memory_type_t;
 #define HRX_MEMORY_TYPE_HOST_LOCAL 0x00000042u
 #define HRX_MEMORY_TYPE_DEVICE_VISIBLE 0x00000010u
 #define HRX_MEMORY_TYPE_DEVICE_LOCAL 0x00000030u
+#define HRX_MEMORY_TYPE_DEVICE_UNCACHED 0x00000080u
 
 // Memory access bitfield. Values match iree_hal_memory_access_t.
 typedef uint16_t hrx_memory_access_t;
@@ -860,9 +861,17 @@ typedef uint64_t hrx_memory_protection_t;
 #define HRX_MEMORY_PROTECTION_READ_WRITE \
   (HRX_MEMORY_PROTECTION_READ | HRX_MEMORY_PROTECTION_WRITE)
 
+typedef enum hrx_virtual_memory_access_scope_t {
+  HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL = 0,
+  HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST = 1,
+  HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE = 2,
+} hrx_virtual_memory_access_scope_t;
+
 HRX_API hrx_status_t hrx_allocator_virtual_memory_protect(
     hrx_allocator_t allocator, hrx_buffer_t virtual_buffer,
-    size_t virtual_offset, size_t size, hrx_memory_protection_t protection);
+    size_t virtual_offset, size_t size,
+    hrx_virtual_memory_access_scope_t access_scope,
+    hrx_memory_protection_t protection);
 
 //===----------------------------------------------------------------------===//
 // Events (stream synchronization points)

--- a/libhrx/src/binding/common/BUILD.bazel
+++ b/libhrx/src/binding/common/BUILD.bazel
@@ -70,6 +70,7 @@ hrx_cc_library(
         "tls.c",
     ],
     hdrs = [
+        "context.h",
         "direct_transfer.h",
         "event_timestamp_pool.h",
         "fat_binary.h",

--- a/libhrx/src/binding/common/CMakeLists.txt
+++ b/libhrx/src/binding/common/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_cc_library(
   NAME
     common
   HDRS
+    "context.h"
     "direct_transfer.h"
     "event_timestamp_pool.h"
     "fat_binary.h"

--- a/libhrx/src/binding/common/context.h
+++ b/libhrx/src/binding/common/context.h
@@ -1,0 +1,31 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef LIBHRX_SRC_BINDING_COMMON_CONTEXT_H_
+#define LIBHRX_SRC_BINDING_COMMON_CONTEXT_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct iree_hal_streaming_context_t iree_hal_streaming_context_t;
+
+// Returns the current thread's borrowed streaming context, or NULL when no
+// context has been selected.
+iree_hal_streaming_context_t* iree_hal_streaming_context_current(void);
+
+// Flushes and waits for every stream in every active context. Destructive
+// operations use this when device pointers may be hidden from host-side
+// resource tracking.
+iree_status_t iree_hal_streaming_context_synchronize_all(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LIBHRX_SRC_BINDING_COMMON_CONTEXT_H_

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -7,11 +7,13 @@
 #ifndef IREE_EXPERIMENTAL_STREAMING_INTERNAL_H_
 #define IREE_EXPERIMENTAL_STREAMING_INTERNAL_H_
 
+#include "common/context.h"
 #include "common/event_timestamp_pool.h"
 #include "common/execution_resource.h"
 #include "common/fat_binary.h"
 #include "common/function_attributes.h"
 #include "common/hrx_bridge.h"
+#include "common/memory.h"
 #include "common/stream.h"
 #include "iree/async/frontier_tracker.h"
 #include "iree/async/util/proactor_pool.h"
@@ -28,7 +30,6 @@ typedef uint64_t iree_hal_streaming_deviceptr_t;
 typedef iree_host_size_t iree_hal_streaming_device_ordinal_t;
 
 typedef struct iree_hal_streaming_buffer_t iree_hal_streaming_buffer_t;
-typedef struct iree_hal_streaming_context_t iree_hal_streaming_context_t;
 typedef struct iree_hal_streaming_context_module_entry_t
     iree_hal_streaming_context_module_entry_t;
 typedef struct iree_hal_streaming_context_symbol_map_t
@@ -1512,9 +1513,6 @@ iree_hal_streaming_context_flags_t iree_hal_streaming_context_flags(
     iree_hal_streaming_context_t* context);
 
 // Synchronization: none (thread-local access).
-iree_hal_streaming_context_t* iree_hal_streaming_context_current(void);
-
-// Synchronization: none (thread-local access).
 uintptr_t iree_hal_streaming_current_thread_token(void);
 
 // Synchronization: none (thread-local modification).
@@ -1658,10 +1656,6 @@ iree_status_t iree_hal_streaming_context_synchronize_event_records(
 // synchronized.
 iree_status_t iree_hal_streaming_context_synchronize_legacy_default(
     iree_hal_streaming_context_t* context);
-
-// Synchronization: all streams in all active contexts.
-// This flushes and waits for every context registered in the process.
-iree_status_t iree_hal_streaming_context_synchronize_all(void);
 
 // Orders future work on |stream| after work already enqueued on each blocking,
 // non-capturing stream in the context. Null entries, the legacy default stream,
@@ -2133,11 +2127,6 @@ iree_status_t iree_hal_streaming_memory_wrap_buffer(
     iree_hal_streaming_context_t* context, iree_hal_buffer_t* buffer,
     iree_hal_streaming_buffer_context_ownership_t context_ownership,
     iree_hal_streaming_buffer_t** out_buffer);
-
-// Releases a wrapper created with iree_hal_streaming_memory_wrap_buffer.
-// Synchronization: none (unregisters existing memory).
-void iree_hal_streaming_memory_release_wrapped_buffer(
-    iree_hal_streaming_buffer_t* buffer);
 
 // Synchronization: none (registers existing memory).
 iree_status_t iree_hal_streaming_memory_register_host(

--- a/libhrx/src/binding/common/memory.c
+++ b/libhrx/src/binding/common/memory.c
@@ -392,11 +392,44 @@ iree_status_t iree_hal_streaming_memory_wrap_buffer(
       out_buffer);
 }
 
+iree_status_t iree_hal_streaming_memory_wrap_virtual_reservation(
+    iree_hal_streaming_context_t* context, hrx_buffer_t virtual_buffer,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(virtual_buffer);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  return iree_hal_streaming_buffer_wrap_hrx_buffer(
+      context, virtual_buffer, HRX_MEMORY_TYPE_DEVICE_LOCAL,
+      /*imported_host_ptr=*/NULL, /*allocation_pool=*/NULL,
+      IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED, out_buffer);
+}
+
 void iree_hal_streaming_memory_release_wrapped_buffer(
     iree_hal_streaming_buffer_t* buffer) {
   if (!buffer) return;
   hrx_buffer_table_remove(&buffer->context->buffer_table, buffer->device_ptr);
   iree_hal_streaming_buffer_free(buffer);
+}
+
+void iree_hal_streaming_memory_prepare_virtual_reservation_release(
+    iree_hal_streaming_buffer_t* buffer) {
+  IREE_ASSERT_ARGUMENT(buffer);
+  IREE_ASSERT_ARGUMENT(buffer->hrx_buf);
+  hrx_buffer_t virtual_buffer = buffer->hrx_buf;
+  buffer->hrx_buf = NULL;
+  buffer->buffer = NULL;
+  hrx_buffer_release(virtual_buffer);
+}
+
+void iree_hal_streaming_memory_restore_virtual_reservation(
+    iree_hal_streaming_buffer_t* buffer, hrx_buffer_t virtual_buffer) {
+  IREE_ASSERT_ARGUMENT(buffer);
+  IREE_ASSERT_ARGUMENT(virtual_buffer);
+  IREE_ASSERT_ARGUMENT(!buffer->hrx_buf);
+  buffer->hrx_buf = virtual_buffer;
+  hrx_buffer_retain(virtual_buffer);
+  buffer->buffer = virtual_buffer->hal_buffer;
 }
 
 static void iree_hal_streaming_temporary_host_buffer_free(

--- a/libhrx/src/binding/common/memory.h
+++ b/libhrx/src/binding/common/memory.h
@@ -7,6 +7,7 @@
 #ifndef IREE_EXPERIMENTAL_STREAMING_MEMORY_H_
 #define IREE_EXPERIMENTAL_STREAMING_MEMORY_H_
 
+#include "hrx_runtime.h"
 #include "iree/base/api.h"
 
 #ifdef __cplusplus
@@ -20,6 +21,29 @@ typedef struct iree_hal_streaming_context_t iree_hal_streaming_context_t;
 iree_status_t iree_hal_streaming_memory_allocate_host_staging(
     iree_hal_streaming_context_t* context, iree_host_size_t size,
     iree_hal_streaming_buffer_t** out_buffer);
+
+// Registers an HRX virtual-address reservation in the streaming pointer table.
+// The wrapper retains both |context| and |virtual_buffer|. The reservation
+// remains owned by the caller and must be released through the VMM allocator
+// after the wrapper is removed.
+iree_status_t iree_hal_streaming_memory_wrap_virtual_reservation(
+    iree_hal_streaming_context_t* context, hrx_buffer_t virtual_buffer,
+    iree_hal_streaming_buffer_t** out_buffer);
+
+// Removes and releases an externally owned buffer wrapper.
+void iree_hal_streaming_memory_release_wrapped_buffer(
+    iree_hal_streaming_buffer_t* buffer);
+
+// Drops a virtual reservation wrapper's HRX/HAL reference before the allocator
+// attempts to consume the reservation. The pointer-table entry remains in place
+// until release succeeds, and concurrent use of an address being freed is not a
+// valid operation. The prepared wrapper must be restored or released below.
+void iree_hal_streaming_memory_prepare_virtual_reservation_release(
+    iree_hal_streaming_buffer_t* buffer);
+
+// Restores a prepared virtual reservation after the allocator rejects release.
+void iree_hal_streaming_memory_restore_virtual_reservation(
+    iree_hal_streaming_buffer_t* buffer, hrx_buffer_t virtual_buffer);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/libhrx/src/binding/hip/BUILD.bazel
+++ b/libhrx/src/binding/hip/BUILD.bazel
@@ -212,10 +212,12 @@ hrx_cc_shared_library(
         "abi_stubs.c",
         "api.c",
         "api_metadata.c",
+        "vmm.c",
     ],
     hdrs = [
         "api.h",
         "binding_internal.h",
+        "vmm.h",
     ],
     additional_linker_inputs = ["amdhip64.map"],
     copts = [

--- a/libhrx/src/binding/hip/CMakeLists.txt
+++ b/libhrx/src/binding/hip/CMakeLists.txt
@@ -257,10 +257,12 @@ iree_cc_library(
   HDRS
     "api.h"
     "binding_internal.h"
+    "vmm.h"
   SRCS
     "abi_stubs.c"
     "api.c"
     "api_metadata.c"
+    "vmm.c"
   DEPS
     ::blocking_printf_provider
     ::execution_context

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -34,6 +34,7 @@
 #include "binding/hip/handle_registry.h"
 #include "binding/hip/launch_params.h"
 #include "binding/hip/stream.h"
+#include "binding/hip/vmm.h"
 #include "common/direct_transfer.h"
 #include "common/graph.h"
 #include "common/internal.h"
@@ -2436,6 +2437,13 @@ HIPAPI hipError_t hipDeviceGetAttribute(int* value, hipDeviceAttribute_t attr,
     case hipDeviceAttributeMemoryPoolsSupported:
       *value = iree_hip_memory_pools_supported() ? 1 : 0;
       break;
+    case hipDeviceAttributeVirtualMemoryManagementSupported: {
+      bool supported = false;
+      hipError_t result = iree_hip_vmm_is_supported(device, &supported);
+      if (result != hipSuccess) HIP_RETURN_ERROR(result);
+      *value = supported ? 1 : 0;
+      break;
+    }
     case hipDeviceAttributeConcurrentManagedAccess:
       *value = 1;
       break;
@@ -24346,188 +24354,67 @@ HIPAPI hipError_t hipFreeAsync(void* ptr, hipStream_t stream) {
 // Virtual memory management
 //===----------------------------------------------------------------------===//
 
-static bool iree_hip_mem_allocation_handle_type_is_valid(
-    hipMemAllocationHandleType handle_type) {
-  switch (handle_type) {
-    case hipMemHandleTypeNone:
-    case hipMemHandleTypePosixFileDescriptor:
-    case hipMemHandleTypeWin32:
-    case hipMemHandleTypeWin32Kmt:
-      return true;
-    default:
-      return false;
-  }
-}
-
-static hipError_t iree_hip_validate_mem_allocation_prop(
-    const hipMemAllocationProp* prop) {
-  if (!prop) return hipErrorInvalidValue;
-  if (prop->type != hipMemAllocationTypePinned) {
-    return hipErrorInvalidValue;
-  }
-  if (!iree_hip_mem_allocation_handle_type_is_valid(
-          prop->requestedHandleType)) {
-    return hipErrorInvalidValue;
-  }
-  if (prop->location.type != hipMemLocationTypeDevice) {
-    return hipErrorInvalidValue;
-  }
-
-  int device_count = 0;
-  hipError_t count_result = hipGetDeviceCount(&device_count);
-  if (count_result != hipSuccess) return count_result;
-  if (prop->location.id < 0 || prop->location.id >= device_count) {
-    return hipErrorInvalidDevice;
-  }
-  return hipSuccess;
-}
-
-static const size_t iree_hip_vmm_allocation_granularity = 64 * 1024;
-
-static bool iree_hip_size_is_vmm_granularity_multiple(size_t size) {
-  return size != 0 && (size % iree_hip_vmm_allocation_granularity) == 0;
-}
-
-static bool iree_hip_is_power_of_two(size_t value) {
-  return value != 0 && (value & (value - 1)) == 0;
-}
-
 // Reserves virtual address space.
 HIPAPI hipError_t hipMemAddressReserve(void** ptr, size_t size,
                                        size_t alignment, void* addr,
                                        unsigned long long flags) {
-  if (!ptr || addr || flags != 0 ||
-      !iree_hip_size_is_vmm_granularity_multiple(size)) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  if (alignment == 0) {
-    alignment = iree_hip_vmm_allocation_granularity;
-  }
-  if (!iree_hip_is_power_of_two(alignment)) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  if (alignment < sizeof(void*)) {
-    alignment = sizeof(void*);
-  }
-
-  *ptr = NULL;
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(
+      iree_hip_vmm_address_reserve(ptr, size, alignment, addr, flags));
 }
 
 // Frees reserved virtual address space.
 HIPAPI hipError_t hipMemAddressFree(void* devPtr, size_t size) {
-  if (!devPtr || !iree_hip_size_is_vmm_granularity_multiple(size)) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(iree_hip_vmm_address_free(devPtr, size));
 }
 
 // Creates a generic allocation handle.
 HIPAPI hipError_t hipMemCreate(hipMemGenericAllocationHandle_t* handle,
                                size_t size, const hipMemAllocationProp* prop,
                                unsigned long long flags) {
-  if (!handle || flags != 0 ||
-      !iree_hip_size_is_vmm_granularity_multiple(size)) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  hipError_t prop_result = iree_hip_validate_mem_allocation_prop(prop);
-  if (prop_result != hipSuccess) {
-    HIP_RETURN_ERROR(prop_result);
-  }
-
-  *handle = NULL;
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(iree_hip_vmm_create(handle, size, prop, flags));
 }
 
 // Releases a generic allocation handle.
 HIPAPI hipError_t hipMemRelease(hipMemGenericAllocationHandle_t handle) {
-  if (!handle) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(iree_hip_vmm_release(handle));
 }
 
 // Maps virtual memory to a physical allocation.
 HIPAPI hipError_t hipMemMap(void* ptr, size_t size, size_t offset,
                             hipMemGenericAllocationHandle_t handle,
                             unsigned long long flags) {
-  if (!ptr || flags != 0 || offset != 0 || !handle ||
-      !iree_hip_size_is_vmm_granularity_multiple(size)) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(iree_hip_vmm_map(ptr, size, offset, handle, flags));
 }
 
 // Unmaps virtual memory.
 HIPAPI hipError_t hipMemUnmap(void* ptr, size_t size) {
-  if (!ptr || !iree_hip_size_is_vmm_granularity_multiple(size)) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(iree_hip_vmm_unmap(ptr, size));
 }
 
 // Sets memory access permissions.
 HIPAPI hipError_t hipMemSetAccess(void* ptr, size_t size,
                                   const hipMemAccessDesc* desc, size_t count) {
-  if (!ptr || !iree_hip_size_is_vmm_granularity_multiple(size) || !desc ||
-      count == 0) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  for (size_t i = 0; i < count; ++i) {
-    if (desc[i].location.type != hipMemLocationTypeDevice ||
-        desc[i].location.id < 0) {
-      HIP_RETURN_ERROR(hipErrorInvalidValue);
-    }
-    switch (desc[i].flags) {
-      case hipMemAccessFlagsProtNone:
-      case hipMemAccessFlagsProtRead:
-      case hipMemAccessFlagsProtReadWrite:
-        break;
-      default:
-        HIP_RETURN_ERROR(hipErrorInvalidValue);
-    }
-  }
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(iree_hip_vmm_set_access(ptr, size, desc, count));
 }
 
 // Gets memory access permissions.
 HIPAPI hipError_t hipMemGetAccess(unsigned long long* flags,
                                   const hipMemLocation* location, void* ptr) {
-  if (!flags || !location || !ptr ||
-      location->type != hipMemLocationTypeDevice || location->id < 0) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(iree_hip_vmm_get_access(flags, location, ptr));
 }
 
 // Gets allocation granularity.
 HIPAPI hipError_t hipMemGetAllocationGranularity(
     size_t* granularity, const hipMemAllocationProp* prop,
     hipMemAllocationGranularity_flags option) {
-  if (!granularity) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  hipError_t prop_result = iree_hip_validate_mem_allocation_prop(prop);
-  if (prop_result != hipSuccess) {
-    HIP_RETURN_ERROR(prop_result);
-  }
-  switch (option) {
-    case hipMemAllocationGranularityMinimum:
-    case hipMemAllocationGranularityRecommended:
-      *granularity = iree_hip_vmm_allocation_granularity;
-      return hipSuccess;
-    default:
-      HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
+  HIP_RETURN_ERROR(
+      iree_hip_vmm_get_allocation_granularity(granularity, prop, option));
 }
 
 // Gets properties from allocation handle.
 HIPAPI hipError_t hipMemGetAllocationPropertiesFromHandle(
     hipMemAllocationProp* prop, hipMemGenericAllocationHandle_t handle) {
-  if (!prop || !handle) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(iree_hip_vmm_get_allocation_properties(prop, handle));
 }
 
 // Exports an allocation handle to a shareable handle.
@@ -24554,9 +24441,7 @@ HIPAPI hipError_t hipMemImportFromShareableHandle(
 // Retains an allocation handle from an address.
 HIPAPI hipError_t hipMemRetainAllocationHandle(
     hipMemGenericAllocationHandle_t* handle, void* addr) {
-  (void)handle;
-  (void)addr;
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(iree_hip_vmm_retain_allocation_handle(handle, addr));
 }
 
 //===----------------------------------------------------------------------===//

--- a/libhrx/src/binding/hip/vmm.c
+++ b/libhrx/src/binding/hip/vmm.c
@@ -1,0 +1,1420 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "binding/hip/vmm.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/context.h"
+#include "common/memory.h"
+#include "hrx_runtime.h"
+#include "iree/base/api.h"
+#include "iree/base/threading/call_once.h"
+#include "iree/base/threading/mutex.h"
+
+typedef struct iree_hip_vmm_allocation_t iree_hip_vmm_allocation_t;
+
+typedef struct iree_hip_vmm_mapping_t {
+  // Offset within the virtual reservation in bytes.
+  size_t virtual_offset;
+  // Offset within the physical allocation in bytes.
+  size_t physical_offset;
+  // Length of this mapping in bytes.
+  size_t size;
+  // Physical allocation retained by the mapping registry.
+  iree_hip_vmm_allocation_t* allocation;
+} iree_hip_vmm_mapping_t;
+
+typedef struct iree_hip_vmm_access_range_t {
+  // HIP location class whose permissions this record describes.
+  hipMemLocationType location_type;
+  // HIP location ordinal within |location_type|.
+  int location_id;
+  // Offset within the virtual reservation in bytes.
+  size_t offset;
+  // Length of the permission range in bytes.
+  size_t size;
+  // Permissions last applied to this range.
+  hipMemAccessFlags flags;
+} iree_hip_vmm_access_range_t;
+
+typedef struct iree_hip_vmm_reservation_t {
+  // Registry and in-flight operation references.
+  iree_atomic_ref_count_t ref_count;
+  // Serializes mapping and access-state mutation for this reservation.
+  iree_slim_mutex_t mutex;
+  // Device retained while allocator-owned reservation state is live.
+  hrx_device_t device;
+  // Borrowed allocator owned by |device|.
+  hrx_allocator_t allocator;
+  // HRX virtual address reservation.
+  hrx_buffer_t virtual_buffer;
+  // Streaming wrapper publishing the reservation to pointer lookup.
+  iree_hal_streaming_buffer_t* streaming_buffer;
+  // Base device address returned to HIP callers.
+  uintptr_t base_address;
+  // Total reservation length in bytes.
+  size_t size;
+  // Minimum page size for mapping and protection operations.
+  size_t granularity;
+  // Device ordinal owning the virtual address space.
+  int device_ordinal;
+  // True after removal from the process registry begins.
+  bool retiring;
+  // Sorted, non-overlapping physical mappings.
+  iree_hip_vmm_mapping_t* mappings;
+  // Number of live entries in |mappings|.
+  size_t mapping_count;
+  // Allocated entry capacity of |mappings|.
+  size_t mapping_capacity;
+  // Sorted, normalized access ranges.
+  iree_hip_vmm_access_range_t* access_ranges;
+  // Number of live entries in |access_ranges|.
+  size_t access_range_count;
+} iree_hip_vmm_reservation_t;
+
+struct iree_hip_vmm_allocation_t {
+  // Registry and in-flight operation references.
+  iree_atomic_ref_count_t ref_count;
+  // Serializes public and mapping reference transitions.
+  iree_slim_mutex_t mutex;
+  // Device retained while physical memory is live.
+  hrx_device_t device;
+  // Device ordinal whose allocator owns the physical handle.
+  int device_ordinal;
+  // Borrowed allocator owned by |device|.
+  hrx_allocator_t allocator;
+  // Allocator-owned physical memory handle.
+  hrx_physical_memory_t physical_memory;
+  // Properties reported through the HIP handle query API.
+  hipMemAllocationProp properties;
+  // Physical allocation length in bytes.
+  size_t size;
+  // Monotonic opaque key exposed as the HIP handle value.
+  uintptr_t handle_key;
+  // Number of public HIP handle references.
+  uint64_t public_reference_count;
+  // Number of mapping records retaining this allocation.
+  uint64_t mapping_reference_count;
+  // True while the final native free is in progress.
+  bool retiring;
+};
+
+typedef struct iree_hip_vmm_registry_t {
+  // Guards registry vectors and handle generation only.
+  iree_slim_mutex_t mutex;
+  // Reservations sorted by base device address.
+  iree_hip_vmm_reservation_t** reservations;
+  // Number of entries in |reservations|.
+  size_t reservation_count;
+  // Allocated entry capacity of |reservations|.
+  size_t reservation_capacity;
+  // Allocations sorted by monotonic handle key.
+  iree_hip_vmm_allocation_t** allocations;
+  // Number of entries in |allocations|.
+  size_t allocation_count;
+  // Allocated entry capacity of |allocations|.
+  size_t allocation_capacity;
+  // Next never-reused opaque handle key.
+  uintptr_t next_handle_key;
+} iree_hip_vmm_registry_t;
+
+static iree_once_flag iree_hip_vmm_registry_once = IREE_ONCE_FLAG_INIT;
+static iree_hip_vmm_registry_t iree_hip_vmm_registry;
+
+static void iree_hip_vmm_registry_initialize(void) {
+  memset(&iree_hip_vmm_registry, 0, sizeof(iree_hip_vmm_registry));
+  iree_slim_mutex_initialize(&iree_hip_vmm_registry.mutex);
+  iree_hip_vmm_registry.next_handle_key = 1;
+}
+
+static iree_hip_vmm_registry_t* iree_hip_vmm_registry_lock(void) {
+  iree_call_once(&iree_hip_vmm_registry_once, iree_hip_vmm_registry_initialize);
+  iree_slim_mutex_lock(&iree_hip_vmm_registry.mutex);
+  return &iree_hip_vmm_registry;
+}
+
+static void iree_hip_vmm_registry_unlock(void) {
+  iree_slim_mutex_unlock(&iree_hip_vmm_registry.mutex);
+}
+
+static hipError_t iree_hip_vmm_from_hrx_status(hrx_status_t status) {
+  if (hrx_status_is_ok(status)) return hipSuccess;
+  const hrx_status_code_t code = hrx_status_code(status);
+  hrx_status_ignore(status);
+  switch (code) {
+    case HRX_STATUS_INVALID_ARGUMENT:
+    case HRX_STATUS_OUT_OF_RANGE:
+      return hipErrorInvalidValue;
+    case HRX_STATUS_OUT_OF_MEMORY:
+      return hipErrorOutOfMemory;
+    case HRX_STATUS_NOT_FOUND:
+      return hipErrorNotFound;
+    case HRX_STATUS_PERMISSION_DENIED:
+      return hipErrorInvalidContext;
+    case HRX_STATUS_UNIMPLEMENTED:
+      return hipErrorNotSupported;
+    case HRX_STATUS_UNAVAILABLE:
+      return hipErrorNotReady;
+    default:
+      return hipErrorUnknown;
+  }
+}
+
+static hipError_t iree_hip_vmm_from_iree_status(iree_status_t status) {
+  if (iree_status_is_ok(status)) return hipSuccess;
+  const iree_status_code_t code = iree_status_code(status);
+  iree_status_ignore(status);
+  switch (code) {
+    case IREE_STATUS_INVALID_ARGUMENT:
+    case IREE_STATUS_OUT_OF_RANGE:
+      return hipErrorInvalidValue;
+    case IREE_STATUS_RESOURCE_EXHAUSTED:
+      return hipErrorOutOfMemory;
+    case IREE_STATUS_NOT_FOUND:
+      return hipErrorNotFound;
+    case IREE_STATUS_PERMISSION_DENIED:
+      return hipErrorInvalidContext;
+    case IREE_STATUS_UNIMPLEMENTED:
+      return hipErrorNotSupported;
+    case IREE_STATUS_UNAVAILABLE:
+      return hipErrorNotReady;
+    case IREE_STATUS_FAILED_PRECONDITION:
+      return hipErrorNotInitialized;
+    default:
+      return hipErrorUnknown;
+  }
+}
+
+static hipError_t iree_hip_vmm_grow_pointer_array(void** values,
+                                                  size_t* capacity,
+                                                  size_t minimum_capacity) {
+  if (*capacity >= minimum_capacity) return hipSuccess;
+  size_t new_capacity = *capacity ? *capacity : 16;
+  while (new_capacity < minimum_capacity) {
+    if (new_capacity > SIZE_MAX / 2) return hipErrorOutOfMemory;
+    new_capacity *= 2;
+  }
+  size_t allocation_size = 0;
+  if (!iree_host_size_checked_mul(new_capacity, sizeof(void*),
+                                  &allocation_size)) {
+    return hipErrorOutOfMemory;
+  }
+  iree_status_t status =
+      iree_allocator_realloc(iree_allocator_system(), allocation_size, values);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    return hipErrorOutOfMemory;
+  }
+  *capacity = new_capacity;
+  return hipSuccess;
+}
+
+static void iree_hip_vmm_reservation_retain(
+    iree_hip_vmm_reservation_t* reservation) {
+  if (!reservation) return;
+  iree_atomic_ref_count_inc(&reservation->ref_count);
+}
+
+static void iree_hip_vmm_reservation_release(
+    iree_hip_vmm_reservation_t* reservation) {
+  if (!reservation) return;
+  if (iree_atomic_ref_count_dec(&reservation->ref_count) != 1) return;
+  iree_allocator_free(iree_allocator_system(), reservation->access_ranges);
+  iree_allocator_free(iree_allocator_system(), reservation->mappings);
+  iree_slim_mutex_deinitialize(&reservation->mutex);
+  hrx_device_release(reservation->device);
+  iree_allocator_free(iree_allocator_system(), reservation);
+}
+
+static void iree_hip_vmm_allocation_retain(
+    iree_hip_vmm_allocation_t* allocation) {
+  if (!allocation) return;
+  iree_atomic_ref_count_inc(&allocation->ref_count);
+}
+
+static void iree_hip_vmm_allocation_release(
+    iree_hip_vmm_allocation_t* allocation) {
+  if (!allocation) return;
+  if (iree_atomic_ref_count_dec(&allocation->ref_count) != 1) return;
+  iree_slim_mutex_deinitialize(&allocation->mutex);
+  hrx_device_release(allocation->device);
+  iree_allocator_free(iree_allocator_system(), allocation);
+}
+
+static size_t iree_hip_vmm_reservation_lower_bound(
+    const iree_hip_vmm_registry_t* registry, uintptr_t base_address) {
+  size_t begin = 0;
+  size_t end = registry->reservation_count;
+  while (begin < end) {
+    const size_t middle = begin + (end - begin) / 2;
+    if (registry->reservations[middle]->base_address < base_address) {
+      begin = middle + 1;
+    } else {
+      end = middle;
+    }
+  }
+  return begin;
+}
+
+static hipError_t iree_hip_vmm_registry_insert_reservation_locked(
+    iree_hip_vmm_registry_t* registry,
+    iree_hip_vmm_reservation_t* reservation) {
+  hipError_t result = iree_hip_vmm_grow_pointer_array(
+      (void**)&registry->reservations, &registry->reservation_capacity,
+      registry->reservation_count + 1);
+  if (result != hipSuccess) return result;
+  const size_t position =
+      iree_hip_vmm_reservation_lower_bound(registry, reservation->base_address);
+  if (position < registry->reservation_count &&
+      registry->reservations[position]->base_address ==
+          reservation->base_address) {
+    return hipErrorInvalidValue;
+  }
+  memmove(&registry->reservations[position + 1],
+          &registry->reservations[position],
+          (registry->reservation_count - position) *
+              sizeof(registry->reservations[0]));
+  registry->reservations[position] = reservation;
+  ++registry->reservation_count;
+  return hipSuccess;
+}
+
+static bool iree_hip_vmm_registry_remove_reservation_locked(
+    iree_hip_vmm_registry_t* registry,
+    iree_hip_vmm_reservation_t* reservation) {
+  const size_t position =
+      iree_hip_vmm_reservation_lower_bound(registry, reservation->base_address);
+  if (position >= registry->reservation_count ||
+      registry->reservations[position] != reservation) {
+    return false;
+  }
+  memmove(&registry->reservations[position],
+          &registry->reservations[position + 1],
+          (registry->reservation_count - position - 1) *
+              sizeof(registry->reservations[0]));
+  --registry->reservation_count;
+  return true;
+}
+
+static iree_hip_vmm_reservation_t* iree_hip_vmm_lookup_reservation(
+    uintptr_t address, bool require_base) {
+  iree_hip_vmm_registry_t* registry = iree_hip_vmm_registry_lock();
+  const size_t position =
+      iree_hip_vmm_reservation_lower_bound(registry, address);
+  iree_hip_vmm_reservation_t* reservation = NULL;
+  if (position < registry->reservation_count &&
+      registry->reservations[position]->base_address == address) {
+    reservation = registry->reservations[position];
+  } else if (!require_base && position > 0) {
+    iree_hip_vmm_reservation_t* candidate =
+        registry->reservations[position - 1];
+    if (address >= candidate->base_address &&
+        address - candidate->base_address < candidate->size) {
+      reservation = candidate;
+    }
+  }
+  if (reservation) iree_hip_vmm_reservation_retain(reservation);
+  iree_hip_vmm_registry_unlock();
+  return reservation;
+}
+
+static size_t iree_hip_vmm_allocation_lower_bound(
+    const iree_hip_vmm_registry_t* registry, uintptr_t handle_key) {
+  size_t begin = 0;
+  size_t end = registry->allocation_count;
+  while (begin < end) {
+    const size_t middle = begin + (end - begin) / 2;
+    if (registry->allocations[middle]->handle_key < handle_key) {
+      begin = middle + 1;
+    } else {
+      end = middle;
+    }
+  }
+  return begin;
+}
+
+static hipError_t iree_hip_vmm_registry_insert_allocation_locked(
+    iree_hip_vmm_registry_t* registry, iree_hip_vmm_allocation_t* allocation) {
+  hipError_t result = iree_hip_vmm_grow_pointer_array(
+      (void**)&registry->allocations, &registry->allocation_capacity,
+      registry->allocation_count + 1);
+  if (result != hipSuccess) return result;
+  const size_t position =
+      iree_hip_vmm_allocation_lower_bound(registry, allocation->handle_key);
+  memmove(&registry->allocations[position + 1],
+          &registry->allocations[position],
+          (registry->allocation_count - position) *
+              sizeof(registry->allocations[0]));
+  registry->allocations[position] = allocation;
+  ++registry->allocation_count;
+  return hipSuccess;
+}
+
+static bool iree_hip_vmm_registry_remove_allocation_locked(
+    iree_hip_vmm_registry_t* registry, iree_hip_vmm_allocation_t* allocation) {
+  const size_t position =
+      iree_hip_vmm_allocation_lower_bound(registry, allocation->handle_key);
+  if (position >= registry->allocation_count ||
+      registry->allocations[position] != allocation) {
+    return false;
+  }
+  memmove(&registry->allocations[position],
+          &registry->allocations[position + 1],
+          (registry->allocation_count - position - 1) *
+              sizeof(registry->allocations[0]));
+  --registry->allocation_count;
+  return true;
+}
+
+static iree_hip_vmm_allocation_t* iree_hip_vmm_lookup_allocation(
+    hipMemGenericAllocationHandle_t handle) {
+  const uintptr_t handle_key = (uintptr_t)handle;
+  iree_hip_vmm_registry_t* registry = iree_hip_vmm_registry_lock();
+  const size_t position =
+      iree_hip_vmm_allocation_lower_bound(registry, handle_key);
+  iree_hip_vmm_allocation_t* allocation = NULL;
+  if (position < registry->allocation_count &&
+      registry->allocations[position]->handle_key == handle_key) {
+    allocation = registry->allocations[position];
+    iree_hip_vmm_allocation_retain(allocation);
+  }
+  iree_hip_vmm_registry_unlock();
+  return allocation;
+}
+
+static bool iree_hip_vmm_is_power_of_two(size_t value) {
+  return value != 0 && (value & (value - 1)) == 0;
+}
+
+static bool iree_hip_vmm_range_is_valid(size_t total_size, size_t offset,
+                                        size_t size, size_t granularity) {
+  return size != 0 && granularity != 0 && size % granularity == 0 &&
+         offset % granularity == 0 && offset <= total_size &&
+         size <= total_size - offset;
+}
+
+static hipError_t iree_hip_vmm_validate_properties(
+    const hipMemAllocationProp* properties) {
+  if (!properties || (properties->type != hipMemAllocationTypePinned &&
+                      properties->type != hipMemAllocationTypeUncached)) {
+    return hipErrorInvalidValue;
+  }
+  switch (properties->requestedHandleType) {
+    case hipMemHandleTypeNone:
+    case hipMemHandleTypePosixFileDescriptor:
+    case hipMemHandleTypeWin32:
+    case hipMemHandleTypeWin32Kmt:
+      break;
+    default:
+      return hipErrorInvalidValue;
+  }
+  int device_count = 0;
+  hipError_t result = hipGetDeviceCount(&device_count);
+  if (result != hipSuccess) return result;
+  if (properties->location.type == hipMemLocationTypeHost) {
+    return hipSuccess;
+  }
+  if (properties->location.type != hipMemLocationTypeDevice) {
+    return hipErrorInvalidValue;
+  }
+  return properties->location.id >= 0 && properties->location.id < device_count
+             ? hipSuccess
+             : hipErrorInvalidDevice;
+}
+
+static hrx_memory_type_t iree_hip_vmm_memory_type(
+    const hipMemAllocationProp* properties) {
+  const hrx_memory_type_t cache_type =
+      properties->type == hipMemAllocationTypeUncached
+          ? HRX_MEMORY_TYPE_DEVICE_UNCACHED
+          : HRX_MEMORY_TYPE_NONE;
+  if (properties->location.type == hipMemLocationTypeHost) {
+    return HRX_MEMORY_TYPE_DEVICE_LOCAL | HRX_MEMORY_TYPE_HOST_VISIBLE |
+           HRX_MEMORY_TYPE_HOST_COHERENT | cache_type;
+  }
+  return HRX_MEMORY_TYPE_DEVICE_LOCAL | cache_type;
+}
+
+static hipError_t iree_hip_vmm_get_device_for_properties(
+    const hipMemAllocationProp* properties, int* out_device_ordinal,
+    hrx_device_t* out_device) {
+  int device_ordinal = properties->location.id;
+  if (properties->location.type == hipMemLocationTypeHost) {
+    hipError_t result = hipGetDevice(&device_ordinal);
+    if (result != hipSuccess) return result;
+  }
+  hrx_device_t device = NULL;
+  hipError_t result =
+      iree_hip_vmm_from_hrx_status(hrx_gpu_device_get(device_ordinal, &device));
+  if (result != hipSuccess) return result;
+  *out_device_ordinal = device_ordinal;
+  *out_device = device;
+  return hipSuccess;
+}
+
+static hipError_t iree_hip_vmm_query_granularity(hrx_device_t device,
+                                                 hrx_memory_type_t memory_type,
+                                                 size_t* out_minimum,
+                                                 size_t* out_recommended) {
+  bool supported = false;
+  hipError_t result =
+      iree_hip_vmm_from_hrx_status(hrx_allocator_query_virtual_memory(
+          hrx_device_allocator(device), memory_type, &supported, out_minimum,
+          out_recommended));
+  if (result != hipSuccess) return result;
+  return supported && *out_minimum != 0 ? hipSuccess : hipErrorNotSupported;
+}
+
+static size_t iree_hip_vmm_mapping_lower_bound(
+    const iree_hip_vmm_reservation_t* reservation, size_t offset) {
+  size_t begin = 0;
+  size_t end = reservation->mapping_count;
+  while (begin < end) {
+    const size_t middle = begin + (end - begin) / 2;
+    if (reservation->mappings[middle].virtual_offset < offset) {
+      begin = middle + 1;
+    } else {
+      end = middle;
+    }
+  }
+  return begin;
+}
+
+static size_t iree_hip_vmm_mapping_containing(
+    const iree_hip_vmm_reservation_t* reservation, size_t offset) {
+  const size_t position = iree_hip_vmm_mapping_lower_bound(reservation, offset);
+  if (position < reservation->mapping_count &&
+      reservation->mappings[position].virtual_offset == offset) {
+    return position;
+  }
+  if (position == 0) return SIZE_MAX;
+  const iree_hip_vmm_mapping_t* candidate =
+      &reservation->mappings[position - 1];
+  return offset - candidate->virtual_offset < candidate->size ? position - 1
+                                                              : SIZE_MAX;
+}
+
+static bool iree_hip_vmm_mapped_range_is_complete(
+    const iree_hip_vmm_reservation_t* reservation, size_t offset, size_t size) {
+  size_t position = iree_hip_vmm_mapping_containing(reservation, offset);
+  if (position == SIZE_MAX) return false;
+  size_t cursor = offset;
+  const size_t end = offset + size;
+  while (position < reservation->mapping_count && cursor < end) {
+    const iree_hip_vmm_mapping_t* mapping = &reservation->mappings[position];
+    if (cursor < mapping->virtual_offset ||
+        cursor - mapping->virtual_offset >= mapping->size) {
+      return false;
+    }
+    const size_t mapping_end = mapping->virtual_offset + mapping->size;
+    cursor = mapping_end < end ? mapping_end : end;
+    ++position;
+  }
+  return cursor == end;
+}
+
+static bool iree_hip_vmm_mapping_range_overlaps(
+    const iree_hip_vmm_reservation_t* reservation, size_t offset, size_t size) {
+  const size_t position = iree_hip_vmm_mapping_lower_bound(reservation, offset);
+  if (position < reservation->mapping_count &&
+      reservation->mappings[position].virtual_offset < offset + size) {
+    return true;
+  }
+  if (position == 0) return false;
+  const iree_hip_vmm_mapping_t* previous = &reservation->mappings[position - 1];
+  return offset < previous->virtual_offset + previous->size;
+}
+
+static hipError_t iree_hip_vmm_reserve_mapping_capacity(
+    iree_hip_vmm_reservation_t* reservation, size_t minimum_capacity) {
+  if (reservation->mapping_capacity >= minimum_capacity) return hipSuccess;
+  size_t new_capacity =
+      reservation->mapping_capacity ? reservation->mapping_capacity : 8;
+  while (new_capacity < minimum_capacity) {
+    if (new_capacity > SIZE_MAX / 2) return hipErrorOutOfMemory;
+    new_capacity *= 2;
+  }
+  size_t allocation_size = 0;
+  if (!iree_host_size_checked_mul(
+          new_capacity, sizeof(reservation->mappings[0]), &allocation_size)) {
+    return hipErrorOutOfMemory;
+  }
+  iree_status_t status = iree_allocator_realloc(
+      iree_allocator_system(), allocation_size, (void**)&reservation->mappings);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    return hipErrorOutOfMemory;
+  }
+  reservation->mapping_capacity = new_capacity;
+  return hipSuccess;
+}
+
+static hipError_t iree_hip_vmm_retire_allocation(
+    iree_hip_vmm_allocation_t* allocation, bool restore_public_on_failure) {
+  iree_hip_vmm_registry_t* registry = iree_hip_vmm_registry_lock();
+  const bool removed =
+      iree_hip_vmm_registry_remove_allocation_locked(registry, allocation);
+  iree_hip_vmm_registry_unlock();
+  if (!removed) return hipErrorInvalidValue;
+
+  hipError_t result =
+      iree_hip_vmm_from_hrx_status(hrx_allocator_physical_memory_free(
+          allocation->allocator, allocation->physical_memory));
+  if (result == hipSuccess) {
+    allocation->physical_memory = NULL;
+    iree_hip_vmm_allocation_release(allocation);  // Registry reference.
+    return hipSuccess;
+  }
+
+  registry = iree_hip_vmm_registry_lock();
+  const hipError_t insert_result =
+      iree_hip_vmm_registry_insert_allocation_locked(registry, allocation);
+  iree_hip_vmm_registry_unlock();
+  iree_slim_mutex_lock(&allocation->mutex);
+  allocation->retiring = false;
+  if (restore_public_on_failure) ++allocation->public_reference_count;
+  iree_slim_mutex_unlock(&allocation->mutex);
+  return insert_result == hipSuccess ? result : insert_result;
+}
+
+static hipError_t iree_hip_vmm_mapping_reference_add(
+    iree_hip_vmm_allocation_t* allocation, bool require_public_reference) {
+  iree_slim_mutex_lock(&allocation->mutex);
+  hipError_t result = hipSuccess;
+  if (allocation->retiring ||
+      (require_public_reference && allocation->public_reference_count == 0) ||
+      allocation->mapping_reference_count == UINT64_MAX) {
+    result = hipErrorInvalidValue;
+  } else {
+    ++allocation->mapping_reference_count;
+  }
+  iree_slim_mutex_unlock(&allocation->mutex);
+  return result;
+}
+
+static hipError_t iree_hip_vmm_mapping_reference_remove(
+    iree_hip_vmm_allocation_t* allocation) {
+  bool retire = false;
+  iree_slim_mutex_lock(&allocation->mutex);
+  if (allocation->mapping_reference_count == 0) {
+    iree_slim_mutex_unlock(&allocation->mutex);
+    return hipErrorInvalidValue;
+  }
+  --allocation->mapping_reference_count;
+  if (allocation->mapping_reference_count == 0 &&
+      allocation->public_reference_count == 0 && !allocation->retiring) {
+    allocation->retiring = true;
+    retire = true;
+  }
+  iree_slim_mutex_unlock(&allocation->mutex);
+  return retire ? iree_hip_vmm_retire_allocation(
+                      allocation, /*restore_public_on_failure=*/false)
+                : hipSuccess;
+}
+
+static int iree_hip_vmm_compare_access_ranges(const void* lhs,
+                                              const void* rhs) {
+  const iree_hip_vmm_access_range_t* a =
+      (const iree_hip_vmm_access_range_t*)lhs;
+  const iree_hip_vmm_access_range_t* b =
+      (const iree_hip_vmm_access_range_t*)rhs;
+  if (a->location_type != b->location_type) {
+    return a->location_type < b->location_type ? -1 : 1;
+  }
+  if (a->location_id != b->location_id) {
+    return a->location_id < b->location_id ? -1 : 1;
+  }
+  if (a->offset == b->offset) return 0;
+  return a->offset < b->offset ? -1 : 1;
+}
+
+static bool iree_hip_vmm_access_location_matches(
+    const iree_hip_vmm_access_range_t* range, const hipMemLocation* location) {
+  const int location_id =
+      location->type == hipMemLocationTypeHost ? 0 : location->id;
+  return range->location_type == location->type &&
+         range->location_id == location_id;
+}
+
+static hipError_t iree_hip_vmm_build_access_update(
+    const iree_hip_vmm_reservation_t* reservation,
+    const hipMemLocation* location, size_t offset, size_t size,
+    hipMemAccessFlags flags, bool insert_update,
+    iree_hip_vmm_access_range_t** out_ranges, size_t* out_count) {
+  *out_ranges = NULL;
+  *out_count = 0;
+  size_t maximum_count = 0;
+  if (!iree_host_size_checked_mul(reservation->access_range_count, 2,
+                                  &maximum_count) ||
+      !iree_host_size_checked_add(maximum_count, insert_update ? 1 : 0,
+                                  &maximum_count)) {
+    return hipErrorOutOfMemory;
+  }
+  if (maximum_count == 0) return hipSuccess;
+
+  size_t allocation_size = 0;
+  if (!iree_host_size_checked_mul(maximum_count,
+                                  sizeof(iree_hip_vmm_access_range_t),
+                                  &allocation_size)) {
+    return hipErrorOutOfMemory;
+  }
+  iree_hip_vmm_access_range_t* ranges = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      iree_allocator_system(), allocation_size, (void**)&ranges);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    return hipErrorOutOfMemory;
+  }
+
+  const size_t update_end = offset + size;
+  size_t count = 0;
+  for (size_t i = 0; i < reservation->access_range_count; ++i) {
+    const iree_hip_vmm_access_range_t* old = &reservation->access_ranges[i];
+    const size_t old_end = old->offset + old->size;
+    if ((location && !iree_hip_vmm_access_location_matches(old, location)) ||
+        old_end <= offset || old->offset >= update_end) {
+      ranges[count++] = *old;
+      continue;
+    }
+    if (old->offset < offset) {
+      ranges[count++] = (iree_hip_vmm_access_range_t){
+          .location_type = old->location_type,
+          .location_id = old->location_id,
+          .offset = old->offset,
+          .size = offset - old->offset,
+          .flags = old->flags,
+      };
+    }
+    if (old_end > update_end) {
+      ranges[count++] = (iree_hip_vmm_access_range_t){
+          .location_type = old->location_type,
+          .location_id = old->location_id,
+          .offset = update_end,
+          .size = old_end - update_end,
+          .flags = old->flags,
+      };
+    }
+  }
+  if (insert_update && flags != hipMemAccessFlagsProtNone) {
+    IREE_ASSERT_ARGUMENT(location);
+    ranges[count++] = (iree_hip_vmm_access_range_t){
+        .location_type = location->type,
+        .location_id =
+            location->type == hipMemLocationTypeHost ? 0 : location->id,
+        .offset = offset,
+        .size = size,
+        .flags = flags,
+    };
+  }
+  qsort(ranges, count, sizeof(ranges[0]), iree_hip_vmm_compare_access_ranges);
+
+  size_t merged_count = 0;
+  for (size_t i = 0; i < count; ++i) {
+    if (merged_count > 0) {
+      iree_hip_vmm_access_range_t* previous = &ranges[merged_count - 1];
+      if (previous->location_type == ranges[i].location_type &&
+          previous->location_id == ranges[i].location_id &&
+          previous->flags == ranges[i].flags &&
+          previous->offset + previous->size == ranges[i].offset) {
+        previous->size += ranges[i].size;
+        continue;
+      }
+    }
+    ranges[merged_count++] = ranges[i];
+  }
+  *out_ranges = ranges;
+  *out_count = merged_count;
+  return hipSuccess;
+}
+
+static hipError_t iree_hip_vmm_validate_access_location(
+    const hipMemLocation* location) {
+  if (!location) return hipErrorInvalidValue;
+  if (location->type == hipMemLocationTypeHost) {
+    return hipSuccess;
+  }
+  if (location->type != hipMemLocationTypeDevice) {
+    return hipErrorInvalidValue;
+  }
+  int device_count = 0;
+  hipError_t result = hipGetDeviceCount(&device_count);
+  if (result != hipSuccess) return result;
+  return location->id >= 0 && location->id < device_count
+             ? hipSuccess
+             : hipErrorInvalidValue;
+}
+
+static hipError_t iree_hip_vmm_validate_access_descriptor(
+    const hipMemAccessDesc* descriptor) {
+  hipError_t result =
+      iree_hip_vmm_validate_access_location(&descriptor->location);
+  if (result != hipSuccess) return result;
+  switch (descriptor->flags) {
+    case hipMemAccessFlagsProtNone:
+    case hipMemAccessFlagsProtRead:
+    case hipMemAccessFlagsProtReadWrite:
+      return hipSuccess;
+    default:
+      return hipErrorInvalidValue;
+  }
+}
+
+static hrx_memory_protection_t iree_hip_vmm_protection(
+    hipMemAccessFlags flags) {
+  switch (flags) {
+    case hipMemAccessFlagsProtRead:
+      return HRX_MEMORY_PROTECTION_READ;
+    case hipMemAccessFlagsProtReadWrite:
+      return HRX_MEMORY_PROTECTION_READ_WRITE;
+    default:
+      return HRX_MEMORY_PROTECTION_NONE;
+  }
+}
+
+hipError_t iree_hip_vmm_is_supported(int device_ordinal, bool* out_supported) {
+  if (!out_supported) return hipErrorInvalidValue;
+  *out_supported = false;
+  hrx_device_t device = NULL;
+  hipError_t result =
+      iree_hip_vmm_from_hrx_status(hrx_gpu_device_get(device_ordinal, &device));
+  if (result != hipSuccess) return result;
+  return iree_hip_vmm_from_hrx_status(hrx_allocator_query_virtual_memory(
+      hrx_device_allocator(device), HRX_MEMORY_TYPE_DEVICE_LOCAL, out_supported,
+      /*min_page_size=*/NULL,
+      /*recommended_page_size=*/NULL));
+}
+
+hipError_t iree_hip_vmm_address_reserve(void** ptr, size_t size,
+                                        size_t alignment, void* address,
+                                        unsigned long long flags) {
+  if (!ptr || flags != 0 || address) return hipErrorInvalidValue;
+  *ptr = NULL;
+  if (alignment != 0 && !iree_hip_vmm_is_power_of_two(alignment)) {
+    return hipErrorInvalidValue;
+  }
+
+  int device_ordinal = 0;
+  hipError_t result = hipGetDevice(&device_ordinal);
+  if (result != hipSuccess) return result;
+  hrx_device_t device = NULL;
+  result =
+      iree_hip_vmm_from_hrx_status(hrx_gpu_device_get(device_ordinal, &device));
+  if (result != hipSuccess) return result;
+  size_t granularity = 0;
+  size_t recommended = 0;
+  result = iree_hip_vmm_query_granularity(device, HRX_MEMORY_TYPE_DEVICE_LOCAL,
+                                          &granularity, &recommended);
+  if (result != hipSuccess ||
+      !iree_hip_vmm_range_is_valid(size, 0, size, granularity)) {
+    return result == hipSuccess ? hipErrorInvalidValue : result;
+  }
+
+  hrx_allocator_t allocator = hrx_device_allocator(device);
+  hrx_buffer_t virtual_buffer = NULL;
+  result = iree_hip_vmm_from_hrx_status(hrx_allocator_virtual_memory_reserve(
+      allocator, /*affinity=*/0, size, &virtual_buffer));
+  if (result != hipSuccess) return result;
+  void* device_ptr = NULL;
+  result = iree_hip_vmm_from_hrx_status(
+      hrx_buffer_get_device_ptr(virtual_buffer, &device_ptr));
+  if (result == hipSuccess && alignment != 0 &&
+      (uintptr_t)device_ptr % alignment != 0) {
+    result = hipErrorNotSupported;
+  }
+
+  iree_hal_streaming_buffer_t* streaming_buffer = NULL;
+  iree_hal_streaming_context_t* context = iree_hal_streaming_context_current();
+  if (result == hipSuccess && !context) {
+    result = hipErrorInvalidContext;
+  }
+  if (result == hipSuccess) {
+    iree_status_t status = iree_hal_streaming_memory_wrap_virtual_reservation(
+        context, virtual_buffer, &streaming_buffer);
+    if (!iree_status_is_ok(status)) {
+      iree_status_ignore(status);
+      result = hipErrorOutOfMemory;
+    }
+  }
+
+  iree_hip_vmm_reservation_t* reservation = NULL;
+  if (result == hipSuccess) {
+    iree_status_t status = iree_allocator_malloc(
+        iree_allocator_system(), sizeof(*reservation), (void**)&reservation);
+    if (!iree_status_is_ok(status)) {
+      iree_status_ignore(status);
+      result = hipErrorOutOfMemory;
+    }
+  }
+  if (result == hipSuccess) {
+    memset(reservation, 0, sizeof(*reservation));
+    iree_atomic_ref_count_init(&reservation->ref_count);
+    iree_slim_mutex_initialize(&reservation->mutex);
+    reservation->device = device;
+    hrx_device_retain(device);
+    reservation->allocator = allocator;
+    reservation->virtual_buffer = virtual_buffer;
+    reservation->streaming_buffer = streaming_buffer;
+    reservation->base_address = (uintptr_t)device_ptr;
+    reservation->size = size;
+    reservation->granularity = granularity;
+    reservation->device_ordinal = device_ordinal;
+
+    iree_hip_vmm_registry_t* registry = iree_hip_vmm_registry_lock();
+    result =
+        iree_hip_vmm_registry_insert_reservation_locked(registry, reservation);
+    iree_hip_vmm_registry_unlock();
+  }
+  if (result != hipSuccess) {
+    iree_hal_streaming_memory_release_wrapped_buffer(streaming_buffer);
+    if (virtual_buffer) {
+      (void)iree_hip_vmm_from_hrx_status(
+          hrx_allocator_virtual_memory_release(allocator, virtual_buffer));
+    }
+    if (reservation) {
+      reservation->virtual_buffer = NULL;
+      reservation->streaming_buffer = NULL;
+      iree_hip_vmm_reservation_release(reservation);
+    }
+    return result;
+  }
+  *ptr = device_ptr;
+  return hipSuccess;
+}
+
+hipError_t iree_hip_vmm_address_free(void* device_ptr, size_t size) {
+  if (!device_ptr || size == 0) return hipErrorInvalidValue;
+  iree_hip_vmm_reservation_t* reservation =
+      iree_hip_vmm_lookup_reservation((uintptr_t)device_ptr,
+                                      /*require_base=*/true);
+  if (!reservation) return hipErrorInvalidValue;
+
+  iree_slim_mutex_lock(&reservation->mutex);
+  if (reservation->retiring || reservation->size != size ||
+      reservation->mapping_count != 0) {
+    iree_slim_mutex_unlock(&reservation->mutex);
+    iree_hip_vmm_reservation_release(reservation);
+    return hipErrorInvalidValue;
+  }
+  reservation->retiring = true;
+  iree_hip_vmm_registry_t* registry = iree_hip_vmm_registry_lock();
+  const bool removed =
+      iree_hip_vmm_registry_remove_reservation_locked(registry, reservation);
+  iree_hip_vmm_registry_unlock();
+  if (!removed) {
+    reservation->retiring = false;
+    iree_slim_mutex_unlock(&reservation->mutex);
+    iree_hip_vmm_reservation_release(reservation);
+    return hipErrorInvalidValue;
+  }
+
+  iree_hal_streaming_memory_prepare_virtual_reservation_release(
+      reservation->streaming_buffer);
+  hipError_t result =
+      iree_hip_vmm_from_hrx_status(hrx_allocator_virtual_memory_release(
+          reservation->allocator, reservation->virtual_buffer));
+  if (result == hipSuccess) {
+    reservation->virtual_buffer = NULL;
+    iree_hal_streaming_memory_release_wrapped_buffer(
+        reservation->streaming_buffer);
+    reservation->streaming_buffer = NULL;
+  } else {
+    iree_hal_streaming_memory_restore_virtual_reservation(
+        reservation->streaming_buffer, reservation->virtual_buffer);
+    registry = iree_hip_vmm_registry_lock();
+    const hipError_t insert_result =
+        iree_hip_vmm_registry_insert_reservation_locked(registry, reservation);
+    iree_hip_vmm_registry_unlock();
+    reservation->retiring = false;
+    if (insert_result != hipSuccess) result = insert_result;
+  }
+  iree_slim_mutex_unlock(&reservation->mutex);
+  if (removed && result == hipSuccess) {
+    iree_hip_vmm_reservation_release(reservation);  // Registry reference.
+  }
+  iree_hip_vmm_reservation_release(reservation);  // Operation reference.
+  return result;
+}
+
+hipError_t iree_hip_vmm_create(hipMemGenericAllocationHandle_t* handle,
+                               size_t size,
+                               const hipMemAllocationProp* properties,
+                               unsigned long long flags) {
+  if (!handle || size == 0 || flags != 0) return hipErrorInvalidValue;
+  *handle = NULL;
+  hipError_t result = iree_hip_vmm_validate_properties(properties);
+  if (result != hipSuccess) return result;
+  if (properties->requestedHandleType != hipMemHandleTypeNone) {
+    return hipErrorNotSupported;
+  }
+
+  int device_ordinal = 0;
+  hrx_device_t device = NULL;
+  result = iree_hip_vmm_get_device_for_properties(properties, &device_ordinal,
+                                                  &device);
+  if (result != hipSuccess) return result;
+  const hrx_memory_type_t memory_type = iree_hip_vmm_memory_type(properties);
+  size_t granularity = 0;
+  size_t recommended = 0;
+  result = iree_hip_vmm_query_granularity(device, memory_type, &granularity,
+                                          &recommended);
+  if (result != hipSuccess ||
+      !iree_hip_vmm_range_is_valid(size, 0, size, granularity)) {
+    return result == hipSuccess ? hipErrorInvalidValue : result;
+  }
+
+  hrx_allocator_t allocator = hrx_device_allocator(device);
+  hrx_physical_memory_t physical_memory = NULL;
+  result = iree_hip_vmm_from_hrx_status(hrx_allocator_physical_memory_allocate(
+      allocator, memory_type, size, &physical_memory));
+  if (result != hipSuccess) return result;
+
+  iree_hip_vmm_allocation_t* allocation = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      iree_allocator_system(), sizeof(*allocation), (void**)&allocation);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    result = hipErrorOutOfMemory;
+  }
+  if (result == hipSuccess) {
+    memset(allocation, 0, sizeof(*allocation));
+    iree_atomic_ref_count_init(&allocation->ref_count);
+    iree_slim_mutex_initialize(&allocation->mutex);
+    allocation->device = device;
+    hrx_device_retain(device);
+    allocation->device_ordinal = device_ordinal;
+    allocation->allocator = allocator;
+    allocation->physical_memory = physical_memory;
+    allocation->properties = *properties;
+    allocation->size = size;
+    allocation->public_reference_count = 1;
+
+    iree_hip_vmm_registry_t* registry = iree_hip_vmm_registry_lock();
+    if (registry->next_handle_key == UINTPTR_MAX) {
+      result = hipErrorOutOfMemory;
+    } else {
+      allocation->handle_key = registry->next_handle_key;
+      ++registry->next_handle_key;
+      result =
+          iree_hip_vmm_registry_insert_allocation_locked(registry, allocation);
+    }
+    iree_hip_vmm_registry_unlock();
+  }
+  if (result != hipSuccess) {
+    (void)iree_hip_vmm_from_hrx_status(
+        hrx_allocator_physical_memory_free(allocator, physical_memory));
+    if (allocation) {
+      allocation->physical_memory = NULL;
+      iree_hip_vmm_allocation_release(allocation);
+    }
+    return result;
+  }
+  *handle = (hipMemGenericAllocationHandle_t)allocation->handle_key;
+  return hipSuccess;
+}
+
+hipError_t iree_hip_vmm_release(hipMemGenericAllocationHandle_t handle) {
+  if (!handle) return hipErrorInvalidValue;
+  iree_hip_vmm_allocation_t* allocation =
+      iree_hip_vmm_lookup_allocation(handle);
+  if (!allocation) return hipErrorInvalidValue;
+
+  bool retire = false;
+  iree_slim_mutex_lock(&allocation->mutex);
+  if (allocation->retiring || allocation->public_reference_count == 0) {
+    iree_slim_mutex_unlock(&allocation->mutex);
+    iree_hip_vmm_allocation_release(allocation);
+    return hipErrorInvalidValue;
+  }
+  --allocation->public_reference_count;
+  if (allocation->public_reference_count == 0 &&
+      allocation->mapping_reference_count == 0) {
+    allocation->retiring = true;
+    retire = true;
+  }
+  iree_slim_mutex_unlock(&allocation->mutex);
+  hipError_t result = retire
+                          ? iree_hip_vmm_retire_allocation(
+                                allocation, /*restore_public_on_failure=*/true)
+                          : hipSuccess;
+  iree_hip_vmm_allocation_release(allocation);
+  return result;
+}
+
+hipError_t iree_hip_vmm_map(void* ptr, size_t size, size_t offset,
+                            hipMemGenericAllocationHandle_t handle,
+                            unsigned long long flags) {
+  if (!ptr || !handle || size == 0 || offset != 0 || flags != 0) {
+    return hipErrorInvalidValue;
+  }
+  iree_hip_vmm_reservation_t* reservation =
+      iree_hip_vmm_lookup_reservation((uintptr_t)ptr,
+                                      /*require_base=*/false);
+  iree_hip_vmm_allocation_t* allocation =
+      iree_hip_vmm_lookup_allocation(handle);
+  if (!reservation || !allocation) {
+    iree_hip_vmm_reservation_release(reservation);
+    iree_hip_vmm_allocation_release(allocation);
+    return hipErrorInvalidValue;
+  }
+  const size_t virtual_offset = (uintptr_t)ptr - reservation->base_address;
+
+  iree_slim_mutex_lock(&reservation->mutex);
+  hipError_t result = hipSuccess;
+  if (reservation->retiring ||
+      !iree_hip_vmm_range_is_valid(reservation->size, virtual_offset, size,
+                                   reservation->granularity) ||
+      offset > allocation->size || size > allocation->size - offset ||
+      iree_hip_vmm_mapping_range_overlaps(reservation, virtual_offset, size)) {
+    result = hipErrorInvalidValue;
+  }
+  if (result == hipSuccess) {
+    result = iree_hip_vmm_reserve_mapping_capacity(
+        reservation, reservation->mapping_count + 1);
+  }
+  if (result == hipSuccess) {
+    result = iree_hip_vmm_mapping_reference_add(
+        allocation, /*require_public_reference=*/true);
+  }
+  if (result == hipSuccess) {
+    result = iree_hip_vmm_from_hrx_status(hrx_allocator_virtual_memory_map(
+        reservation->allocator, reservation->virtual_buffer, virtual_offset,
+        allocation->physical_memory, offset, size));
+    if (result == hipSuccess) {
+      const size_t position =
+          iree_hip_vmm_mapping_lower_bound(reservation, virtual_offset);
+      memmove(&reservation->mappings[position + 1],
+              &reservation->mappings[position],
+              (reservation->mapping_count - position) *
+                  sizeof(reservation->mappings[0]));
+      reservation->mappings[position] = (iree_hip_vmm_mapping_t){
+          .virtual_offset = virtual_offset,
+          .physical_offset = offset,
+          .size = size,
+          .allocation = allocation,
+      };
+      ++reservation->mapping_count;
+    } else {
+      (void)iree_hip_vmm_mapping_reference_remove(allocation);
+    }
+  }
+  iree_slim_mutex_unlock(&reservation->mutex);
+  iree_hip_vmm_allocation_release(allocation);
+  iree_hip_vmm_reservation_release(reservation);
+  return result;
+}
+
+static hipError_t iree_hip_vmm_build_mapping_unmap(
+    const iree_hip_vmm_reservation_t* reservation, size_t offset, size_t size,
+    iree_hip_vmm_mapping_t** out_mappings, size_t* out_count) {
+  *out_mappings = NULL;
+  *out_count = 0;
+  size_t maximum_count = 0;
+  if (!iree_host_size_checked_mul(reservation->mapping_count, 2,
+                                  &maximum_count)) {
+    return hipErrorOutOfMemory;
+  }
+  size_t allocation_size = 0;
+  if (!iree_host_size_checked_mul(maximum_count, sizeof(iree_hip_vmm_mapping_t),
+                                  &allocation_size)) {
+    return hipErrorOutOfMemory;
+  }
+  iree_hip_vmm_mapping_t* mappings = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      iree_allocator_system(), allocation_size, (void**)&mappings);
+  if (!iree_status_is_ok(status)) {
+    iree_status_ignore(status);
+    return hipErrorOutOfMemory;
+  }
+
+  const size_t unmap_end = offset + size;
+  size_t count = 0;
+  for (size_t i = 0; i < reservation->mapping_count; ++i) {
+    const iree_hip_vmm_mapping_t* old = &reservation->mappings[i];
+    const size_t old_end = old->virtual_offset + old->size;
+    if (old_end <= offset || old->virtual_offset >= unmap_end) {
+      mappings[count++] = *old;
+      continue;
+    }
+    if (old->virtual_offset < offset) {
+      mappings[count++] = (iree_hip_vmm_mapping_t){
+          .virtual_offset = old->virtual_offset,
+          .physical_offset = old->physical_offset,
+          .size = offset - old->virtual_offset,
+          .allocation = old->allocation,
+      };
+    }
+    if (old_end > unmap_end) {
+      mappings[count++] = (iree_hip_vmm_mapping_t){
+          .virtual_offset = unmap_end,
+          .physical_offset =
+              old->physical_offset + unmap_end - old->virtual_offset,
+          .size = old_end - unmap_end,
+          .allocation = old->allocation,
+      };
+    }
+  }
+  *out_mappings = mappings;
+  *out_count = count;
+  return hipSuccess;
+}
+
+hipError_t iree_hip_vmm_unmap(void* ptr, size_t size) {
+  if (!ptr || size == 0) return hipErrorInvalidValue;
+  iree_hip_vmm_reservation_t* reservation =
+      iree_hip_vmm_lookup_reservation((uintptr_t)ptr,
+                                      /*require_base=*/false);
+  if (!reservation) return hipErrorInvalidValue;
+  const size_t offset = (uintptr_t)ptr - reservation->base_address;
+
+  iree_slim_mutex_lock(&reservation->mutex);
+  hipError_t result = hipSuccess;
+  if (reservation->retiring ||
+      !iree_hip_vmm_range_is_valid(reservation->size, offset, size,
+                                   reservation->granularity) ||
+      !iree_hip_vmm_mapped_range_is_complete(reservation, offset, size)) {
+    result = hipErrorInvalidValue;
+  }
+  iree_hip_vmm_mapping_t* updated_mappings = NULL;
+  size_t updated_mapping_count = 0;
+  if (result == hipSuccess) {
+    result = iree_hip_vmm_build_mapping_unmap(
+        reservation, offset, size, &updated_mappings, &updated_mapping_count);
+  }
+  iree_hip_vmm_access_range_t* updated_access_ranges = NULL;
+  size_t updated_access_range_count = 0;
+  if (result == hipSuccess) {
+    // A NULL location removes this interval from every location's access
+    // ledger. Allocate the complete replacement before changing native state.
+    result = iree_hip_vmm_build_access_update(
+        reservation, /*location=*/NULL, offset, size, hipMemAccessFlagsProtNone,
+        /*insert_update=*/false, &updated_access_ranges,
+        &updated_access_range_count);
+  }
+  size_t retained_mapping_count = 0;
+  for (size_t i = 0; i < updated_mapping_count && result == hipSuccess; ++i) {
+    result =
+        iree_hip_vmm_mapping_reference_add(updated_mappings[i].allocation,
+                                           /*require_public_reference=*/false);
+    if (result == hipSuccess) ++retained_mapping_count;
+  }
+  if (result == hipSuccess) {
+    // Kernel arguments and device memory can contain pointers into this
+    // reservation without exposing them to host-side resource tracking. Drain
+    // every active stream before revoking the mapping those pointers name.
+    result = iree_hip_vmm_from_iree_status(
+        iree_hal_streaming_context_synchronize_all());
+  }
+  if (result == hipSuccess) {
+    result = iree_hip_vmm_from_hrx_status(hrx_allocator_virtual_memory_unmap(
+        reservation->allocator, reservation->virtual_buffer, offset, size));
+  }
+  if (result != hipSuccess) {
+    for (size_t i = 0; i < retained_mapping_count; ++i) {
+      const hipError_t remove_result =
+          iree_hip_vmm_mapping_reference_remove(updated_mappings[i].allocation);
+      if (remove_result != hipSuccess) result = remove_result;
+    }
+  } else {
+    iree_hip_vmm_mapping_t* old_mappings = reservation->mappings;
+    const size_t old_mapping_count = reservation->mapping_count;
+    reservation->mappings = updated_mappings;
+    reservation->mapping_count = updated_mapping_count;
+    reservation->mapping_capacity = updated_mapping_count;
+    updated_mappings = NULL;
+
+    iree_allocator_free(iree_allocator_system(), reservation->access_ranges);
+    reservation->access_ranges = updated_access_ranges;
+    reservation->access_range_count = updated_access_range_count;
+    updated_access_ranges = NULL;
+
+    for (size_t i = 0; i < old_mapping_count; ++i) {
+      hipError_t remove_result =
+          iree_hip_vmm_mapping_reference_remove(old_mappings[i].allocation);
+      if (result == hipSuccess) result = remove_result;
+    }
+    iree_allocator_free(iree_allocator_system(), old_mappings);
+  }
+  iree_allocator_free(iree_allocator_system(), updated_access_ranges);
+  iree_allocator_free(iree_allocator_system(), updated_mappings);
+  iree_slim_mutex_unlock(&reservation->mutex);
+  iree_hip_vmm_reservation_release(reservation);
+  return result;
+}
+
+hipError_t iree_hip_vmm_set_access(void* ptr, size_t size,
+                                   const hipMemAccessDesc* descriptors,
+                                   size_t count) {
+  if (!ptr || size == 0 || !descriptors || count == 0) {
+    return hipErrorInvalidValue;
+  }
+  for (size_t i = 0; i < count; ++i) {
+    hipError_t result =
+        iree_hip_vmm_validate_access_descriptor(&descriptors[i]);
+    if (result != hipSuccess) return result;
+  }
+
+  iree_hip_vmm_reservation_t* reservation =
+      iree_hip_vmm_lookup_reservation((uintptr_t)ptr,
+                                      /*require_base=*/false);
+  if (!reservation) return hipErrorInvalidValue;
+  const size_t offset = (uintptr_t)ptr - reservation->base_address;
+  iree_slim_mutex_lock(&reservation->mutex);
+  hipError_t result = hipSuccess;
+  if (reservation->retiring ||
+      !iree_hip_vmm_range_is_valid(reservation->size, offset, size,
+                                   reservation->granularity) ||
+      !iree_hip_vmm_mapped_range_is_complete(reservation, offset, size)) {
+    result = hipErrorInvalidValue;
+  }
+  for (size_t i = 0; i < count && result == hipSuccess; ++i) {
+    iree_hip_vmm_access_range_t* updated_ranges = NULL;
+    size_t updated_count = 0;
+    result = iree_hip_vmm_build_access_update(
+        reservation, &descriptors[i].location, offset, size,
+        descriptors[i].flags, /*insert_update=*/true, &updated_ranges,
+        &updated_count);
+    if (result != hipSuccess) break;
+    const hrx_virtual_memory_access_scope_t scope =
+        descriptors[i].location.type == hipMemLocationTypeHost
+            ? HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST
+            : HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE;
+    hrx_device_t access_device = reservation->device;
+    if (scope == HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE) {
+      result = iree_hip_vmm_from_hrx_status(
+          hrx_gpu_device_get(descriptors[i].location.id, &access_device));
+      if (result != hipSuccess) {
+        iree_allocator_free(iree_allocator_system(), updated_ranges);
+        break;
+      }
+    }
+    result = iree_hip_vmm_from_hrx_status(hrx_allocator_virtual_memory_protect(
+        hrx_device_allocator(access_device), reservation->virtual_buffer,
+        offset, size, scope, iree_hip_vmm_protection(descriptors[i].flags)));
+    if (result == hipSuccess) {
+      iree_allocator_free(iree_allocator_system(), reservation->access_ranges);
+      reservation->access_ranges = updated_ranges;
+      reservation->access_range_count = updated_count;
+    } else {
+      iree_allocator_free(iree_allocator_system(), updated_ranges);
+    }
+  }
+  iree_slim_mutex_unlock(&reservation->mutex);
+  iree_hip_vmm_reservation_release(reservation);
+  return result;
+}
+
+hipError_t iree_hip_vmm_get_access(unsigned long long* flags,
+                                   const hipMemLocation* location, void* ptr) {
+  if (!flags || !ptr) return hipErrorInvalidValue;
+  hipError_t result = iree_hip_vmm_validate_access_location(location);
+  if (result != hipSuccess) return result;
+  iree_hip_vmm_reservation_t* reservation =
+      iree_hip_vmm_lookup_reservation((uintptr_t)ptr,
+                                      /*require_base=*/false);
+  if (!reservation) return hipErrorInvalidValue;
+  const size_t offset = (uintptr_t)ptr - reservation->base_address;
+
+  iree_slim_mutex_lock(&reservation->mutex);
+  if (reservation->retiring ||
+      iree_hip_vmm_mapping_containing(reservation, offset) == SIZE_MAX) {
+    result = hipErrorInvalidValue;
+  } else {
+    *flags = hipMemAccessFlagsProtNone;
+    for (size_t i = 0; i < reservation->access_range_count; ++i) {
+      const iree_hip_vmm_access_range_t* range = &reservation->access_ranges[i];
+      if (iree_hip_vmm_access_location_matches(range, location) &&
+          offset >= range->offset && offset - range->offset < range->size) {
+        *flags = range->flags;
+        break;
+      }
+    }
+  }
+  iree_slim_mutex_unlock(&reservation->mutex);
+  iree_hip_vmm_reservation_release(reservation);
+  return result;
+}
+
+hipError_t iree_hip_vmm_get_allocation_granularity(
+    size_t* granularity, const hipMemAllocationProp* properties,
+    hipMemAllocationGranularity_flags option) {
+  if (!granularity) return hipErrorInvalidValue;
+  hipError_t result = iree_hip_vmm_validate_properties(properties);
+  if (result == hipErrorInvalidDevice) result = hipErrorInvalidValue;
+  if (result != hipSuccess) return result;
+  if (option != hipMemAllocationGranularityMinimum &&
+      option != hipMemAllocationGranularityRecommended) {
+    return hipErrorInvalidValue;
+  }
+  int device_ordinal = 0;
+  hrx_device_t device = NULL;
+  result = iree_hip_vmm_get_device_for_properties(properties, &device_ordinal,
+                                                  &device);
+  if (result != hipSuccess) return result;
+  size_t minimum = 0;
+  size_t recommended = 0;
+  result = iree_hip_vmm_query_granularity(
+      device, iree_hip_vmm_memory_type(properties), &minimum, &recommended);
+  if (result == hipSuccess) {
+    *granularity =
+        option == hipMemAllocationGranularityMinimum ? minimum : recommended;
+  }
+  return result;
+}
+
+hipError_t iree_hip_vmm_get_allocation_properties(
+    hipMemAllocationProp* properties, hipMemGenericAllocationHandle_t handle) {
+  if (!properties || !handle) return hipErrorInvalidValue;
+  iree_hip_vmm_allocation_t* allocation =
+      iree_hip_vmm_lookup_allocation(handle);
+  if (!allocation) return hipErrorInvalidValue;
+  iree_slim_mutex_lock(&allocation->mutex);
+  hipError_t result = hipSuccess;
+  if (allocation->retiring || allocation->public_reference_count == 0) {
+    result = hipErrorInvalidValue;
+  } else {
+    *properties = allocation->properties;
+  }
+  iree_slim_mutex_unlock(&allocation->mutex);
+  iree_hip_vmm_allocation_release(allocation);
+  return result;
+}
+
+hipError_t iree_hip_vmm_retain_allocation_handle(
+    hipMemGenericAllocationHandle_t* handle, void* address) {
+  if (!handle || !address) return hipErrorInvalidValue;
+  *handle = NULL;
+  iree_hip_vmm_reservation_t* reservation =
+      iree_hip_vmm_lookup_reservation((uintptr_t)address,
+                                      /*require_base=*/false);
+  if (!reservation) return hipErrorInvalidValue;
+  const size_t offset = (uintptr_t)address - reservation->base_address;
+  iree_slim_mutex_lock(&reservation->mutex);
+  const size_t mapping_position =
+      iree_hip_vmm_mapping_containing(reservation, offset);
+  hipError_t result = hipSuccess;
+  if (reservation->retiring || mapping_position == SIZE_MAX) {
+    result = hipErrorInvalidValue;
+  } else {
+    iree_hip_vmm_allocation_t* allocation =
+        reservation->mappings[mapping_position].allocation;
+    iree_slim_mutex_lock(&allocation->mutex);
+    if (allocation->retiring ||
+        allocation->public_reference_count == UINT64_MAX) {
+      result = hipErrorInvalidValue;
+    } else {
+      ++allocation->public_reference_count;
+      *handle = (hipMemGenericAllocationHandle_t)allocation->handle_key;
+    }
+    iree_slim_mutex_unlock(&allocation->mutex);
+  }
+  iree_slim_mutex_unlock(&reservation->mutex);
+  iree_hip_vmm_reservation_release(reservation);
+  return result;
+}

--- a/libhrx/src/binding/hip/vmm.h
+++ b/libhrx/src/binding/hip/vmm.h
@@ -1,0 +1,39 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef LIBHRX_SRC_BINDING_HIP_VMM_H_
+#define LIBHRX_SRC_BINDING_HIP_VMM_H_
+
+#include "binding/hip/api.h"
+
+hipError_t iree_hip_vmm_is_supported(int device_ordinal, bool* out_supported);
+hipError_t iree_hip_vmm_address_reserve(void** ptr, size_t size,
+                                        size_t alignment, void* address,
+                                        unsigned long long flags);
+hipError_t iree_hip_vmm_address_free(void* device_ptr, size_t size);
+hipError_t iree_hip_vmm_create(hipMemGenericAllocationHandle_t* handle,
+                               size_t size,
+                               const hipMemAllocationProp* properties,
+                               unsigned long long flags);
+hipError_t iree_hip_vmm_release(hipMemGenericAllocationHandle_t handle);
+hipError_t iree_hip_vmm_map(void* ptr, size_t size, size_t offset,
+                            hipMemGenericAllocationHandle_t handle,
+                            unsigned long long flags);
+hipError_t iree_hip_vmm_unmap(void* ptr, size_t size);
+hipError_t iree_hip_vmm_set_access(void* ptr, size_t size,
+                                   const hipMemAccessDesc* descriptors,
+                                   size_t count);
+hipError_t iree_hip_vmm_get_access(unsigned long long* flags,
+                                   const hipMemLocation* location, void* ptr);
+hipError_t iree_hip_vmm_get_allocation_granularity(
+    size_t* granularity, const hipMemAllocationProp* properties,
+    hipMemAllocationGranularity_flags option);
+hipError_t iree_hip_vmm_get_allocation_properties(
+    hipMemAllocationProp* properties, hipMemGenericAllocationHandle_t handle);
+hipError_t iree_hip_vmm_retain_allocation_handle(
+    hipMemGenericAllocationHandle_t* handle, void* address);
+
+#endif  // LIBHRX_SRC_BINDING_HIP_VMM_H_

--- a/libhrx/src/libhrx/allocator.c
+++ b/libhrx/src/libhrx/allocator.c
@@ -294,16 +294,40 @@ hrx_status_t hrx_allocator_virtual_memory_unmap(hrx_allocator_t allocator,
       (iree_device_size_t)virtual_offset, (iree_device_size_t)size));
 }
 
+static iree_status_t hrx_virtual_memory_access_scope_to_hal(
+    hrx_virtual_memory_access_scope_t access_scope,
+    iree_hal_virtual_memory_access_scope_t* out_access_scope) {
+  switch (access_scope) {
+    case HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL:
+      *out_access_scope = IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL;
+      return iree_ok_status();
+    case HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST:
+      *out_access_scope = IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST;
+      return iree_ok_status();
+    case HRX_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE:
+      *out_access_scope = IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE;
+      return iree_ok_status();
+    default:
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "invalid virtual-memory access scope");
+  }
+}
+
 hrx_status_t hrx_allocator_virtual_memory_protect(
     hrx_allocator_t allocator, hrx_buffer_t virtual_buffer,
-    size_t virtual_offset, size_t size, hrx_memory_protection_t protection) {
+    size_t virtual_offset, size_t size,
+    hrx_virtual_memory_access_scope_t access_scope,
+    hrx_memory_protection_t protection) {
   if (!allocator || !virtual_buffer) {
     return hrx_make_status(HRX_STATUS_INVALID_ARGUMENT, "NULL argument");
   }
+  iree_hal_virtual_memory_access_scope_t hal_access_scope;
+  iree_status_t status =
+      hrx_virtual_memory_access_scope_to_hal(access_scope, &hal_access_scope);
+  if (!iree_status_is_ok(status)) return hrx_status_from_iree(status);
   return hrx_status_from_iree(iree_hal_allocator_virtual_memory_protect(
       allocator->hal_allocator, virtual_buffer->hal_buffer,
       (iree_device_size_t)virtual_offset, (iree_device_size_t)size,
       /*queue_family_affinity=*/IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
-      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
-      (iree_hal_memory_protection_t)protection));
+      hal_access_scope, (iree_hal_memory_protection_t)protection));
 }

--- a/libhrx/src/libhrx/buffer.c
+++ b/libhrx/src/libhrx/buffer.c
@@ -211,17 +211,28 @@ hrx_status_t hrx_buffer_get_device_ptr(hrx_buffer_t buffer, void** device_ptr) {
                             hrx_make_status(HRX_STATUS_INVALID_ARGUMENT,
                                             "buffer or device_ptr is NULL"));
   }
-  // For CPU devices using the task driver, the device pointer is available via
-  // mapping.
-  // For real GPU devices, this would use iree_hal_buffer_export.
-  // For now, map the buffer to get a usable pointer.
+  // Device allocations may not be host-visible, so ask the allocator for its
+  // native device address before falling back to a host mapping.
+  iree_hal_external_buffer_t external_buffer;
+  iree_status_t status = iree_hal_allocator_export_buffer(
+      buffer->device->allocator.hal_allocator, buffer->hal_buffer,
+      IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION,
+      IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE, &external_buffer);
+  if (iree_status_is_ok(status)) {
+    *device_ptr =
+        (void*)(uintptr_t)external_buffer.handle.device_allocation.ptr;
+    HRX_RETURN_AND_END_ZONE(z0, hrx_ok_status());
+  }
+  iree_status_ignore(status);
+
+  // CPU allocators expose their device address through the host mapping.
   if (buffer->mapped_ptr) {
     *device_ptr = buffer->mapped_ptr;
     HRX_RETURN_AND_END_ZONE(z0, hrx_ok_status());
   }
 
   // Try to get a native allocation pointer.
-  iree_status_t status = iree_hal_buffer_map_range(
+  status = iree_hal_buffer_map_range(
       buffer->hal_buffer, IREE_HAL_MAPPING_MODE_SCOPED,
       IREE_HAL_MEMORY_ACCESS_ALL, 0, buffer->size, &buffer->mapping);
   if (iree_status_is_ok(status)) {

--- a/libhrx/src/libhrx/hrx_internal.h
+++ b/libhrx/src/libhrx/hrx_internal.h
@@ -119,6 +119,9 @@ static_assert(HRX_MEMORY_TYPE_DEVICE_VISIBLE ==
               "memory type mismatch");
 static_assert(HRX_MEMORY_TYPE_DEVICE_LOCAL == IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
               "memory type mismatch");
+static_assert(HRX_MEMORY_TYPE_DEVICE_UNCACHED ==
+                  IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED,
+              "memory type mismatch");
 
 // Memory access bitfield.
 static_assert(HRX_MEMORY_ACCESS_NONE == IREE_HAL_MEMORY_ACCESS_NONE,


### PR DESCRIPTION
Implements same-process HIP virtual memory management using the generic HRX allocator VMM contract.

  - Implements virtual-address reservation and release through `hipMemAddressReserve` and `hipMemAddressFree`.
  - Implements physical allocation creation, retention, property queries, and release through `hipMemCreate`, `hipMemRetainAllocationHandle`, `hipMemGetAllocationPropertiesFromHandle`, and
  `hipMemRelease`.
  - Implements mapping, partial unmapping, and per-location access tracking through `hipMemMap`, `hipMemUnmap`, `hipMemSetAccess`, and `hipMemGetAccess`.
  - Reports VMM support and allocation granularity from the selected device.
  - Publishes reserved address ranges through the binding pointer table so mapped addresses work with kernel launches and memory operations.
  - Retains physical backing while mappings or public handles remain live.
  - Drains active streams before unmapping because device pointers may be embedded in opaque kernel arguments or device memory and therefore cannot be tracked reliably by the binding.
  - Rejects host-NUMA and uncached placements when the underlying HAL cannot preserve their semantics instead of silently substituting ordinary device memory.
  - Keeps shareable-handle import and export explicitly unsupported because this change only implements same-process ownership.